### PR TITLE
refactor(draggable, modals, typography): use transient props + snapshot testing [DO NOT MERGE]

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,7 +29,7 @@ export default [
   reactPlugin,
   prettierConfig,
   {
-    ignores: ['**/dist']
+    ignores: ['**/dist', 'packages/*/demo/stories/*.spec.tsx']
   },
   {
     rules: {

--- a/packages/buttons/demo/stories/ButtonStory.spec.tsx
+++ b/packages/buttons/demo/stories/ButtonStory.spec.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { ButtonStory } from './ButtonStory';
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<ButtonStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('ButtonStory Component', () => {
+  it('renders default ButtonStory', () => {
+    renderAndMatchSnapshot({ children: 'Button' });
+  });
+
+  it('renders ButtonStory with a start icon', () => {
+    renderAndMatchSnapshot({ children: 'Button', hasStartIcon: true });
+  });
+
+  it('renders ButtonStory with an end icon', () => {
+    renderAndMatchSnapshot({ children: 'Button', hasEndIcon: true });
+  });
+
+  it('renders ButtonStory with both start and end icons', () => {
+    renderAndMatchSnapshot({ children: 'Button', hasStartIcon: true, hasEndIcon: true });
+  });
+
+  it('renders ButtonStory with a rotated start icon', () => {
+    renderAndMatchSnapshot({ children: 'Button', hasStartIcon: true, isStartIconRotated: true });
+  });
+
+  it('renders ButtonStory with a rotated end icon', () => {
+    renderAndMatchSnapshot({ children: 'Button', hasEndIcon: true, isEndIconRotated: true });
+  });
+
+  it('renders ButtonStory with both rotated start and end icons', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      isStartIconRotated: true,
+      hasEndIcon: true,
+      isEndIconRotated: true
+    });
+  });
+
+  it('renders ButtonStory with danger styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', isDanger: true });
+  });
+
+  it('renders ButtonStory with primary styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', isPrimary: true });
+  });
+
+  it('renders ButtonStory with neutral styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', isNeutral: true });
+  });
+
+  it('renders ButtonStory with basic styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', isBasic: true });
+  });
+
+  it('renders ButtonStory with link styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', isLink: true });
+  });
+
+  it('renders ButtonStory with pill styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', isPill: true });
+  });
+
+  it('renders ButtonStory with focus inset styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', focusInset: true });
+  });
+
+  it('renders ButtonStory with stretched styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', isStretched: true });
+  });
+
+  it('renders ButtonStory with small size', () => {
+    renderAndMatchSnapshot({ children: 'Button', size: 'small' });
+  });
+
+  it('renders ButtonStory with large size', () => {
+    renderAndMatchSnapshot({ children: 'Button', size: 'large' });
+  });
+
+  it('renders ButtonStory with start icon, end icon, and danger styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      isDanger: true
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, and primary styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      isPrimary: true
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, and pill styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      isPill: true
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, and stretched styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      isStretched: true
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, and focus inset styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      focusInset: true
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, and large size', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      size: 'large'
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, and small size', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      size: 'small'
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, rotated icons, and danger styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      isStartIconRotated: true,
+      hasEndIcon: true,
+      isEndIconRotated: true,
+      isDanger: true
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, rotated icons, and primary styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      isStartIconRotated: true,
+      hasEndIcon: true,
+      isEndIconRotated: true,
+      isPrimary: true
+    });
+  });
+});

--- a/packages/buttons/demo/stories/SplitButtonStory.spec.tsx
+++ b/packages/buttons/demo/stories/SplitButtonStory.spec.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { SplitButtonStory } from './SplitButtonStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<SplitButtonStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('SplitButtonStory Component', () => {
+  it('renders default SplitButtonStory', () => {
+    renderAndMatchSnapshot({ children: 'Split Button' });
+  });
+
+  it('renders SplitButtonStory with a rotated chevron button', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', isRotated: true });
+  });
+
+  it('renders SplitButtonStory with danger styling', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', isDanger: true });
+  });
+
+  it('renders SplitButtonStory with primary styling', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', isPrimary: true });
+  });
+
+  it('renders SplitButtonStory with neutral styling', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', isNeutral: true });
+  });
+
+  it('renders SplitButtonStory with basic styling', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', isBasic: true });
+  });
+
+  it('renders SplitButtonStory with pill styling', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', isPill: true });
+  });
+
+  it('renders SplitButtonStory with focus inset styling', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', focusInset: true });
+  });
+
+  it('renders SplitButtonStory with small size', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', size: 'small' });
+  });
+
+  it('renders SplitButtonStory with large size', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', size: 'large' });
+  });
+
+  it('renders SplitButtonStory with aria-label', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', 'aria-label': 'Split Button Aria' });
+  });
+
+  it('renders SplitButtonStory with danger styling and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      isDanger: true,
+      isRotated: true
+    });
+  });
+
+  it('renders SplitButtonStory with primary styling and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      isPrimary: true,
+      isRotated: true
+    });
+  });
+
+  it('renders SplitButtonStory with neutral styling and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      isNeutral: true,
+      isRotated: true
+    });
+  });
+
+  it('renders SplitButtonStory with basic styling and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      isBasic: true,
+      isRotated: true
+    });
+  });
+
+  it('renders SplitButtonStory with pill styling and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      isPill: true,
+      isRotated: true
+    });
+  });
+
+  it('renders SplitButtonStory with focus inset styling and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      focusInset: true,
+      isRotated: true
+    });
+  });
+
+  it('renders SplitButtonStory with small size and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      size: 'small',
+      isRotated: true
+    });
+  });
+
+  it('renders SplitButtonStory with large size and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      size: 'large',
+      isRotated: true
+    });
+  });
+});

--- a/packages/buttons/demo/stories/__snapshots__/ButtonStory.spec.tsx.snap
+++ b/packages/buttons/demo/stories/__snapshots__/ButtonStory.spec.tsx.snap
@@ -1,0 +1,3375 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ButtonStory Component renders ButtonStory with a rotated end icon 1`] = `
+.c2 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with a rotated start icon 1`] = `
+.c2 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with a start icon 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with an end icon 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with basic styling 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with both rotated start and end icons 1`] = `
+.c2 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with both start and end icons 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with danger styling 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with focus inset styling 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with large size 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.3571428571428572em;
+  height: 48px;
+  line-height: 46px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with link styling 1`] = `
+.c0 {
+  display: inline;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 0px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-overflow: ellipsis;
+  font-family: inherit;
+  font-weight: inherit;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-touch-callout: none;
+  padding: 0;
+  font-size: inherit;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  color: #1f73b7;
+  outline-color: #1f73b7;
+}
+
+.c0:hover {
+  color: #13456d;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  color: #0f3655;
+}
+
+.c0:disabled {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with neutral styling 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with pill styling 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with primary styling 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  background-color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  background-color: #0f3655;
+}
+
+.c0:disabled {
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with small size 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, and danger styling 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, and focus inset styling 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, and large size 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.3571428571428572em;
+  height: 48px;
+  line-height: 46px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, and pill styling 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, and primary styling 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  background-color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  background-color: #0f3655;
+}
+
+.c0:disabled {
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, and small size 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, and stretched styling 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  width: 100%;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, rotated icons, and danger styling 1`] = `
+.c2 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, rotated icons, and primary styling 1`] = `
+.c2 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  background-color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  background-color: #0f3655;
+}
+
+.c0:disabled {
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with stretched styling 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  width: 100%;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders default ButtonStory 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;

--- a/packages/buttons/demo/stories/__snapshots__/ButtonStory.spec.tsx.snap
+++ b/packages/buttons/demo/stories/__snapshots__/ButtonStory.spec.tsx.snap
@@ -125,14 +125,14 @@ exports[`ButtonStory Component renders ButtonStory with a rotated end icon 1`] =
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Button
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -263,13 +263,13 @@ exports[`ButtonStory Component renders ButtonStory with a rotated start icon 1`]
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
   Button
@@ -398,13 +398,13 @@ exports[`ButtonStory Component renders ButtonStory with a start icon 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
   Button
@@ -533,14 +533,14 @@ exports[`ButtonStory Component renders ButtonStory with an end icon 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Button
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -648,7 +648,7 @@ exports[`ButtonStory Component renders ButtonStory with basic styling 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Button
@@ -790,20 +790,20 @@ exports[`ButtonStory Component renders ButtonStory with both rotated start and e
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
   Button
   <svg
     class="c1  c3"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -938,20 +938,20 @@ exports[`ButtonStory Component renders ButtonStory with both start and end icons
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
   Button
   <svg
     class="c1  c3"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -1062,7 +1062,7 @@ exports[`ButtonStory Component renders ButtonStory with danger styling 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Button
@@ -1174,7 +1174,7 @@ exports[`ButtonStory Component renders ButtonStory with focus inset styling 1`] 
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Button
@@ -1286,7 +1286,7 @@ exports[`ButtonStory Component renders ButtonStory with large size 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Button
@@ -1376,7 +1376,7 @@ exports[`ButtonStory Component renders ButtonStory with link styling 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Button
@@ -1487,7 +1487,7 @@ exports[`ButtonStory Component renders ButtonStory with neutral styling 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Button
@@ -1599,7 +1599,7 @@ exports[`ButtonStory Component renders ButtonStory with pill styling 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Button
@@ -1705,7 +1705,7 @@ exports[`ButtonStory Component renders ButtonStory with primary styling 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Button
@@ -1817,7 +1817,7 @@ exports[`ButtonStory Component renders ButtonStory with small size 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Button
@@ -1953,20 +1953,20 @@ exports[`ButtonStory Component renders ButtonStory with start icon, end icon, an
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
   Button
   <svg
     class="c1  c3"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2101,20 +2101,20 @@ exports[`ButtonStory Component renders ButtonStory with start icon, end icon, an
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
   Button
   <svg
     class="c1  c3"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2249,20 +2249,20 @@ exports[`ButtonStory Component renders ButtonStory with start icon, end icon, an
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
   Button
   <svg
     class="c1  c3"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2397,20 +2397,20 @@ exports[`ButtonStory Component renders ButtonStory with start icon, end icon, an
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
   Button
   <svg
     class="c1  c3"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2535,20 +2535,20 @@ exports[`ButtonStory Component renders ButtonStory with start icon, end icon, an
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
   Button
   <svg
     class="c1  c3"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2683,20 +2683,20 @@ exports[`ButtonStory Component renders ButtonStory with start icon, end icon, an
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
   Button
   <svg
     class="c1  c3"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2832,20 +2832,20 @@ exports[`ButtonStory Component renders ButtonStory with start icon, end icon, an
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
   Button
   <svg
     class="c1  c3"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2986,20 +2986,20 @@ exports[`ButtonStory Component renders ButtonStory with start icon, end icon, ro
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
   Button
   <svg
     class="c1  c3"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -3130,20 +3130,20 @@ exports[`ButtonStory Component renders ButtonStory with start icon, end icon, ro
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
   Button
   <svg
     class="c1  c3"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -3255,7 +3255,7 @@ exports[`ButtonStory Component renders ButtonStory with stretched styling 1`] = 
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Button
@@ -3367,7 +3367,7 @@ exports[`ButtonStory Component renders default ButtonStory 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Button

--- a/packages/buttons/demo/stories/__snapshots__/SplitButtonStory.spec.tsx.snap
+++ b/packages/buttons/demo/stories/__snapshots__/SplitButtonStory.spec.tsx.snap
@@ -1,0 +1,4448 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SplitButtonStory Component renders SplitButtonStory with a rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with aria-label 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    aria-label="Split Button Aria"
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with basic styling 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid transparent;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+  box-shadow: inset 0 0 0 1px #1f73b7, inset 0 0 0 3px transparent;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c3:hover {
+  color: #39434b;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with basic styling and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid transparent;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+  box-shadow: inset 0 0 0 1px #1f73b7, inset 0 0 0 3px transparent;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c3:hover {
+  color: #39434b;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with danger styling 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with danger styling and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with focus inset styling 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with focus inset styling and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with large size 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.3571428571428572em;
+  height: 48px;
+  line-height: 46px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 48px;
+  min-width: 48px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with large size and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.3571428571428572em;
+  height: 48px;
+  line-height: 46px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 48px;
+  min-width: 48px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with neutral styling 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 .c4 {
+  color: #5c6970;
+}
+
+.c2:hover .c4,
+.c2:focus-visible .c4 {
+  color: #39434b;
+}
+
+.c2:active .c4 {
+  color: #293239;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with neutral styling and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 .c4 {
+  color: #5c6970;
+}
+
+.c2:hover .c4,
+.c2:focus-visible .c4 {
+  color: #39434b;
+}
+
+.c2:active .c4 {
+  color: #293239;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with pill styling 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) .c4 {
+  margin-right: -2px;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) .c4 {
+  margin-left: -2px;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with pill styling and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) .c4 {
+  margin-right: -2px;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) .c4 {
+  margin-left: -2px;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with primary styling 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  background-color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 0px solid transparent;
+  outline-offset: 2px;
+  box-shadow: inset 0 0 0 2px #fff, inset 0 0 0 2px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  background-color: #0f3655;
+}
+
+.c2:disabled {
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with primary styling and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  background-color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 0px solid transparent;
+  outline-offset: 2px;
+  box-shadow: inset 0 0 0 2px #fff, inset 0 0 0 2px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  background-color: #0f3655;
+}
+
+.c2:disabled {
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with small size 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 32px;
+  min-width: 32px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with small size and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 32px;
+  min-width: 32px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders default SplitButtonStory 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;

--- a/packages/buttons/demo/stories/__snapshots__/SplitButtonStory.spec.tsx.snap
+++ b/packages/buttons/demo/stories/__snapshots__/SplitButtonStory.spec.tsx.snap
@@ -198,12 +198,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with a rotated chev
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -211,14 +211,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with a rotated chev
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -429,12 +429,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with aria-label 1`]
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -443,14 +443,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with aria-label 1`]
     aria-label="Split Button Aria"
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -671,12 +671,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with basic styling 
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -684,14 +684,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with basic styling 
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -915,12 +915,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with basic styling 
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -928,14 +928,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with basic styling 
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -1146,12 +1146,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with danger styling
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -1159,14 +1159,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with danger styling
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -1380,12 +1380,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with danger styling
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -1393,14 +1393,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with danger styling
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -1611,12 +1611,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with focus inset st
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -1624,14 +1624,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with focus inset st
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -1845,12 +1845,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with focus inset st
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -1858,14 +1858,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with focus inset st
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -2076,12 +2076,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with large size 1`]
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -2089,14 +2089,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with large size 1`]
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -2310,12 +2310,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with large size and
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -2323,14 +2323,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with large size and
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -2553,12 +2553,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with neutral stylin
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -2566,14 +2566,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with neutral stylin
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -2799,12 +2799,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with neutral stylin
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -2812,14 +2812,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with neutral stylin
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -3038,12 +3038,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with pill styling 1
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -3051,14 +3051,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with pill styling 1
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -3280,12 +3280,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with pill styling a
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -3293,14 +3293,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with pill styling a
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -3496,12 +3496,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with primary stylin
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -3509,14 +3509,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with primary stylin
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -3715,12 +3715,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with primary stylin
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -3728,14 +3728,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with primary stylin
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -3946,12 +3946,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with small size 1`]
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -3959,14 +3959,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with small size 1`]
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -4180,12 +4180,12 @@ exports[`SplitButtonStory Component renders SplitButtonStory with small size and
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -4193,14 +4193,14 @@ exports[`SplitButtonStory Component renders SplitButtonStory with small size and
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -4411,12 +4411,12 @@ exports[`SplitButtonStory Component renders default SplitButtonStory 1`] = `
 <div
   class="c0 c1"
   data-garden-id="buttons.button_group_view"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <button
     class="c2"
     data-garden-id="buttons.button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     Split Button
@@ -4424,14 +4424,14 @@ exports[`SplitButtonStory Component renders default SplitButtonStory 1`] = `
   <button
     class="c2 c3"
     data-garden-id="buttons.icon_button"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     type="button"
   >
     <svg
       aria-hidden="true"
       class="c4  c5"
       data-garden-id="buttons.icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"

--- a/packages/draggable/demo/stories/DraggableStory.spec.tsx
+++ b/packages/draggable/demo/stories/DraggableStory.spec.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { DraggableStory } from './DraggableStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<DraggableStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('DraggableStory Component', () => {
+  it('renders default DraggableStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  it('renders DraggableStory with grip', () => {
+    renderAndMatchSnapshot({ hasGrip: true });
+  });
+
+  it('renders DraggableStory with children', () => {
+    renderAndMatchSnapshot({ children: 'Draggable Item' });
+  });
+
+  it('renders DraggableStory with grip and children', () => {
+    renderAndMatchSnapshot({ hasGrip: true, children: 'Draggable Item' });
+  });
+
+  it('renders DraggableStory with focusInset', () => {
+    renderAndMatchSnapshot({ focusInset: true });
+  });
+
+  it('renders DraggableStory with isBare styling', () => {
+    renderAndMatchSnapshot({ isBare: true });
+  });
+
+  it('renders DraggableStory with compact styling', () => {
+    renderAndMatchSnapshot({ isCompact: true });
+  });
+
+  it('renders DraggableStory as disabled', () => {
+    renderAndMatchSnapshot({ isDisabled: true });
+  });
+
+  it('renders DraggableStory as grabbed', () => {
+    renderAndMatchSnapshot({ isGrabbed: true });
+  });
+
+  it('renders DraggableStory as placeholder', () => {
+    renderAndMatchSnapshot({ isPlaceholder: true });
+  });
+
+  it('renders DraggableStory with a custom tag', () => {
+    renderAndMatchSnapshot({ tag: 'section' });
+  });
+
+  it('renders DraggableStory with focusInset and grip', () => {
+    renderAndMatchSnapshot({ focusInset: true, hasGrip: true });
+  });
+
+  it('renders DraggableStory with isBare and children', () => {
+    renderAndMatchSnapshot({ isBare: true, children: 'Draggable Item' });
+  });
+
+  it('renders DraggableStory with isCompact and grip', () => {
+    renderAndMatchSnapshot({ isCompact: true, hasGrip: true });
+  });
+
+  it('renders DraggableStory with isDisabled and children', () => {
+    renderAndMatchSnapshot({ isDisabled: true, children: 'Draggable Item' });
+  });
+
+  it('renders DraggableStory with isGrabbed and grip', () => {
+    renderAndMatchSnapshot({ isGrabbed: true, hasGrip: true });
+  });
+
+  it('renders DraggableStory with isPlaceholder and children', () => {
+    renderAndMatchSnapshot({ isPlaceholder: true, children: 'Draggable Item' });
+  });
+
+  it('renders DraggableStory with a custom tag and grip', () => {
+    renderAndMatchSnapshot({ tag: 'section', hasGrip: true });
+  });
+
+  it('renders DraggableStory with all props', () => {
+    renderAndMatchSnapshot({
+      hasGrip: true,
+      children: 'Draggable Item',
+      focusInset: true,
+      isBare: true,
+      isCompact: true,
+      isDisabled: true,
+      isGrabbed: true,
+      isPlaceholder: true,
+      tag: 'section'
+    });
+  });
+});

--- a/packages/draggable/demo/stories/DropzoneStory.spec.tsx
+++ b/packages/draggable/demo/stories/DropzoneStory.spec.tsx
@@ -1,0 +1,649 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { DropzoneStory } from './DropzoneStory';
+import ReplaceIcon from '@zendeskgarden/svg-icons/src/16/arrow-retweet-stroke.svg';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<DropzoneStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('DropzoneStory Component', () => {
+  it('renders default DropzoneStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  it('renders DropzoneStory with children', () => {
+    renderAndMatchSnapshot({ children: 'Drop files here' });
+  });
+
+  it('renders DropzoneStory with an icon', () => {
+    renderAndMatchSnapshot({ hasIcon: true });
+  });
+
+  it('renders DropzoneStory with children and an icon', () => {
+    renderAndMatchSnapshot({ children: 'Drop files here', hasIcon: true });
+  });
+
+  it('renders DropzoneStory with active state', () => {
+    renderAndMatchSnapshot({ isActive: true });
+  });
+
+  it('renders DropzoneStory with vertical alignment', () => {
+    renderAndMatchSnapshot({ isVertical: true });
+  });
+
+  it('renders DropzoneStory with danger styling', () => {
+    renderAndMatchSnapshot({ isDanger: true });
+  });
+
+  it('renders DropzoneStory with disabled state', () => {
+    renderAndMatchSnapshot({ isDisabled: true });
+  });
+
+  it('renders DropzoneStory with highlighted state', () => {
+    renderAndMatchSnapshot({ isHighlighted: true });
+  });
+
+  it('renders DropzoneStory with a custom tag', () => {
+    renderAndMatchSnapshot({ tag: 'section' });
+  });
+
+  it('renders DropzoneStory with children, icon, and active state', () => {
+    renderAndMatchSnapshot({ children: 'Drop files here', hasIcon: true, isActive: true });
+  });
+
+  it('renders DropzoneStory with children, icon, and vertical alignment', () => {
+    renderAndMatchSnapshot({ children: 'Drop files here', hasIcon: true, isVertical: true });
+  });
+
+  it('renders DropzoneStory with children, icon, and danger styling', () => {
+    renderAndMatchSnapshot({ children: 'Drop files here', hasIcon: true, isDanger: true });
+  });
+
+  it('renders DropzoneStory with children, icon, and disabled state', () => {
+    renderAndMatchSnapshot({ children: 'Drop files here', hasIcon: true, isDisabled: true });
+  });
+
+  it('renders DropzoneStory with children, icon, and highlighted state', () => {
+    renderAndMatchSnapshot({ children: 'Drop files here', hasIcon: true, isHighlighted: true });
+  });
+
+  it('renders DropzoneStory with children, icon, and custom tag', () => {
+    renderAndMatchSnapshot({ children: 'Drop files here', hasIcon: true, tag: 'section' });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, and vertical alignment', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, and danger styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isDanger: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, and disabled state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isDisabled: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, and danger styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      isDanger: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, and disabled state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      isDisabled: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, danger styling, and disabled state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isDanger: true,
+      isDisabled: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, danger styling, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isDanger: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, danger styling, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isDanger: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, disabled state, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isDisabled: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, disabled state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isDisabled: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, and danger styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      isDanger: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, and disabled state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      isDisabled: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, danger styling, and disabled state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isDanger: true,
+      isDisabled: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, danger styling, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isDanger: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, danger styling, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isDanger: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, disabled state, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isDisabled: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, disabled state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isDisabled: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, danger styling, and disabled state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      isDanger: true,
+      isDisabled: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, danger styling, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      isDanger: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, danger styling, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      isDanger: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, disabled state, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      isDisabled: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, disabled state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      isDisabled: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, danger styling, disabled state, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isDanger: true,
+      isDisabled: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, danger styling, disabled state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isDanger: true,
+      isDisabled: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, danger styling, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isDanger: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, disabled state, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isDisabled: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, danger styling, and disabled state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      isDanger: true,
+      isDisabled: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, danger styling, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      isDanger: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, danger styling, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      isDanger: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, disabled state, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      isDisabled: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, disabled state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      isDisabled: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, danger styling, disabled state, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isDanger: true,
+      isDisabled: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, danger styling, disabled state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isDanger: true,
+      isDisabled: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, danger styling, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isDanger: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, disabled state, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isDisabled: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, danger styling, disabled state, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      isDanger: true,
+      isDisabled: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, danger styling, disabled state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      isDanger: true,
+      isDisabled: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, danger styling, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      isDanger: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, disabled state, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      isDisabled: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, danger styling, disabled state, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isDanger: true,
+      isDisabled: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, danger styling, disabled state, and highlighted state', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      isDanger: true,
+      isDisabled: true,
+      isHighlighted: true
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, danger styling, disabled state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      isDanger: true,
+      isDisabled: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, danger styling, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      isDanger: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, disabled state, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      isDisabled: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, vertical alignment, danger styling, disabled state, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isVertical: true,
+      isDanger: true,
+      isDisabled: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+
+  it('renders DropzoneStory with children, icon, active state, vertical alignment, danger styling, disabled state, highlighted state, and custom tag', () => {
+    renderAndMatchSnapshot({
+      children: 'Drop files here',
+      hasIcon: true,
+      isActive: true,
+      isVertical: true,
+      isDanger: true,
+      isDisabled: true,
+      isHighlighted: true,
+      tag: 'section'
+    });
+  });
+});

--- a/packages/draggable/demo/stories/__snapshots__/DraggableStory.spec.tsx.snap
+++ b/packages/draggable/demo/stories/__snapshots__/DraggableStory.spec.tsx.snap
@@ -1,0 +1,1663 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DraggableStory Component renders DraggableStory as disabled 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: default;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`DraggableStory Component renders DraggableStory as grabbed 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: -webkit-grabbing;
+  cursor: -moz-grabbing;
+  cursor: grabbing;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 28px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0:hover {
+  background-color: #fff;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7,0 20px 28px 0 rgba(10,13,14,0.16);
+}
+
+<div
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+/>
+`;
+
+exports[`DraggableStory Component renders DraggableStory as placeholder 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: default;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0 > * {
+  visibility: hidden;
+}
+
+<div
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+/>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with a custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0:hover {
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+<section
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+/>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with a custom tag and grip 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  box-sizing: border-box;
+  color: #5c6970;
+  margin-right: 8px;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0:hover {
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+<section
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+>
+  <div
+    class="c1"
+    data-garden-id="draggable.grip"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="currentColor"
+      >
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="1"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="1"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="5"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="5"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="9"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="9"
+        />
+      </g>
+    </svg>
+  </div>
+</section>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with all props 1`] = `
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  box-sizing: border-box;
+  color: #5c6970;
+  margin-right: 8px;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: default;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 5px 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7,0 20px 28px 0 rgba(10,13,14,0.16);
+}
+
+.c0 > .c1 {
+  color: #848f99;
+}
+
+.c3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1 c2"
+    data-garden-id="draggable.grip"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="currentColor"
+      >
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="1"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="1"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="5"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="5"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="9"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="9"
+        />
+      </g>
+    </svg>
+  </div>
+  <div
+    class="c3"
+    data-garden-id="draggable.content"
+    data-garden-version="9.0.0"
+  >
+    Draggable Item
+  </div>
+</section>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with children 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0:hover {
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c1 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+<div
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+>
+  <div
+    class="c1"
+    data-garden-id="draggable.content"
+    data-garden-version="9.0.0"
+  >
+    Draggable Item
+  </div>
+</div>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with compact styling 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 5px 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0:hover {
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+<div
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+/>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with focusInset 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0:hover {
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+<div
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+/>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with focusInset and grip 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  box-sizing: border-box;
+  color: #5c6970;
+  margin-right: 8px;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0:hover {
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+<div
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+>
+  <div
+    class="c1"
+    data-garden-id="draggable.grip"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="currentColor"
+      >
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="1"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="1"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="5"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="5"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="9"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="9"
+        />
+      </g>
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with grip 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  box-sizing: border-box;
+  color: #5c6970;
+  margin-right: 8px;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0:hover {
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+<div
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+>
+  <div
+    class="c1"
+    data-garden-id="draggable.grip"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="currentColor"
+      >
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="1"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="1"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="5"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="5"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="9"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="9"
+        />
+      </g>
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with grip and children 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  box-sizing: border-box;
+  color: #5c6970;
+  margin-right: 8px;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0:hover {
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+<div
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+>
+  <div
+    class="c1"
+    data-garden-id="draggable.grip"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="currentColor"
+      >
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="1"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="1"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="5"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="5"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="9"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="9"
+        />
+      </g>
+    </svg>
+  </div>
+  <div
+    class="c2"
+    data-garden-id="draggable.content"
+    data-garden-version="9.0.0"
+  >
+    Draggable Item
+  </div>
+</div>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with isBare and children 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: transparent;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0:hover {
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c1 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+<div
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+>
+  <div
+    class="c1"
+    data-garden-id="draggable.content"
+    data-garden-version="9.0.0"
+  >
+    Draggable Item
+  </div>
+</div>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with isBare styling 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: transparent;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0:hover {
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+<div
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+/>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with isCompact and grip 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  box-sizing: border-box;
+  color: #5c6970;
+  margin-right: 8px;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 5px 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0:hover {
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+<div
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+>
+  <div
+    class="c1"
+    data-garden-id="draggable.grip"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="currentColor"
+      >
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="1"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="1"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="5"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="5"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="9"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="9"
+        />
+      </g>
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with isDisabled and children 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: default;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c1 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="draggable.content"
+    data-garden-version="9.0.0"
+  >
+    Draggable Item
+  </div>
+</div>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with isGrabbed and grip 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  box-sizing: border-box;
+  color: #5c6970;
+  margin-right: 8px;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: -webkit-grabbing;
+  cursor: -moz-grabbing;
+  cursor: grabbing;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 28px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0:hover {
+  background-color: #fff;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7,0 20px 28px 0 rgba(10,13,14,0.16);
+}
+
+<div
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+>
+  <div
+    class="c1"
+    data-garden-id="draggable.grip"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="currentColor"
+      >
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="1"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="1"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="5"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="5"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="3"
+          y="9"
+        />
+        <rect
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="2"
+          x="7"
+          y="9"
+        />
+      </g>
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`DraggableStory Component renders DraggableStory with isPlaceholder and children 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: default;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0 > * {
+  visibility: hidden;
+}
+
+.c1 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+<div
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+>
+  <div
+    class="c1"
+    data-garden-id="draggable.content"
+    data-garden-version="9.0.0"
+  >
+    Draggable Item
+  </div>
+</div>
+`;
+
+exports[`DraggableStory Component renders default DraggableStory 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 9px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0:hover {
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+<div
+  class="c0"
+  data-garden-id="draggable"
+  data-garden-version="9.0.0"
+  tabindex="0"
+/>
+`;

--- a/packages/draggable/demo/stories/__snapshots__/DraggableStory.spec.tsx.snap
+++ b/packages/draggable/demo/stories/__snapshots__/DraggableStory.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`DraggableStory Component renders DraggableStory as disabled 1`] = `
   aria-disabled="true"
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -98,7 +98,7 @@ exports[`DraggableStory Component renders DraggableStory as grabbed 1`] = `
 <div
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 />
 `;
@@ -149,7 +149,7 @@ exports[`DraggableStory Component renders DraggableStory as placeholder 1`] = `
 <div
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 />
 `;
@@ -203,7 +203,7 @@ exports[`DraggableStory Component renders DraggableStory with a custom tag 1`] =
 <section
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 />
 `;
@@ -269,13 +269,13 @@ exports[`DraggableStory Component renders DraggableStory with a custom tag and g
 <section
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 >
   <div
     class="c1"
     data-garden-id="draggable.grip"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       aria-hidden="true"
@@ -410,12 +410,12 @@ exports[`DraggableStory Component renders DraggableStory with all props 1`] = `
   aria-disabled="true"
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1 c2"
     data-garden-id="draggable.grip"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       aria-hidden="true"
@@ -482,7 +482,7 @@ exports[`DraggableStory Component renders DraggableStory with all props 1`] = `
   <div
     class="c3"
     data-garden-id="draggable.content"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Draggable Item
   </div>
@@ -546,13 +546,13 @@ exports[`DraggableStory Component renders DraggableStory with children 1`] = `
 <div
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 >
   <div
     class="c1"
     data-garden-id="draggable.content"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Draggable Item
   </div>
@@ -608,7 +608,7 @@ exports[`DraggableStory Component renders DraggableStory with compact styling 1`
 <div
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 />
 `;
@@ -662,7 +662,7 @@ exports[`DraggableStory Component renders DraggableStory with focusInset 1`] = `
 <div
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 />
 `;
@@ -728,13 +728,13 @@ exports[`DraggableStory Component renders DraggableStory with focusInset and gri
 <div
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 >
   <div
     class="c1"
     data-garden-id="draggable.grip"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       aria-hidden="true"
@@ -862,13 +862,13 @@ exports[`DraggableStory Component renders DraggableStory with grip 1`] = `
 <div
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 >
   <div
     class="c1"
     data-garden-id="draggable.grip"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       aria-hidden="true"
@@ -1004,13 +1004,13 @@ exports[`DraggableStory Component renders DraggableStory with grip and children 
 <div
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 >
   <div
     class="c1"
     data-garden-id="draggable.grip"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       aria-hidden="true"
@@ -1077,7 +1077,7 @@ exports[`DraggableStory Component renders DraggableStory with grip and children 
   <div
     class="c2"
     data-garden-id="draggable.content"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Draggable Item
   </div>
@@ -1141,13 +1141,13 @@ exports[`DraggableStory Component renders DraggableStory with isBare and childre
 <div
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 >
   <div
     class="c1"
     data-garden-id="draggable.content"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Draggable Item
   </div>
@@ -1203,7 +1203,7 @@ exports[`DraggableStory Component renders DraggableStory with isBare styling 1`]
 <div
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 />
 `;
@@ -1269,13 +1269,13 @@ exports[`DraggableStory Component renders DraggableStory with isCompact and grip
 <div
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 >
   <div
     class="c1"
     data-garden-id="draggable.grip"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       aria-hidden="true"
@@ -1394,12 +1394,12 @@ exports[`DraggableStory Component renders DraggableStory with isDisabled and chi
   aria-disabled="true"
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="draggable.content"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Draggable Item
   </div>
@@ -1468,13 +1468,13 @@ exports[`DraggableStory Component renders DraggableStory with isGrabbed and grip
 <div
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 >
   <div
     class="c1"
     data-garden-id="draggable.grip"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       aria-hidden="true"
@@ -1595,13 +1595,13 @@ exports[`DraggableStory Component renders DraggableStory with isPlaceholder and 
 <div
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 >
   <div
     class="c1"
     data-garden-id="draggable.content"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Draggable Item
   </div>
@@ -1657,7 +1657,7 @@ exports[`DraggableStory Component renders default DraggableStory 1`] = `
 <div
   class="c0"
   data-garden-id="draggable"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   tabindex="0"
 />
 `;

--- a/packages/draggable/demo/stories/__snapshots__/DropzoneStory.spec.tsx.snap
+++ b/packages/draggable/demo/stories/__snapshots__/DropzoneStory.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`DropzoneStory Component renders DropzoneStory with a custom tag 1`] = `
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -46,7 +46,7 @@ exports[`DropzoneStory Component renders DropzoneStory with active state 1`] = `
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -92,13 +92,13 @@ exports[`DropzoneStory Component renders DropzoneStory with an icon 1`] = `
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -149,12 +149,12 @@ exports[`DropzoneStory Component renders DropzoneStory with children 1`] = `
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <p
     class="c1"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -213,13 +213,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children and an icon
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -228,7 +228,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children and an icon
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -287,13 +287,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -302,7 +302,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -361,13 +361,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -376,7 +376,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -436,13 +436,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -451,7 +451,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -510,13 +510,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -525,7 +525,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -587,13 +587,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -602,7 +602,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -661,13 +661,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -676,7 +676,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -736,13 +736,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -751,7 +751,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -810,13 +810,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -825,7 +825,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -885,13 +885,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -900,7 +900,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -960,13 +960,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -975,7 +975,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -1034,13 +1034,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -1049,7 +1049,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -1109,13 +1109,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -1124,7 +1124,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -1184,13 +1184,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -1199,7 +1199,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -1259,13 +1259,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -1274,7 +1274,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -1333,13 +1333,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -1348,7 +1348,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -1410,13 +1410,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -1425,7 +1425,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -1487,13 +1487,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -1502,7 +1502,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -1565,13 +1565,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -1580,7 +1580,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -1642,13 +1642,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -1657,7 +1657,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -1719,13 +1719,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -1734,7 +1734,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -1797,13 +1797,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -1812,7 +1812,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -1874,13 +1874,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -1889,7 +1889,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -1952,13 +1952,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -1967,7 +1967,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -2030,13 +2030,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -2045,7 +2045,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -2108,13 +2108,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -2123,7 +2123,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -2185,13 +2185,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -2200,7 +2200,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -2263,13 +2263,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -2278,7 +2278,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -2341,13 +2341,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -2356,7 +2356,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -2419,13 +2419,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -2434,7 +2434,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -2496,13 +2496,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -2511,7 +2511,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, acti
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -2570,13 +2570,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, and 
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -2585,7 +2585,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, and 
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -2644,13 +2644,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, and 
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -2659,7 +2659,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, and 
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -2718,13 +2718,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, and 
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -2733,7 +2733,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, and 
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -2793,13 +2793,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, and 
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -2808,7 +2808,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, and 
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -2867,13 +2867,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, and 
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -2882,7 +2882,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, and 
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -2944,13 +2944,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, and 
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -2959,7 +2959,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, and 
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -3018,13 +3018,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, dang
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -3033,7 +3033,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, dang
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -3093,13 +3093,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, dang
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -3108,7 +3108,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, dang
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -3167,13 +3167,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, dang
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -3182,7 +3182,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, dang
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -3242,13 +3242,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, dang
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -3257,7 +3257,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, dang
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -3317,13 +3317,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, dang
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -3332,7 +3332,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, dang
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -3392,13 +3392,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, dang
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -3407,7 +3407,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, dang
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -3466,13 +3466,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, dang
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -3481,7 +3481,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, dang
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -3541,13 +3541,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, disa
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -3556,7 +3556,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, disa
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -3616,13 +3616,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, disa
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -3631,7 +3631,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, disa
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -3691,13 +3691,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, disa
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -3706,7 +3706,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, disa
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -3765,13 +3765,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, high
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -3780,7 +3780,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, high
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -3842,13 +3842,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -3857,7 +3857,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -3919,13 +3919,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -3934,7 +3934,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -3997,13 +3997,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -4012,7 +4012,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -4074,13 +4074,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -4089,7 +4089,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -4151,13 +4151,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -4166,7 +4166,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -4229,13 +4229,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -4244,7 +4244,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -4306,13 +4306,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -4321,7 +4321,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -4384,13 +4384,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -4399,7 +4399,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -4462,13 +4462,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -4477,7 +4477,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -4540,13 +4540,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -4555,7 +4555,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -4617,13 +4617,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -4632,7 +4632,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -4695,13 +4695,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -4710,7 +4710,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -4773,13 +4773,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -4788,7 +4788,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -4851,13 +4851,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -4866,7 +4866,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -4928,13 +4928,13 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
 <section
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     aria-hidden="true"
     class="c1"
     data-garden-id="dropzone.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -4943,7 +4943,7 @@ exports[`DropzoneStory Component renders DropzoneStory with children, icon, vert
   <p
     class="c2"
     data-garden-id="dropzone.message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     Drop files here
   </p>
@@ -4971,7 +4971,7 @@ exports[`DropzoneStory Component renders DropzoneStory with danger styling 1`] =
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -4997,7 +4997,7 @@ exports[`DropzoneStory Component renders DropzoneStory with disabled state 1`] =
   aria-disabled="true"
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -5022,7 +5022,7 @@ exports[`DropzoneStory Component renders DropzoneStory with highlighted state 1`
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -5047,7 +5047,7 @@ exports[`DropzoneStory Component renders DropzoneStory with vertical alignment 1
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -5072,6 +5072,6 @@ exports[`DropzoneStory Component renders default DropzoneStory 1`] = `
 <div
   class="c0"
   data-garden-id="dropzone"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;

--- a/packages/draggable/demo/stories/__snapshots__/DropzoneStory.spec.tsx.snap
+++ b/packages/draggable/demo/stories/__snapshots__/DropzoneStory.spec.tsx.snap
@@ -1,0 +1,5077 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DropzoneStory Component renders DropzoneStory with a custom tag 1`] = `
+.c0 {
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #848f99;
+  background-color: transparent;
+  color: #5c6970;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with active state 1`] = `
+.c0 {
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+  color: #1f73b7;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with an icon 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #848f99;
+  background-color: transparent;
+  color: #5c6970;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #848f99;
+  background-color: transparent;
+  color: #5c6970;
+}
+
+.c1 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <p
+    class="c1"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children and an icon 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #848f99;
+  background-color: transparent;
+  color: #5c6970;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+  color: #1f73b7;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, and danger styling 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: rgba(205,54,66,0.08);
+  color: #cd3642;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, and disabled state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+  color: #0f3655;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, and vertical alignment 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+  color: #1f73b7;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, danger styling, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: rgba(205,54,66,0.08);
+  color: #cd3642;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, danger styling, and disabled state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, danger styling, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: rgba(205,54,66,0.08);
+  color: #671219;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, danger styling, disabled state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, danger styling, disabled state, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, danger styling, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: rgba(205,54,66,0.08);
+  color: #671219;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, disabled state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, disabled state, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, disabled state, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+  color: #0f3655;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+  color: #1f73b7;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, and danger styling 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: rgba(205,54,66,0.08);
+  color: #cd3642;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, and disabled state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+  color: #0f3655;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, danger styling, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: rgba(205,54,66,0.08);
+  color: #cd3642;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, danger styling, and disabled state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, danger styling, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: rgba(205,54,66,0.08);
+  color: #671219;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, danger styling, disabled state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, danger styling, disabled state, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, danger styling, disabled state, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, danger styling, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: rgba(205,54,66,0.08);
+  color: #671219;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, disabled state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, disabled state, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, disabled state, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, active state, vertical alignment, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+  color: #0f3655;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, and active state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+  color: #1f73b7;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #848f99;
+  background-color: transparent;
+  color: #5c6970;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, and danger styling 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, and disabled state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+  color: #0f3655;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, and vertical alignment 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #848f99;
+  background-color: transparent;
+  color: #5c6970;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, danger styling, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, danger styling, and disabled state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, danger styling, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: rgba(205,54,66,0.08);
+  color: #671219;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, danger styling, disabled state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, danger styling, disabled state, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, danger styling, disabled state, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, danger styling, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: rgba(205,54,66,0.08);
+  color: #671219;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, disabled state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, disabled state, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, disabled state, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+  color: #0f3655;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #848f99;
+  background-color: transparent;
+  color: #5c6970;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, and danger styling 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, and disabled state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+  color: #0f3655;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, danger styling, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, danger styling, and disabled state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, danger styling, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: rgba(205,54,66,0.08);
+  color: #671219;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, danger styling, disabled state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, danger styling, disabled state, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, danger styling, disabled state, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, danger styling, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: rgba(205,54,66,0.08);
+  color: #671219;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, disabled state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, disabled state, and highlighted state 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</div>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, disabled state, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with children, icon, vertical alignment, highlighted state, and custom tag 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  text-align: center;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+  color: #0f3655;
+}
+
+.c2 {
+  margin: 0;
+  line-height: 1.4285714285714286;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  margin-bottom: 8px;
+}
+
+<section
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+>
+  <div
+    aria-hidden="true"
+    class="c1"
+    data-garden-id="dropzone.icon"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+  <p
+    class="c2"
+    data-garden-id="dropzone.message"
+    data-garden-version="9.0.0"
+  >
+    Drop files here
+  </p>
+</section>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with danger styling 1`] = `
+.c0 {
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with disabled state 1`] = `
+.c0 {
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+<div
+  aria-disabled="true"
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with highlighted state 1`] = `
+.c0 {
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 4px;
+  padding: 15px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+  color: #0f3655;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`DropzoneStory Component renders DropzoneStory with vertical alignment 1`] = `
+.c0 {
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #848f99;
+  background-color: transparent;
+  color: #5c6970;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`DropzoneStory Component renders default DropzoneStory 1`] = `
+.c0 {
+  -webkit-transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: dashed;
+  border-radius: 4px;
+  padding: 16px;
+  width: 100%;
+  font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",Arial,sans-serif;
+  font-size: 14px;
+  border-color: #848f99;
+  background-color: transparent;
+  color: #5c6970;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropzone"
+  data-garden-version="9.0.0"
+/>
+`;

--- a/packages/draggable/src/elements/draggable-list/DraggableList.tsx
+++ b/packages/draggable/src/elements/draggable-list/DraggableList.tsx
@@ -12,15 +12,17 @@ import { StyledDraggableList } from '../../styled';
 import { IDraggableListProps } from '../../types';
 import { DraggableListContext } from '../../utils/useDraggableListContext';
 
-const DraggableListComponent = forwardRef<HTMLUListElement, IDraggableListProps>((props, ref) => {
-  const value = useMemo(() => ({ isHorizontal: props.isHorizontal }), [props.isHorizontal]);
+const DraggableListComponent = forwardRef<HTMLUListElement, IDraggableListProps>(
+  ({ isHorizontal, ...other }, ref) => {
+    const value = useMemo(() => ({ isHorizontal }), [isHorizontal]);
 
-  return (
-    <DraggableListContext.Provider value={value}>
-      <StyledDraggableList {...props} ref={ref} />
-    </DraggableListContext.Provider>
-  );
-});
+    return (
+      <DraggableListContext.Provider value={value}>
+        <StyledDraggableList $isHorizontal={isHorizontal} ref={ref} {...other} />
+      </DraggableListContext.Provider>
+    );
+  }
+);
 
 DraggableListComponent.displayName = 'DraggableList';
 

--- a/packages/draggable/src/elements/draggable-list/components/DropIndicator.tsx
+++ b/packages/draggable/src/elements/draggable-list/components/DropIndicator.tsx
@@ -22,7 +22,7 @@ export const DropIndicator = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIEl
       <StyledDropIndicator
         {...props}
         aria-label={ariaLabel}
-        isHorizontal={isHorizontal}
+        $isHorizontal={isHorizontal}
         ref={ref}
       />
     );

--- a/packages/draggable/src/elements/draggable-list/components/Item.tsx
+++ b/packages/draggable/src/elements/draggable-list/components/Item.tsx
@@ -15,7 +15,7 @@ import { useDraggableListContext } from '../../../utils/useDraggableListContext'
 export const Item = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>((props, ref) => {
   const { isHorizontal } = useDraggableListContext();
 
-  return <StyledItem {...props} isHorizontal={isHorizontal} ref={ref} />;
+  return <StyledItem {...props} $isHorizontal={isHorizontal} ref={ref} />;
 });
 
 Item.displayName = 'DraggableList.Item';

--- a/packages/draggable/src/elements/draggable/Draggable.tsx
+++ b/packages/draggable/src/elements/draggable/Draggable.tsx
@@ -11,19 +11,38 @@ import { Grip } from './components/Grip';
 import { StyledDraggable } from '../../styled';
 import { IDraggableProps } from '../../types';
 
-const DraggableComponent = forwardRef<HTMLDivElement, IDraggableProps>(({ tag, ...props }, ref) => {
-  const isDisabled = props.isDisabled;
+const DraggableComponent = forwardRef<HTMLDivElement, IDraggableProps>(
+  (
+    {
+      focusInset,
+      isBare,
+      isCompact,
+      isDisabled,
+      isGrabbed,
+      isPlaceholder,
 
-  return (
-    <StyledDraggable
-      as={tag}
-      aria-disabled={isDisabled}
-      tabIndex={isDisabled ? undefined : 0}
-      {...props}
-      ref={ref}
-    />
-  );
-});
+      tag,
+      ...other
+    },
+    ref
+  ) => {
+    return (
+      <StyledDraggable
+        $focusInset={focusInset}
+        $isBare={isBare}
+        $isCompact={isCompact}
+        $isDisabled={isDisabled}
+        $isGrabbed={isGrabbed}
+        $isPlaceholder={isPlaceholder}
+        aria-disabled={isDisabled}
+        as={tag}
+        ref={ref}
+        tabIndex={isDisabled ? undefined : 0}
+        {...other}
+      />
+    );
+  }
+);
 
 DraggableComponent.displayName = 'Draggable';
 

--- a/packages/draggable/src/elements/dropzone/Dropzone.tsx
+++ b/packages/draggable/src/elements/dropzone/Dropzone.tsx
@@ -14,8 +14,7 @@ import { IDropzoneProps } from '../../types';
 import { DropzoneContext } from '../../utils/useDropzoneContext';
 
 const DropzoneComponent = forwardRef<HTMLDivElement, IDropzoneProps>(
-  ({ tag, isVertical, children, ...props }, ref) => {
-    const { isDanger } = props;
+  ({ children, isActive, isDanger, isDisabled, isHighlighted, isVertical, tag, ...other }, ref) => {
     const [hasMessage, setHasMessage] = useState(false);
     const [hasIcon, setHasIcon] = useState(false);
     const value = useMemo(
@@ -30,16 +29,20 @@ const DropzoneComponent = forwardRef<HTMLDivElement, IDropzoneProps>(
       <DropzoneContext.Provider value={value}>
         <StyledDropzone
           as={tag}
-          aria-disabled={props.isDisabled}
-          {...props}
-          hasIcon={hasIcon}
-          hasMessage={hasMessage}
-          isVertical={isVertical}
+          aria-disabled={isDisabled}
+          {...other}
+          $isActive={isActive}
+          $isDisabled={isDisabled}
+          $isDanger={isDanger}
+          $isHighlighted={isHighlighted}
+          $hasIcon={hasIcon}
+          $hasMessage={hasMessage}
+          $isVertical={isVertical}
           ref={ref}
         >
           {/* [1] */}
           {!!(hasMessage && isDanger) && !hasIcon && (
-            <StyledIcon aria-hidden="true" hasMessage={hasMessage} isVertical={isVertical}>
+            <StyledIcon aria-hidden="true" $hasMessage={hasMessage} $isVertical={isVertical}>
               <TrashIcon />
             </StyledIcon>
           )}

--- a/packages/draggable/src/elements/dropzone/components/Icon.tsx
+++ b/packages/draggable/src/elements/dropzone/components/Icon.tsx
@@ -31,8 +31,8 @@ export const Icon = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((
     <StyledIcon
       aria-hidden="true"
       {...props}
-      hasMessage={hasMessage}
-      isVertical={isVertical}
+      $hasMessage={hasMessage}
+      $isVertical={isVertical}
       ref={ref}
     />
   );

--- a/packages/draggable/src/styled/draggable-list/StyledDraggableList.ts
+++ b/packages/draggable/src/styled/draggable-list/StyledDraggableList.ts
@@ -12,18 +12,18 @@ import { StyledItem } from './StyledItem';
 const COMPONENT_ID = 'draggable_list';
 
 export interface IStyledDraggableListProps extends ThemeProps<DefaultTheme> {
-  isHorizontal?: boolean;
+  $isHorizontal?: boolean;
 }
 
 const sizeStyles = (props: IStyledDraggableListProps) => {
   const {
-    isHorizontal,
+    $isHorizontal,
     theme: { space }
   } = props;
   let marginStart = 'margin-top';
   let marginEnd = 'margin-bottom';
 
-  if (isHorizontal) {
+  if ($isHorizontal) {
     marginStart = 'margin-right';
     marginEnd = 'margin-left';
   }
@@ -45,7 +45,7 @@ export const StyledDraggableList = styled.ul.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledDraggableListProps & ThemeProps<DefaultTheme>>`
   display: flex;
-  flex-direction: ${p => (p.isHorizontal ? 'row' : 'column')};
+  flex-direction: ${p => (p.$isHorizontal ? 'row' : 'column')};
   margin: 0; /* [1] */
   padding: 0; /* [1] */
   list-style: none; /* [1] */

--- a/packages/draggable/src/styled/draggable-list/StyledDropIndicator.ts
+++ b/packages/draggable/src/styled/draggable-list/StyledDropIndicator.ts
@@ -11,7 +11,7 @@ import { retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming'
 const COMPONENT_ID = 'draggable_list.drop_indicator';
 
 export interface IStyledDropIndicatorProps extends ThemeProps<DefaultTheme> {
-  isHorizontal?: boolean;
+  $isHorizontal?: boolean;
 }
 
 const colorStyles = (props: IStyledDropIndicatorProps) => {
@@ -33,10 +33,10 @@ const colorStyles = (props: IStyledDropIndicatorProps) => {
 };
 
 const sizeStyles = (props: IStyledDropIndicatorProps) => {
-  const { isHorizontal, theme } = props;
+  const { $isHorizontal, theme } = props;
   const pseudoSize = theme.space.xs;
-  const translateX = isHorizontal ? theme.space.xxs : theme.space.xs;
-  const translateY = isHorizontal ? theme.space.xs : theme.space.xxs;
+  const translateX = $isHorizontal ? theme.space.xxs : theme.space.xs;
+  const translateY = $isHorizontal ? theme.space.xs : theme.space.xxs;
 
   return css`
     &::before,

--- a/packages/draggable/src/styled/draggable-list/StyledItem.ts
+++ b/packages/draggable/src/styled/draggable-list/StyledItem.ts
@@ -11,17 +11,17 @@ import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
 const COMPONENT_ID = 'draggable_list.item';
 
 export interface IStyledItemProps extends ThemeProps<DefaultTheme> {
-  isHorizontal?: boolean;
+  $isHorizontal?: boolean;
 }
 
 const sizeStyles = (props: IStyledItemProps) => {
   const {
-    isHorizontal,
+    $isHorizontal,
     theme: { space }
   } = props;
 
   return css`
-    padding: ${isHorizontal ? `0 ${space.xxs}` : `${space.xxs} 0`};
+    padding: ${$isHorizontal ? `0 ${space.xxs}` : `${space.xxs} 0`};
   `;
 };
 

--- a/packages/draggable/src/styled/draggable/StyledDraggable.spec.tsx
+++ b/packages/draggable/src/styled/draggable/StyledDraggable.spec.tsx
@@ -24,19 +24,19 @@ describe('StyledDraggable', () => {
     });
 
     it('applies grabbing cursor when grabbed', () => {
-      const { container } = render(<StyledDraggable isGrabbed />);
+      const { container } = render(<StyledDraggable $isGrabbed />);
 
       expect(container.firstChild).toHaveStyle('cursor: grabbing');
     });
 
     it('applies default cursor when disabled', () => {
-      const { container } = render(<StyledDraggable isDisabled />);
+      const { container } = render(<StyledDraggable $isDisabled />);
 
       expect(container.firstChild).toHaveStyle('cursor: default');
     });
 
     it('applies default cursor when placeholder', () => {
-      const { container } = render(<StyledDraggable isPlaceholder />);
+      const { container } = render(<StyledDraggable $isPlaceholder />);
 
       expect(container.firstChild).toHaveStyle('cursor: default');
     });

--- a/packages/draggable/src/styled/draggable/StyledDraggable.ts
+++ b/packages/draggable/src/styled/draggable/StyledDraggable.ts
@@ -18,12 +18,12 @@ import { StyledGrip } from './StyledGrip';
 const COMPONENT_ID = 'draggable';
 
 export interface IStyledDraggableProps extends ThemeProps<DefaultTheme> {
-  focusInset?: boolean;
-  isBare?: boolean;
-  isCompact?: boolean;
-  isDisabled?: boolean;
-  isGrabbed?: boolean;
-  isPlaceholder?: boolean;
+  $focusInset?: boolean;
+  $isBare?: boolean;
+  $isCompact?: boolean;
+  $isDisabled?: boolean;
+  $isGrabbed?: boolean;
+  $isPlaceholder?: boolean;
 }
 
 export function getDragShadow(theme: IGardenTheme) {
@@ -36,7 +36,7 @@ export function getDragShadow(theme: IGardenTheme) {
 }
 
 const colorStyles = (props: IStyledDraggableProps) => {
-  const { isBare, isGrabbed, isDisabled, isPlaceholder, focusInset, theme } = props;
+  const { $isBare, $isGrabbed, $isDisabled, $isPlaceholder, $focusInset, theme } = props;
 
   const dragShadow = getDragShadow(theme);
   const baseBgColor = getColor({ variable: 'background.default', theme });
@@ -53,17 +53,17 @@ const colorStyles = (props: IStyledDraggableProps) => {
   let borderColor = 'transparent';
   let backgroundColor = baseBgColor;
 
-  if (isDisabled) {
+  if ($isDisabled) {
     backgroundColor = disabledBgColor;
     color = disabledColor;
-  } else if (isPlaceholder) {
+  } else if ($isPlaceholder) {
     backgroundColor = placeholderBgColor;
   } else {
     color = getColor({ variable: 'foreground.default', theme });
-    borderColor = isBare ? 'transparent' : getColor({ variable: 'border.default', theme });
+    borderColor = $isBare ? 'transparent' : getColor({ variable: 'border.default', theme });
     hoverBackgroundColor = getColor({
-      variable: isGrabbed ? 'background.raised' : 'background.primaryEmphasis',
-      ...(!isGrabbed && { transparency: theme.opacity[100], dark: { offset: -100 } }),
+      variable: $isGrabbed ? 'background.raised' : 'background.primaryEmphasis',
+      ...(!$isGrabbed && { transparency: theme.opacity[100], dark: { offset: -100 } }),
       theme
     });
     boxShadow = dragShadow;
@@ -71,7 +71,7 @@ const colorStyles = (props: IStyledDraggableProps) => {
 
   return css`
     border-color: ${borderColor};
-    box-shadow: ${isGrabbed && boxShadow};
+    box-shadow: ${$isGrabbed && boxShadow};
     background-color: ${backgroundColor};
     color: ${color};
 
@@ -81,18 +81,18 @@ const colorStyles = (props: IStyledDraggableProps) => {
 
     ${focusStyles({
       theme,
-      inset: focusInset,
-      boxShadow: isGrabbed ? dragShadow : undefined
+      inset: $focusInset,
+      boxShadow: $isGrabbed ? dragShadow : undefined
     })}
 
     > ${StyledGrip} {
-      color: ${isDisabled && disabledColor};
+      color: ${$isDisabled && disabledColor};
     }
   `;
 };
 
 const sizeStyles = (props: IStyledDraggableProps) => {
-  const { isCompact, theme } = props;
+  const { $isCompact, theme } = props;
   const paddingDefault = theme.space.base * 2.25;
   const paddingCompact = theme.space.base * 1.25;
 
@@ -103,7 +103,7 @@ const sizeStyles = (props: IStyledDraggableProps) => {
     margin: 0; /* [1] */
     border: ${theme.borders.sm};
     border-radius: ${theme.borderRadii.md};
-    padding: ${isCompact ? `${paddingCompact}px ${paddingDefault}px` : `${paddingDefault}px`};
+    padding: ${$isCompact ? `${paddingCompact}px ${paddingDefault}px` : `${paddingDefault}px`};
     line-height: ${getLineHeight(theme.space.base * 5, theme.fontSizes.md)};
     font-size: ${theme.fontSizes.md};
     font-weight: ${theme.fontWeights.regular};
@@ -111,9 +111,9 @@ const sizeStyles = (props: IStyledDraggableProps) => {
 };
 
 const getCursor = (props: IStyledDraggableProps) => {
-  let cursor = props.isGrabbed ? 'grabbing' : 'grab';
+  let cursor = props.$isGrabbed ? 'grabbing' : 'grab';
 
-  if (props.isDisabled || props.isPlaceholder) {
+  if (props.$isDisabled || props.$isPlaceholder) {
     cursor = 'default';
   }
 
@@ -144,7 +144,7 @@ export const StyledDraggable = styled.div.attrs({
   ${colorStyles}
 
   > * {
-    visibility: ${p => p.isPlaceholder && !p.isDisabled && 'hidden'};
+    visibility: ${p => p.$isPlaceholder && !p.$isDisabled && 'hidden'};
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/draggable/src/styled/dropzone/StyledDropzone.ts
+++ b/packages/draggable/src/styled/dropzone/StyledDropzone.ts
@@ -12,22 +12,22 @@ import { retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming'
 const COMPONENT_ID = 'dropzone';
 
 export interface IStyledDropzoneProps extends ThemeProps<DefaultTheme> {
-  isActive?: boolean;
-  isVertical?: boolean;
-  isDanger?: boolean;
-  isDisabled?: boolean;
-  isHighlighted?: boolean;
-  hasMessage?: boolean;
-  hasIcon?: boolean;
+  $isActive?: boolean;
+  $isVertical?: boolean;
+  $isDanger?: boolean;
+  $isDisabled?: boolean;
+  $isHighlighted?: boolean;
+  $hasMessage?: boolean;
+  $hasIcon?: boolean;
 }
 
 const colorStyles = (props: IStyledDropzoneProps) => {
-  const { isDanger, isDisabled, isActive, isHighlighted, theme } = props;
+  const { $isDanger, $isDisabled, $isActive, $isHighlighted, theme } = props;
 
-  const fgVariable = isDanger ? 'foreground.danger' : 'foreground.primary';
+  const fgVariable = $isDanger ? 'foreground.danger' : 'foreground.primary';
   const fgActive = getColor({ variable: fgVariable, theme });
   const borderActive = getColor({
-    variable: isDanger ? `border.dangerEmphasis` : 'border.primaryEmphasis',
+    variable: $isDanger ? `border.dangerEmphasis` : 'border.primaryEmphasis',
     theme
   });
 
@@ -35,12 +35,12 @@ const colorStyles = (props: IStyledDropzoneProps) => {
   let borderColor = getColor({ variable: `border.emphasis`, theme });
   let color = getColor({ variable: `foreground.subtle`, theme });
 
-  if (isDisabled) {
+  if ($isDisabled) {
     backgroundColor = getColor({ variable: 'background.disabled', theme });
     borderColor = getColor({ variable: `border.disabled`, theme });
     color = getColor({ variable: 'foreground.disabled', theme });
-  } else if (isActive || isHighlighted) {
-    color = isHighlighted
+  } else if ($isActive || $isHighlighted) {
+    color = $isHighlighted
       ? getColor({
           variable: fgVariable,
           light: { offset: 200 },
@@ -49,13 +49,13 @@ const colorStyles = (props: IStyledDropzoneProps) => {
         })
       : fgActive;
     backgroundColor = getColor({
-      variable: isDanger ? 'background.dangerEmphasis' : 'background.primaryEmphasis',
+      variable: $isDanger ? 'background.dangerEmphasis' : 'background.primaryEmphasis',
       transparency: theme.opacity[100],
       dark: { offset: -100 },
       theme
     });
     borderColor = borderActive;
-  } else if (isDanger) {
+  } else if ($isDanger) {
     borderColor = borderActive;
     color = fgActive;
   }
@@ -68,14 +68,14 @@ const colorStyles = (props: IStyledDropzoneProps) => {
 };
 
 const sizeStyles = (props: IStyledDropzoneProps) => {
-  const { theme, isHighlighted } = props;
-  const borderWidth = isHighlighted ? math(`${theme.borderWidths.sm} * 2`) : theme.borderWidths.sm;
+  const { theme, $isHighlighted } = props;
+  const borderWidth = $isHighlighted ? math(`${theme.borderWidths.sm} * 2`) : theme.borderWidths.sm;
 
   return css`
     border-width: ${borderWidth};
-    border-style: ${isHighlighted ? theme.borderStyles.solid : 'dashed'};
+    border-style: ${$isHighlighted ? theme.borderStyles.solid : 'dashed'};
     border-radius: ${theme.borderRadii.md};
-    padding: ${isHighlighted ? theme.space.base * 4 - 1 : theme.space.base * 4}px;
+    padding: ${$isHighlighted ? theme.space.base * 4 - 1 : theme.space.base * 4}px;
     width: 100%;
     font-family: ${theme.fonts.system};
     font-size: ${theme.fontSizes.md};
@@ -89,10 +89,10 @@ export const StyledDropzone = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledDropzoneProps>`
-  display: ${p => (p.hasMessage || p.hasIcon) && 'flex'};
-  flex-direction: ${p => p.hasMessage && p.isVertical && 'column'};
-  align-items: ${p => (p.hasMessage || p.hasIcon) && 'center'};
-  justify-content: ${p => (p.hasMessage || p.hasIcon) && 'center'};
+  display: ${p => (p.$hasMessage || p.$hasIcon) && 'flex'};
+  flex-direction: ${p => p.$hasMessage && p.$isVertical && 'column'};
+  align-items: ${p => (p.$hasMessage || p.$hasIcon) && 'center'};
+  justify-content: ${p => (p.$hasMessage || p.$hasIcon) && 'center'};
   /* prettier-ignore */
   transition:
     border-color 0.25s ease-in-out,
@@ -100,7 +100,7 @@ export const StyledDropzone = styled.div.attrs({
     color 0.25s ease-in-out,
     z-index 0.25s ease-in-out;
   margin: 0; /* [1] */
-  text-align: ${p => p.hasMessage && 'center'};
+  text-align: ${p => p.$hasMessage && 'center'};
   direction: ${props => props.theme.rtl && 'rtl'};
   box-sizing: border-box;
 

--- a/packages/draggable/src/styled/dropzone/StyledIcon.spec.tsx
+++ b/packages/draggable/src/styled/dropzone/StyledIcon.spec.tsx
@@ -18,19 +18,19 @@ describe('StyledIcon', () => {
   });
 
   it('renders default styling correctly', () => {
-    const { container } = render(<StyledIcon hasMessage />);
+    const { container } = render(<StyledIcon $hasMessage />);
 
     expect(container.firstChild).toHaveStyle(`margin-right: ${DEFAULT_THEME.space.xs}`);
   });
 
   it('renders RTL styling correctly', () => {
-    const { container } = renderRtl(<StyledIcon hasMessage />);
+    const { container } = renderRtl(<StyledIcon $hasMessage />);
 
     expect(container.firstChild).toHaveStyle(`margin-left: ${DEFAULT_THEME.space.xs}`);
   });
 
   it('renders vertical styling correctly', () => {
-    const { container } = render(<StyledIcon isVertical hasMessage />);
+    const { container } = render(<StyledIcon $isVertical $hasMessage />);
 
     expect(container.firstChild).toHaveStyle(`margin-bottom: ${DEFAULT_THEME.space.xs}`);
   });

--- a/packages/draggable/src/styled/dropzone/StyledIcon.ts
+++ b/packages/draggable/src/styled/dropzone/StyledIcon.ts
@@ -11,15 +11,15 @@ import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
 const COMPONENT_ID = 'dropzone.icon';
 
 interface IStyledIconProps extends ThemeProps<DefaultTheme> {
-  isVertical?: boolean;
-  hasMessage?: boolean;
+  $isVertical?: boolean;
+  $hasMessage?: boolean;
 }
 
-function sizeStyles({ theme, isVertical }: IStyledIconProps) {
+function sizeStyles({ theme, $isVertical }: IStyledIconProps) {
   let property;
   let value;
 
-  if (isVertical) {
+  if ($isVertical) {
     property = 'margin-bottom';
     value = theme.space.xs;
   } else {
@@ -43,7 +43,7 @@ export const StyledIcon = styled.div.attrs({
   width: ${props => props.theme.iconSizes.md};
   height: ${props => props.theme.iconSizes.md};
 
-  ${p => p.hasMessage && sizeStyles(p)}
+  ${p => p.$hasMessage && sizeStyles(p)}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/dropdowns.legacy/demo/stories/AutocompleteStory.spec.tsx
+++ b/packages/dropdowns.legacy/demo/stories/AutocompleteStory.spec.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { AutocompleteStory } from './AutocompleteStory';
+import { AUTOCOMPLETE_ITEMS } from './data';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<AutocompleteStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('AutocompleteStory Component', () => {
+  it('renders default AutocompleteStory', () => {
+    renderAndMatchSnapshot({
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with a label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with a regular label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      isLabelRegular: true,
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with a hidden label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      isLabelHidden: true,
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with a hint', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      hasHint: true,
+      hint: 'Please select your favorite vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      hasMessage: true,
+      message: 'This is a required field',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with an icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      hasIcon: true,
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with custom items', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: [{ text: 'Custom Item', value: 'custom-item' }],
+      selectedItem: { text: 'Custom Item', value: 'custom-item' },
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with a selected item', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[1],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with input value', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: 'Asparagus',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory when open', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      isOpen: true,
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with compact menu', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      isCompact: true,
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with validation success', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      validation: 'success',
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with validation error', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      validation: 'error',
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with validation warning', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      validation: 'warning',
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+});

--- a/packages/dropdowns.legacy/demo/stories/ComboboxStory.spec.tsx
+++ b/packages/dropdowns.legacy/demo/stories/ComboboxStory.spec.tsx
@@ -1,0 +1,221 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { ComboboxStory } from './ComboboxStory';
+import { AUTOCOMPLETE_ITEMS } from './data';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<ComboboxStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('ComboboxStory Component', () => {
+  it('renders default ComboboxStory', () => {
+    renderAndMatchSnapshot({
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a regular label', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelRegular: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a hidden label', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelHidden: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a hint', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      hasMessage: true,
+      message: 'This field is required',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a start icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      hasStartIcon: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with an end icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      hasEndIcon: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with both start and end icons', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a compact menu', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isCompact: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a custom placement', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      placement: 'top',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      hasMessage: true,
+      message: 'This field is required',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, hidden label, and start icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelHidden: true,
+      hasStartIcon: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, regular label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      hasMessage: true,
+      message: 'This field is required',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, hidden label, hint, and end icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      hasEndIcon: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, regular label, hint, message, and compact menu', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      hasMessage: true,
+      message: 'This field is required',
+      isCompact: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, hidden label, hint, message, and custom placement', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      hasMessage: true,
+      message: 'This field is required',
+      placement: 'top',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, regular label, hint, message, start icon, and end icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      hasMessage: true,
+      message: 'This field is required',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, hidden label, hint, message, compact menu, and custom placement', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      hasMessage: true,
+      message: 'This field is required',
+      isCompact: true,
+      placement: 'top',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a disabled input', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      disabled: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a controlled input value', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      inputValue: 'Tomato',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a controlled open state', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isOpen: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+});

--- a/packages/dropdowns.legacy/demo/stories/MenuStory.spec.tsx
+++ b/packages/dropdowns.legacy/demo/stories/MenuStory.spec.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { MenuStory } from './MenuStory';
+import { MENU_ITEMS } from './data';
+import { Dropdown } from '@zendeskgarden/react-dropdowns.legacy';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(
+    <Dropdown
+      {...props}
+      downshiftProps={{
+        itemToString: (item?: any) => item && item.value,
+        ...props.downshiftProps
+      }}
+    >
+      <MenuStory {...props} />
+      );
+    </Dropdown>
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('MenuStory Component', () => {
+  it('renders default MenuStory', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS });
+  });
+
+  it('renders MenuStory with compact styling', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, isCompact: true });
+  });
+
+  it('renders MenuStory with a custom placement', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, placement: 'top' });
+  });
+
+  it('renders MenuStory with a custom maxHeight', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, maxHeight: '200px' });
+  });
+
+  it('renders MenuStory with a custom maxHeight and compact styling', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, maxHeight: '200px', isCompact: true });
+  });
+
+  it('renders MenuStory with a custom maxHeight, compact styling, and animated transitions', () => {
+    renderAndMatchSnapshot({
+      items: MENU_ITEMS,
+      maxHeight: '200px',
+      isCompact: true
+    });
+  });
+
+  it('renders MenuStory with a custom itemProps (disabled)', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, itemProps: { disabled: true } });
+  });
+
+  it('renders MenuStory with a custom itemProps (isFocused)', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, itemProps: { isFocused: true } });
+  });
+
+  it('renders MenuStory with a custom itemProps (isHovered)', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, itemProps: { isHovered: true } });
+  });
+
+  it('renders MenuStory with a custom itemProps (isActive)', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, itemProps: { isActive: true } });
+  });
+
+  it('renders MenuStory with a custom itemProps (isCompact)', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, itemProps: { isCompact: true } });
+  });
+
+  it('renders MenuStory with a custom itemProps (isCompact and isActive)', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, itemProps: { isCompact: true, isActive: true } });
+  });
+
+  it('renders MenuStory with a custom itemProps (disabled and isCompact)', () => {
+    renderAndMatchSnapshot({
+      items: MENU_ITEMS,
+      itemProps: {
+        disabled: true,
+        isCompact: true
+      }
+    });
+  });
+});

--- a/packages/dropdowns.legacy/demo/stories/MultiSelectStory.spec.tsx
+++ b/packages/dropdowns.legacy/demo/stories/MultiSelectStory.spec.tsx
@@ -1,0 +1,301 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { MultiselectStory } from './MultiselectStory';
+import { MULTISELECT_ITEMS } from './data';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<MultiselectStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('MultiselectStory Component', () => {
+  it('renders default MultiselectStory', () => {
+    renderAndMatchSnapshot({
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a label', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a regular label', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelRegular: true,
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a hidden label', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelHidden: true,
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a hint', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      hasHint: true,
+      hint: 'Select your favorite flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      hasMessage: true,
+      message: 'Please select at least one flower',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      validationLabel: 'Invalid selection',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      hasHint: true,
+      hint: 'Select your favorite flowers',
+      hasMessage: true,
+      message: 'Please select at least one flower',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a label, hidden label, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelHidden: true,
+      validationLabel: 'Invalid selection',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a label, regular label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Select your favorite flowers',
+      hasMessage: true,
+      message: 'Please select at least one flower',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a label, hidden label, hint, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Select your favorite flowers',
+      validationLabel: 'Invalid selection',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a label, regular label, hint, message, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Select your favorite flowers',
+      hasMessage: true,
+      message: 'Please select at least one flower',
+      validationLabel: 'Invalid selection',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with selected items', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [MULTISELECT_ITEMS[0], MULTISELECT_ITEMS[1]],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a placeholder', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      placeholder: 'Select flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a custom input value', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: 'Aster',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a custom "show more" text', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [MULTISELECT_ITEMS[0], MULTISELECT_ITEMS[1], MULTISELECT_ITEMS[2]],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn(),
+      showMore: 'more items'
+    });
+  });
+
+  it('renders MultiselectStory with compact styling', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn(),
+      isCompact: true
+    });
+  });
+
+  it('renders MultiselectStory with a custom placement', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn(),
+      placement: 'top'
+    });
+  });
+
+  it('renders MultiselectStory with an icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn(),
+      hasIcon: true
+    });
+  });
+
+  it('renders MultiselectStory with a label, hint, message, and compact styling', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      hasHint: true,
+      hint: 'Select your favorite flowers',
+      hasMessage: true,
+      message: 'Please select at least one flower',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn(),
+      isCompact: true
+    });
+  });
+
+  it('renders MultiselectStory with a label, hidden label, validation label, and custom placement', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelHidden: true,
+      validationLabel: 'Invalid selection',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn(),
+      placement: 'top'
+    });
+  });
+
+  it('renders MultiselectStory with a label, regular label, hint, message, validation label, and icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Select your favorite flowers',
+      hasMessage: true,
+      message: 'Please select at least one flower',
+      validationLabel: 'Invalid selection',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn(),
+      hasIcon: true
+    });
+  });
+});

--- a/packages/dropdowns.legacy/demo/stories/__snapshots__/AutocompleteStory.spec.tsx.snap
+++ b/packages/dropdowns.legacy/demo/stories/__snapshots__/AutocompleteStory.spec.tsx.snap
@@ -740,30 +740,30 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-10-input"
           id="downshift-10-label"
         >
@@ -774,7 +774,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":ra:--hint"
         >
           Hint
@@ -787,7 +787,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
           aria-owns="downshift-10-menu"
           class="c8 c9 c10 c11"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -802,7 +802,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-input"
             role="combobox"
             value=""
@@ -811,7 +811,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-hidden="true"
             class="c13  c14"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -829,7 +829,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":ra:--message"
           role="alert"
         >
@@ -839,14 +839,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
       <div
         class="c17 is-animated"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-10-label"
           class="c18 is-animated"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-10-menu"
           role="listbox"
           style="width: 0px;"
@@ -855,14 +855,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="true"
             class="c19"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-0"
             role="option"
           >
             <div
               class="c20"
               data-garden-id="dropdowns.item_icon"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <svg
                 aria-hidden="true"
@@ -887,7 +887,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="false"
             class="c21"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-1"
             role="option"
           >
@@ -897,7 +897,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="false"
             class="c21"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-2"
             role="option"
           >
@@ -907,7 +907,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="false"
             class="c21"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-3"
             role="option"
           >
@@ -917,7 +917,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="false"
             class="c21"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-4"
             role="option"
           >
@@ -927,7 +927,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="false"
             class="c21"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-5"
             role="option"
           >
@@ -937,7 +937,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="false"
             class="c21"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-6"
             role="option"
           >
@@ -947,7 +947,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="false"
             class="c21"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-7"
             role="option"
           >
@@ -957,7 +957,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="false"
             class="c21"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-8"
             role="option"
           >
@@ -967,7 +967,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="false"
             class="c21"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-9"
             role="option"
           >
@@ -977,7 +977,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="false"
             class="c21"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-10"
             role="option"
           >
@@ -987,7 +987,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="false"
             class="c21"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-11"
             role="option"
           >
@@ -997,7 +997,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="false"
             class="c21"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-12"
             role="option"
           >
@@ -1007,7 +1007,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="false"
             class="c21"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-13"
             role="option"
           >
@@ -1017,7 +1017,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
             aria-selected="false"
             class="c21"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-item-14"
             role="option"
           >
@@ -1667,30 +1667,30 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a hidden lab
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-3-input"
           hidden=""
           id="downshift-3-label"
@@ -1704,13 +1704,13 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a hidden lab
           aria-labelledby="downshift-3-label"
           class="c6 c7 c8 c9"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <div
             class="c10"
             data-garden-id="dropdowns.select"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Asparagus
           </div>
@@ -1724,7 +1724,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a hidden lab
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-3-input"
             role="combobox"
             value=""
@@ -1733,7 +1733,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a hidden lab
             aria-hidden="true"
             class="c13  c14"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -1751,7 +1751,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a hidden lab
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r3:--hint"
         >
           Hint
@@ -1761,7 +1761,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a hidden lab
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r3:--message"
           role="alert"
         >
@@ -1771,14 +1771,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a hidden lab
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-3-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-3-menu"
           role="listbox"
         />
@@ -2425,30 +2425,30 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a hint 1`] =
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-4-input"
           id="downshift-4-label"
         >
@@ -2459,7 +2459,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a hint 1`] =
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r4:--hint"
         >
           Please select your favorite vegetable
@@ -2471,13 +2471,13 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a hint 1`] =
           aria-labelledby="downshift-4-label"
           class="c8 c9 c10 c11"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.select"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Asparagus
           </div>
@@ -2491,7 +2491,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a hint 1`] =
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-4-input"
             role="combobox"
             value=""
@@ -2500,7 +2500,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a hint 1`] =
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -2518,7 +2518,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a hint 1`] =
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r4:--message"
           role="alert"
         >
@@ -2528,14 +2528,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a hint 1`] =
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-4-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-4-menu"
           role="listbox"
         />
@@ -3182,30 +3182,30 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a label 1`] 
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-1-input"
           id="downshift-1-label"
         >
@@ -3216,7 +3216,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a label 1`] 
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r1:--hint"
         >
           Hint
@@ -3228,13 +3228,13 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a label 1`] 
           aria-labelledby="downshift-1-label"
           class="c8 c9 c10 c11"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.select"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Asparagus
           </div>
@@ -3248,7 +3248,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a label 1`] 
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-1-input"
             role="combobox"
             value=""
@@ -3257,7 +3257,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a label 1`] 
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -3275,7 +3275,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a label 1`] 
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r1:--message"
           role="alert"
         >
@@ -3285,14 +3285,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a label 1`] 
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-1-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-1-menu"
           role="listbox"
         />
@@ -3939,30 +3939,30 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a message 1`
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-5-input"
           id="downshift-5-label"
         >
@@ -3973,7 +3973,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a message 1`
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r5:--hint"
         >
           Hint
@@ -3985,13 +3985,13 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a message 1`
           aria-labelledby="downshift-5-label"
           class="c8 c9 c10 c11"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.select"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Asparagus
           </div>
@@ -4005,7 +4005,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a message 1`
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-5-input"
             role="combobox"
             value=""
@@ -4014,7 +4014,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a message 1`
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -4032,7 +4032,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a message 1`
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r5:--message"
           role="alert"
         >
@@ -4042,14 +4042,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a message 1`
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-5-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-5-menu"
           role="listbox"
         />
@@ -4696,30 +4696,30 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a regular la
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-2-input"
           id="downshift-2-label"
         >
@@ -4730,7 +4730,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a regular la
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r2:--hint"
         >
           Hint
@@ -4742,13 +4742,13 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a regular la
           aria-labelledby="downshift-2-label"
           class="c8 c9 c10 c11"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.select"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Asparagus
           </div>
@@ -4762,7 +4762,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a regular la
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-2-input"
             role="combobox"
             value=""
@@ -4771,7 +4771,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a regular la
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -4789,7 +4789,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a regular la
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r2:--message"
           role="alert"
         >
@@ -4799,14 +4799,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a regular la
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-2-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-2-menu"
           role="listbox"
         />
@@ -5453,30 +5453,30 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a selected i
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-8-input"
           id="downshift-8-label"
         >
@@ -5487,7 +5487,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a selected i
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r8:--hint"
         >
           Hint
@@ -5499,13 +5499,13 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a selected i
           aria-labelledby="downshift-8-label"
           class="c8 c9 c10 c11"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.select"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Brussel sprouts
           </div>
@@ -5519,7 +5519,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a selected i
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-8-input"
             role="combobox"
             value=""
@@ -5528,7 +5528,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a selected i
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -5546,7 +5546,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a selected i
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r8:--message"
           role="alert"
         >
@@ -5556,14 +5556,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory with a selected i
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-8-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-8-menu"
           role="listbox"
         />
@@ -6220,30 +6220,30 @@ exports[`AutocompleteStory Component renders AutocompleteStory with an icon 1`] 
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-6-input"
           id="downshift-6-label"
         >
@@ -6254,7 +6254,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with an icon 1`] 
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r6:--hint"
         >
           Hint
@@ -6266,19 +6266,19 @@ exports[`AutocompleteStory Component renders AutocompleteStory with an icon 1`] 
           aria-labelledby="downshift-6-label"
           class="c8 c9 c10 c11"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <svg
             class="c12  c13"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             xmlns="http://www.w3.org/2000/svg"
           />
           <div
             class="c14"
             data-garden-id="dropdowns.select"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Asparagus
           </div>
@@ -6292,7 +6292,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with an icon 1`] 
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-6-input"
             role="combobox"
             value=""
@@ -6301,7 +6301,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with an icon 1`] 
             aria-hidden="true"
             class="c12  c17"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -6319,7 +6319,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with an icon 1`] 
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r6:--message"
           role="alert"
         >
@@ -6329,14 +6329,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory with an icon 1`] 
       <div
         class="c20"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-6-label"
           class="c21"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-6-menu"
           role="listbox"
         />
@@ -6983,30 +6983,30 @@ exports[`AutocompleteStory Component renders AutocompleteStory with compact menu
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-11-input"
           id="downshift-11-label"
         >
@@ -7017,7 +7017,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with compact menu
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rb:--hint"
         >
           Hint
@@ -7029,13 +7029,13 @@ exports[`AutocompleteStory Component renders AutocompleteStory with compact menu
           aria-labelledby="downshift-11-label"
           class="c8 c9 c10 c11"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.select"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Asparagus
           </div>
@@ -7049,7 +7049,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with compact menu
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-11-input"
             role="combobox"
             value=""
@@ -7058,7 +7058,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with compact menu
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -7076,7 +7076,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with compact menu
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rb:--message"
           role="alert"
         >
@@ -7086,14 +7086,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory with compact menu
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-11-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-11-menu"
           role="listbox"
         />
@@ -7740,30 +7740,30 @@ exports[`AutocompleteStory Component renders AutocompleteStory with custom items
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-7-input"
           id="downshift-7-label"
         >
@@ -7774,7 +7774,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with custom items
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r7:--hint"
         >
           Hint
@@ -7786,13 +7786,13 @@ exports[`AutocompleteStory Component renders AutocompleteStory with custom items
           aria-labelledby="downshift-7-label"
           class="c8 c9 c10 c11"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.select"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Custom Item
           </div>
@@ -7806,7 +7806,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with custom items
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-7-input"
             role="combobox"
             value=""
@@ -7815,7 +7815,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with custom items
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -7833,7 +7833,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with custom items
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r7:--message"
           role="alert"
         >
@@ -7843,14 +7843,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory with custom items
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-7-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-7-menu"
           role="listbox"
         />
@@ -8497,30 +8497,30 @@ exports[`AutocompleteStory Component renders AutocompleteStory with input value 
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-9-input"
           id="downshift-9-label"
         >
@@ -8531,7 +8531,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with input value 
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r9:--hint"
         >
           Hint
@@ -8543,13 +8543,13 @@ exports[`AutocompleteStory Component renders AutocompleteStory with input value 
           aria-labelledby="downshift-9-label"
           class="c8 c9 c10 c11"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.select"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Asparagus
           </div>
@@ -8563,7 +8563,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with input value 
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-9-input"
             role="combobox"
             value="Asparagus"
@@ -8572,7 +8572,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with input value 
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -8590,7 +8590,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with input value 
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r9:--message"
           role="alert"
         >
@@ -8600,14 +8600,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory with input value 
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-9-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-9-menu"
           role="listbox"
         />
@@ -9266,30 +9266,30 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation e
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-13-input"
           id="downshift-13-label"
         >
@@ -9300,7 +9300,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation e
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rd:--hint"
         >
           Hint
@@ -9312,13 +9312,13 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation e
           aria-labelledby="downshift-13-label"
           class="c8 c9 c10 c11"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.select"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Asparagus
           </div>
@@ -9332,7 +9332,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation e
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-13-input"
             role="combobox"
             value=""
@@ -9341,7 +9341,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation e
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -9359,7 +9359,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation e
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rd:--message"
           role="alert"
         >
@@ -9367,7 +9367,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation e
             aria-label="error"
             class="c19  c20"
             data-garden-id="forms.input_message_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             role="img"
@@ -9402,14 +9402,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation e
       <div
         class="c21"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-13-label"
           class="c22"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-13-menu"
           role="listbox"
         />
@@ -10068,30 +10068,30 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation s
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-12-input"
           id="downshift-12-label"
         >
@@ -10102,7 +10102,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation s
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rc:--hint"
         >
           Hint
@@ -10114,13 +10114,13 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation s
           aria-labelledby="downshift-12-label"
           class="c8 c9 c10 c11"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.select"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Asparagus
           </div>
@@ -10134,7 +10134,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation s
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-12-input"
             role="combobox"
             value=""
@@ -10143,7 +10143,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation s
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -10161,7 +10161,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation s
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rc:--message"
           role="alert"
         >
@@ -10169,7 +10169,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation s
             aria-label="success"
             class="c19  c20"
             data-garden-id="forms.input_message_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             role="img"
@@ -10199,14 +10199,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation s
       <div
         class="c21"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-12-label"
           class="c22"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-12-menu"
           role="listbox"
         />
@@ -10865,30 +10865,30 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation w
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-14-input"
           id="downshift-14-label"
         >
@@ -10899,7 +10899,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation w
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":re:--hint"
         >
           Hint
@@ -10911,13 +10911,13 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation w
           aria-labelledby="downshift-14-label"
           class="c8 c9 c10 c11"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.select"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Asparagus
           </div>
@@ -10931,7 +10931,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation w
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-14-input"
             role="combobox"
             value=""
@@ -10940,7 +10940,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation w
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -10958,7 +10958,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation w
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":re:--message"
           role="alert"
         >
@@ -10966,7 +10966,7 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation w
             aria-label="warning"
             class="c19  c20"
             data-garden-id="forms.input_message_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             role="img"
@@ -10993,14 +10993,14 @@ exports[`AutocompleteStory Component renders AutocompleteStory with validation w
       <div
         class="c21"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-14-label"
           class="c22"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-14-menu"
           role="listbox"
         />
@@ -11647,30 +11647,30 @@ exports[`AutocompleteStory Component renders default AutocompleteStory 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-0-input"
           id="downshift-0-label"
         >
@@ -11681,7 +11681,7 @@ exports[`AutocompleteStory Component renders default AutocompleteStory 1`] = `
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r0:--hint"
         >
           Hint
@@ -11693,13 +11693,13 @@ exports[`AutocompleteStory Component renders default AutocompleteStory 1`] = `
           aria-labelledby="downshift-0-label"
           class="c8 c9 c10 c11"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.select"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Asparagus
           </div>
@@ -11713,7 +11713,7 @@ exports[`AutocompleteStory Component renders default AutocompleteStory 1`] = `
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-0-input"
             role="combobox"
             value=""
@@ -11722,7 +11722,7 @@ exports[`AutocompleteStory Component renders default AutocompleteStory 1`] = `
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -11740,7 +11740,7 @@ exports[`AutocompleteStory Component renders default AutocompleteStory 1`] = `
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r0:--message"
           role="alert"
         >
@@ -11750,14 +11750,14 @@ exports[`AutocompleteStory Component renders default AutocompleteStory 1`] = `
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-0-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-0-menu"
           role="listbox"
         />

--- a/packages/dropdowns.legacy/demo/stories/__snapshots__/AutocompleteStory.spec.tsx.snap
+++ b/packages/dropdowns.legacy/demo/stories/__snapshots__/AutocompleteStory.spec.tsx.snap
@@ -1,0 +1,11768 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c15 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c12::-ms-browse {
+  border-radius: 2px;
+}
+
+.c12::-ms-clear,
+.c12::-ms-reveal {
+  display: none;
+}
+
+.c12::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c12::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c12::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c12::-webkit-clear-button,
+.c12::-webkit-inner-spin-button,
+.c12::-webkit-search-cancel-button,
+.c12::-webkit-search-results-button {
+  display: none;
+}
+
+.c12::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c12::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c12:invalid {
+  box-shadow: none;
+}
+
+.c12[type='file']::-ms-value {
+  display: none;
+}
+
+.c12::-ms-browse {
+  font-size: 12px;
+}
+
+.c12[type='date'],
+.c12[type='datetime-local'],
+.c12[type='file'],
+.c12[type='month'],
+.c12[type='time'],
+.c12[type='week'] {
+  max-height: 40px;
+}
+
+.c12[type='file'] {
+  line-height: 1;
+}
+
+.c12::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c12::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c12::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c12.c12,
+.c6 + .c12.c12,
+.c15 + .c12.c12,
+.c12.c12 + .c6,
+.c12.c12 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c12::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c12::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c12:hover {
+  border-color: #1f73b7;
+}
+
+.c12:focus {
+  outline: none;
+}
+
+.c12:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c12::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c12::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c12:disabled,
+.c12[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c12:disabled {
+  cursor: default;
+}
+
+.c14 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #39434b;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10 {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c18 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c17 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+}
+
+.c17 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c17 > *:focus {
+  outline: none;
+}
+
+.c17.is-animated > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c21 {
+  display: block;
+  position: relative;
+  z-index: 0;
+  cursor: pointer;
+  padding: 8px 36px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 20px;
+  word-wrap: break-word;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-color: inherit;
+  color: #293239;
+}
+
+.c21:first-child {
+  margin-top: 4px;
+}
+
+.c21:last-child {
+  margin-bottom: 4px;
+}
+
+.c21:focus {
+  outline: none;
+}
+
+.c21 a,
+.c21 a:hover,
+.c21 a:focus,
+.c21 a:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c21 a,
+.c21 a:hover,
+.c21 a:focus,
+.c21 a:active {
+  color: inherit;
+}
+
+.c19 {
+  display: block;
+  position: relative;
+  z-index: 0;
+  cursor: pointer;
+  padding: 8px 36px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 20px;
+  word-wrap: break-word;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-color: rgba(31,115,183,0.08);
+  color: #293239;
+}
+
+.c19:first-child {
+  margin-top: 4px;
+}
+
+.c19:last-child {
+  margin-bottom: 4px;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19 a,
+.c19 a:hover,
+.c19 a:focus,
+.c19 a:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c19 a,
+.c19 a:hover,
+.c19 a:focus,
+.c19 a:active {
+  color: inherit;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: absolute;
+  top: 0;
+  left: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.1s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
+  opacity: 1;
+  color: #1f73b7;
+  width: 16px;
+  height: calc(20px + 16px);
+}
+
+.c20 > * {
+  width: 16px;
+  height: 16px;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c12[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c12[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-10-input"
+          id="downshift-10-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":ra:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="true"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-10-label"
+          aria-owns="downshift-10-menu"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-activedescendant="downshift-10-item-0"
+            aria-autocomplete="list"
+            aria-controls="downshift-10-menu"
+            aria-describedby=":ra:--hint :ra:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-10-label"
+            autocomplete="off"
+            class="c8 c12 "
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-10-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c13  c14"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":ra:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c17 is-animated"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-10-label"
+          class="c18 is-animated"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-10-menu"
+          role="listbox"
+          style="width: 0px;"
+        >
+          <li
+            aria-selected="true"
+            class="c19"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-0"
+            role="option"
+          >
+            <div
+              class="c20"
+              data-garden-id="dropdowns.item_icon"
+              data-garden-version="9.0.0"
+            >
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </div>
+            Asparagus
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-1"
+            role="option"
+          >
+            Brussel sprouts
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-2"
+            role="option"
+          >
+            Cauliflower
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-3"
+            role="option"
+          >
+            Garlic
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-4"
+            role="option"
+          >
+            Jerusalem artichoke
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-5"
+            role="option"
+          >
+            Kale
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-6"
+            role="option"
+          >
+            Lettuce
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-7"
+            role="option"
+          >
+            Onion
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-8"
+            role="option"
+          >
+            Mushroom
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-9"
+            role="option"
+          >
+            Potato
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-10"
+            role="option"
+          >
+            Radish
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-11"
+            role="option"
+          >
+            Spinach
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-12"
+            role="option"
+          >
+            Tomato
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-13"
+            role="option"
+          >
+            Yam
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-14"
+            role="option"
+          >
+            Zucchini
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with a hidden label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c15 + .c7.c7,
+.c17 + .c7.c7,
+.c7.c7 + .c15,
+.c7.c7 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c15 + .c11.c11,
+.c17 + .c11.c11,
+.c11.c11 + .c15,
+.c11.c11 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c14 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 > .c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c9 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c12 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c10 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-3-input"
+          hidden=""
+          id="downshift-3-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-3-label"
+          class="c6 c7 c8 c9"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c10"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r3:--hint :r3:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-3-label"
+            autocomplete="off"
+            class="c6 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-3-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c13  c14"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r3:--hint"
+        >
+          Hint
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r3:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-3-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-3-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with a hint 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-4-input"
+          id="downshift-4-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r4:--hint"
+        >
+          Please select your favorite vegetable
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-4-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r4:--hint :r4:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-4-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-4-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r4:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-4-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-4-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with a label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-1-input"
+          id="downshift-1-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r1:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-1-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r1:--hint :r1:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-1-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-1-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r1:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-1-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-1-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with a message 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-5-input"
+          id="downshift-5-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r5:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-5-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r5:--hint :r5:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-5-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-5-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r5:--message"
+          role="alert"
+        >
+          This is a required field
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-5-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-5-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with a regular label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-2-input"
+          id="downshift-2-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r2:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-2-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r2:--hint :r2:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-2-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-2-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r2:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-2-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-2-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with a selected item 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-8-input"
+          id="downshift-8-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r8:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-8-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Brussel sprouts
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r8:--hint :r8:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-8-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-8-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r8:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-8-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-8-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with an icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c19 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c18 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c18 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c18 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c18 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c15 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c15::-ms-browse {
+  border-radius: 2px;
+}
+
+.c15::-ms-clear,
+.c15::-ms-reveal {
+  display: none;
+}
+
+.c15::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c15::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c15::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c15::-webkit-clear-button,
+.c15::-webkit-inner-spin-button,
+.c15::-webkit-search-cancel-button,
+.c15::-webkit-search-results-button {
+  display: none;
+}
+
+.c15::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c15:invalid {
+  box-shadow: none;
+}
+
+.c15[type='file']::-ms-value {
+  display: none;
+}
+
+.c15::-ms-browse {
+  font-size: 12px;
+}
+
+.c15[type='date'],
+.c15[type='datetime-local'],
+.c15[type='file'],
+.c15[type='month'],
+.c15[type='time'],
+.c15[type='week'] {
+  max-height: 40px;
+}
+
+.c15[type='file'] {
+  line-height: 1;
+}
+
+.c15::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c15::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c15.c15,
+.c6 + .c15.c15,
+.c18 + .c15.c15,
+.c15.c15 + .c6,
+.c15.c15 ~ .c18 {
+  margin-top: 8px;
+}
+
+.c15::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c15:hover {
+  border-color: #1f73b7;
+}
+
+.c15:focus {
+  outline: none;
+}
+
+.c15:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c15::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c15::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c15:disabled,
+.c15[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c15:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c17 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c12 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c21 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c20 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c20 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c20 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c16 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c14 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c15[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c15[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-6-input"
+          id="downshift-6-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r6:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-6-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <svg
+            class="c12  c13"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <div
+            class="c14"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r6:--hint :r6:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-6-label"
+            autocomplete="off"
+            class="c8 c15 c16"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-6-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c12  c17"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c18 c19"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r6:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c20"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-6-label"
+          class="c21"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-6-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with compact menu 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 11px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 32px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 4px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 100px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-11-input"
+          id="downshift-11-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rb:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-11-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rb:--hint :rb:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-11-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-11-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rb:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-11-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-11-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with custom items 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-7-input"
+          id="downshift-7-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r7:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-7-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Custom Item
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r7:--hint :r7:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-7-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-7-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r7:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-7-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-7-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with input value 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-9-input"
+          id="downshift-9-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r9:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-9-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r9:--hint :r9:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-9-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-9-input"
+            role="combobox"
+            value="Asparagus"
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r9:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-9-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-9-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with validation error 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c20 {
+  width: 16px;
+  height: 16px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 24px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #cd3642;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c18 .c19 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #cd3642;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c22 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c21 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c21 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c21 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-13-input"
+          id="downshift-13-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rd:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="true"
+          aria-labelledby="downshift-13-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rd:--hint :rd:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-13-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-13-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rd:--message"
+          role="alert"
+        >
+          <svg
+            aria-label="error"
+            class="c19  c20"
+            data-garden-id="forms.input_message_icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+            >
+              <circle
+                cx="7.5"
+                cy="8.5"
+                r="7"
+              />
+              <path
+                d="M7.5 4.5V9"
+                stroke-linecap="round"
+              />
+            </g>
+            <circle
+              cx="7.5"
+              cy="12"
+              fill="currentColor"
+              r="1"
+            />
+          </svg>
+          Message
+        </div>
+      </div>
+      <div
+        class="c21"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-13-label"
+          class="c22"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-13-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with validation success 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c20 {
+  width: 16px;
+  height: 16px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 24px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #037f52;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c18 .c19 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #037f52;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #037f52;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c22 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c21 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c21 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c21 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-12-input"
+          id="downshift-12-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rc:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-12-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rc:--hint :rc:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-12-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-12-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rc:--message"
+          role="alert"
+        >
+          <svg
+            aria-label="success"
+            class="c19  c20"
+            data-garden-id="forms.input_message_icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+            >
+              <path
+                d="M4 9l2.5 2.5 5-5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <circle
+                cx="7.5"
+                cy="8.5"
+                r="7"
+              />
+            </g>
+          </svg>
+          Message
+        </div>
+      </div>
+      <div
+        class="c21"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-12-label"
+          class="c22"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-12-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with validation warning 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c20 {
+  width: 16px;
+  height: 16px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 24px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #ac5918;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c18 .c19 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #ac5918;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #ac5918;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c22 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c21 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c21 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c21 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-14-input"
+          id="downshift-14-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":re:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="true"
+          aria-labelledby="downshift-14-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":re:--hint :re:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-14-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-14-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":re:--message"
+          role="alert"
+        >
+          <svg
+            aria-label="warning"
+            class="c19  c20"
+            data-garden-id="forms.input_message_icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M.88 13.77L7.06 1.86c.19-.36.7-.36.89 0l6.18 11.91c.17.33-.07.73-.44.73H1.32c-.37 0-.61-.4-.44-.73zM7.5 6v3.5"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+            />
+            <circle
+              cx="7.5"
+              cy="12"
+              fill="currentColor"
+              r="1"
+            />
+          </svg>
+          Message
+        </div>
+      </div>
+      <div
+        class="c21"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-14-label"
+          class="c22"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-14-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders default AutocompleteStory 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-0-input"
+          id="downshift-0-label"
+        >
+          Label
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r0:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-0-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r0:--hint :r0:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-0-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-0-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r0:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-0-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-0-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/dropdowns.legacy/demo/stories/__snapshots__/ComboboxStory.spec.tsx.snap
+++ b/packages/dropdowns.legacy/demo/stories/__snapshots__/ComboboxStory.spec.tsx.snap
@@ -601,30 +601,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a compact menu 1`] =
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-9-input"
           id="downshift-9-label"
         >
@@ -635,7 +635,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a compact menu 1`] =
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r9:--hint"
         >
           Hint
@@ -647,7 +647,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a compact menu 1`] =
           aria-labelledby="downshift-9-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -660,7 +660,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a compact menu 1`] =
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-9-input"
             role="combobox"
             value=""
@@ -671,7 +671,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a compact menu 1`] =
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r9:--message"
           role="alert"
         >
@@ -681,14 +681,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a compact menu 1`] =
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-9-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-9-menu"
           role="listbox"
         />
@@ -1299,30 +1299,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled input v
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-20-input"
           id="downshift-20-label"
         >
@@ -1333,7 +1333,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled input v
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rk:--hint"
         >
           Hint
@@ -1345,7 +1345,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled input v
           aria-labelledby="downshift-20-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -1358,7 +1358,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled input v
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-20-input"
             role="combobox"
             value="Tomato"
@@ -1369,7 +1369,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled input v
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rk:--message"
           role="alert"
         >
@@ -1379,14 +1379,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled input v
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-20-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-20-menu"
           role="listbox"
         />
@@ -2045,30 +2045,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-21-input"
           id="downshift-21-label"
         >
@@ -2079,7 +2079,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rl:--hint"
         >
           Hint
@@ -2092,7 +2092,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
           aria-owns="downshift-21-menu"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -2106,7 +2106,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-input"
             role="combobox"
             value=""
@@ -2117,7 +2117,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rl:--message"
           role="alert"
         >
@@ -2127,14 +2127,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
       <div
         class="c15 is-animated"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-21-label"
           class="c16 is-animated"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-21-menu"
           role="listbox"
           style="width: 0px;"
@@ -2143,7 +2143,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-0"
             role="option"
           >
@@ -2153,7 +2153,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-1"
             role="option"
           >
@@ -2163,7 +2163,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-2"
             role="option"
           >
@@ -2173,7 +2173,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-3"
             role="option"
           >
@@ -2183,7 +2183,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-4"
             role="option"
           >
@@ -2193,7 +2193,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-5"
             role="option"
           >
@@ -2203,7 +2203,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-6"
             role="option"
           >
@@ -2213,7 +2213,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-7"
             role="option"
           >
@@ -2223,7 +2223,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-8"
             role="option"
           >
@@ -2233,7 +2233,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-9"
             role="option"
           >
@@ -2243,7 +2243,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-10"
             role="option"
           >
@@ -2253,7 +2253,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-11"
             role="option"
           >
@@ -2263,7 +2263,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-12"
             role="option"
           >
@@ -2273,7 +2273,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-13"
             role="option"
           >
@@ -2283,7 +2283,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a controlled open st
             aria-selected="false"
             class="c17"
             data-garden-id="dropdowns.item"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-21-item-14"
             role="option"
           >
@@ -2897,30 +2897,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom placement 1
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-10-input"
           id="downshift-10-label"
         >
@@ -2931,7 +2931,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom placement 1
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":ra:--hint"
         >
           Hint
@@ -2943,7 +2943,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom placement 1
           aria-labelledby="downshift-10-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -2956,7 +2956,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom placement 1
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-10-input"
             role="combobox"
             value=""
@@ -2967,7 +2967,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom placement 1
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":ra:--message"
           role="alert"
         >
@@ -2977,14 +2977,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom placement 1
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-10-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-10-menu"
           role="listbox"
         />
@@ -3595,30 +3595,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a disabled input 1`]
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-19-input"
           id="downshift-19-label"
         >
@@ -3629,7 +3629,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a disabled input 1`]
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rj:--hint"
         >
           Hint
@@ -3642,7 +3642,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a disabled input 1`]
           aria-labelledby="downshift-19-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -3655,7 +3655,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a disabled input 1`]
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             disabled=""
             id="downshift-19-input"
             role="combobox"
@@ -3667,7 +3667,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a disabled input 1`]
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rj:--message"
           role="alert"
         >
@@ -3677,14 +3677,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a disabled input 1`]
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-19-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-19-menu"
           role="listbox"
         />
@@ -4295,30 +4295,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] =
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-3-input"
           hidden=""
           id="downshift-3-label"
@@ -4332,7 +4332,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] =
           aria-labelledby="downshift-3-label"
           class="c6 c7 c8"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -4345,7 +4345,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] =
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-3-input"
             role="combobox"
             value=""
@@ -4356,7 +4356,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] =
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r3:--hint"
         >
           Hint
@@ -4366,7 +4366,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] =
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r3:--message"
           role="alert"
         >
@@ -4376,14 +4376,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] =
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-3-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-3-menu"
           role="listbox"
         />
@@ -4994,30 +4994,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-4-input"
           id="downshift-4-label"
         >
@@ -5028,7 +5028,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r4:--hint"
         >
           Select your favorite vegetable
@@ -5040,7 +5040,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
           aria-labelledby="downshift-4-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -5053,7 +5053,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-4-input"
             role="combobox"
             value=""
@@ -5064,7 +5064,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r4:--message"
           role="alert"
         >
@@ -5074,14 +5074,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-4-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-4-menu"
           role="listbox"
         />
@@ -5692,30 +5692,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-1-input"
           id="downshift-1-label"
         >
@@ -5726,7 +5726,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r1:--hint"
         >
           Hint
@@ -5738,7 +5738,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
           aria-labelledby="downshift-1-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -5751,7 +5751,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-1-input"
             role="combobox"
             value=""
@@ -5762,7 +5762,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r1:--message"
           role="alert"
         >
@@ -5772,14 +5772,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-1-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-1-menu"
           role="listbox"
         />
@@ -6406,30 +6406,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-12-input"
           hidden=""
           id="downshift-12-label"
@@ -6443,13 +6443,13 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
           aria-labelledby="downshift-12-label"
           class="c6 c7 c8"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <svg
             class="c9  c10"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             xmlns="http://www.w3.org/2000/svg"
           />
           <input
@@ -6462,7 +6462,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-12-input"
             role="combobox"
             value=""
@@ -6473,7 +6473,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rc:--hint"
         >
           Hint
@@ -6483,7 +6483,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rc:--message"
           role="alert"
         >
@@ -6493,14 +6493,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
       <div
         class="c17"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-12-label"
           class="c18"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-12-menu"
           role="listbox"
         />
@@ -7127,30 +7127,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-14-input"
           hidden=""
           id="downshift-14-label"
@@ -7164,7 +7164,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
           aria-labelledby="downshift-14-label"
           class="c6 c7 c8"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -7177,7 +7177,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-14-input"
             role="combobox"
             value=""
@@ -7185,7 +7185,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
           <svg
             class="c11  c12"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             xmlns="http://www.w3.org/2000/svg"
           />
         </div>
@@ -7194,7 +7194,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":re:--hint"
         >
           Select your favorite vegetable
@@ -7204,7 +7204,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":re:--message"
           role="alert"
         >
@@ -7214,14 +7214,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
       <div
         class="c17"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-14-label"
           class="c18"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-14-menu"
           role="listbox"
         />
@@ -7832,30 +7832,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-16-input"
           hidden=""
           id="downshift-16-label"
@@ -7869,7 +7869,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
           aria-labelledby="downshift-16-label"
           class="c6 c7 c8"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -7882,7 +7882,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-16-input"
             role="combobox"
             value=""
@@ -7893,7 +7893,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rg:--hint"
         >
           Select your favorite vegetable
@@ -7903,7 +7903,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rg:--message"
           role="alert"
         >
@@ -7913,14 +7913,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-16-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-16-menu"
           role="listbox"
         />
@@ -8531,30 +8531,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-18-input"
           hidden=""
           id="downshift-18-label"
@@ -8568,7 +8568,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
           aria-labelledby="downshift-18-label"
           class="c6 c7 c8"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -8581,7 +8581,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-18-input"
             role="combobox"
             value=""
@@ -8592,7 +8592,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":ri:--hint"
         >
           Select your favorite vegetable
@@ -8602,7 +8602,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":ri:--message"
           role="alert"
         >
@@ -8612,14 +8612,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hidden labe
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-18-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-18-menu"
           role="listbox"
         />
@@ -9230,30 +9230,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hint, and m
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-11-input"
           id="downshift-11-label"
         >
@@ -9264,7 +9264,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hint, and m
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rb:--hint"
         >
           Select your favorite vegetable
@@ -9276,7 +9276,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hint, and m
           aria-labelledby="downshift-11-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -9289,7 +9289,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hint, and m
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-11-input"
             role="combobox"
             value=""
@@ -9300,7 +9300,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hint, and m
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rb:--message"
           role="alert"
         >
@@ -9310,14 +9310,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, hint, and m
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-11-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-11-menu"
           role="listbox"
         />
@@ -9928,30 +9928,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-13-input"
           id="downshift-13-label"
         >
@@ -9962,7 +9962,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rd:--hint"
         >
           Select your favorite vegetable
@@ -9974,7 +9974,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
           aria-labelledby="downshift-13-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -9987,7 +9987,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-13-input"
             role="combobox"
             value=""
@@ -9998,7 +9998,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rd:--message"
           role="alert"
         >
@@ -10008,14 +10008,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-13-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-13-menu"
           role="listbox"
         />
@@ -10626,30 +10626,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-15-input"
           id="downshift-15-label"
         >
@@ -10660,7 +10660,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rf:--hint"
         >
           Select your favorite vegetable
@@ -10672,7 +10672,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
           aria-labelledby="downshift-15-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -10685,7 +10685,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-15-input"
             role="combobox"
             value=""
@@ -10696,7 +10696,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rf:--message"
           role="alert"
         >
@@ -10706,14 +10706,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-15-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-15-menu"
           role="listbox"
         />
@@ -11350,30 +11350,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-17-input"
           id="downshift-17-label"
         >
@@ -11384,7 +11384,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rh:--hint"
         >
           Select your favorite vegetable
@@ -11396,13 +11396,13 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
           aria-labelledby="downshift-17-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <svg
             class="c11  c12"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             xmlns="http://www.w3.org/2000/svg"
           />
           <input
@@ -11415,7 +11415,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-17-input"
             role="combobox"
             value=""
@@ -11423,7 +11423,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
           <svg
             class="c11  c15"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             xmlns="http://www.w3.org/2000/svg"
           />
         </div>
@@ -11432,7 +11432,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rh:--message"
           role="alert"
         >
@@ -11442,14 +11442,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a label, regular lab
       <div
         class="c18"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-17-label"
           class="c19"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-17-menu"
           role="listbox"
         />
@@ -12060,30 +12060,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-5-input"
           id="downshift-5-label"
         >
@@ -12094,7 +12094,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r5:--hint"
         >
           Hint
@@ -12106,7 +12106,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
           aria-labelledby="downshift-5-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -12119,7 +12119,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-5-input"
             role="combobox"
             value=""
@@ -12130,7 +12130,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r5:--message"
           role="alert"
         >
@@ -12140,14 +12140,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-5-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-5-menu"
           role="listbox"
         />
@@ -12758,30 +12758,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a regular label 1`] 
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-2-input"
           id="downshift-2-label"
         >
@@ -12792,7 +12792,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a regular label 1`] 
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r2:--hint"
         >
           Hint
@@ -12804,7 +12804,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a regular label 1`] 
           aria-labelledby="downshift-2-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -12817,7 +12817,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a regular label 1`] 
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-2-input"
             role="combobox"
             value=""
@@ -12828,7 +12828,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a regular label 1`] 
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r2:--message"
           role="alert"
         >
@@ -12838,14 +12838,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a regular label 1`] 
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-2-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-2-menu"
           role="listbox"
         />
@@ -13472,30 +13472,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a start icon 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-6-input"
           id="downshift-6-label"
         >
@@ -13506,7 +13506,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a start icon 1`] = `
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r6:--hint"
         >
           Hint
@@ -13518,13 +13518,13 @@ exports[`ComboboxStory Component renders ComboboxStory with a start icon 1`] = `
           aria-labelledby="downshift-6-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <svg
             class="c11  c12"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             xmlns="http://www.w3.org/2000/svg"
           />
           <input
@@ -13537,7 +13537,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a start icon 1`] = `
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-6-input"
             role="combobox"
             value=""
@@ -13548,7 +13548,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a start icon 1`] = `
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r6:--message"
           role="alert"
         >
@@ -13558,14 +13558,14 @@ exports[`ComboboxStory Component renders ComboboxStory with a start icon 1`] = `
       <div
         class="c17"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-6-label"
           class="c18"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-6-menu"
           role="listbox"
         />
@@ -14192,30 +14192,30 @@ exports[`ComboboxStory Component renders ComboboxStory with an end icon 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-7-input"
           id="downshift-7-label"
         >
@@ -14226,7 +14226,7 @@ exports[`ComboboxStory Component renders ComboboxStory with an end icon 1`] = `
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r7:--hint"
         >
           Hint
@@ -14238,7 +14238,7 @@ exports[`ComboboxStory Component renders ComboboxStory with an end icon 1`] = `
           aria-labelledby="downshift-7-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -14251,7 +14251,7 @@ exports[`ComboboxStory Component renders ComboboxStory with an end icon 1`] = `
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-7-input"
             role="combobox"
             value=""
@@ -14259,7 +14259,7 @@ exports[`ComboboxStory Component renders ComboboxStory with an end icon 1`] = `
           <svg
             class="c13  c14"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             xmlns="http://www.w3.org/2000/svg"
           />
         </div>
@@ -14268,7 +14268,7 @@ exports[`ComboboxStory Component renders ComboboxStory with an end icon 1`] = `
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r7:--message"
           role="alert"
         >
@@ -14278,14 +14278,14 @@ exports[`ComboboxStory Component renders ComboboxStory with an end icon 1`] = `
       <div
         class="c17"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-7-label"
           class="c18"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-7-menu"
           role="listbox"
         />
@@ -14922,30 +14922,30 @@ exports[`ComboboxStory Component renders ComboboxStory with both start and end i
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-8-input"
           id="downshift-8-label"
         >
@@ -14956,7 +14956,7 @@ exports[`ComboboxStory Component renders ComboboxStory with both start and end i
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r8:--hint"
         >
           Hint
@@ -14968,13 +14968,13 @@ exports[`ComboboxStory Component renders ComboboxStory with both start and end i
           aria-labelledby="downshift-8-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <svg
             class="c11  c12"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             xmlns="http://www.w3.org/2000/svg"
           />
           <input
@@ -14987,7 +14987,7 @@ exports[`ComboboxStory Component renders ComboboxStory with both start and end i
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-8-input"
             role="combobox"
             value=""
@@ -14995,7 +14995,7 @@ exports[`ComboboxStory Component renders ComboboxStory with both start and end i
           <svg
             class="c11  c15"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             xmlns="http://www.w3.org/2000/svg"
           />
         </div>
@@ -15004,7 +15004,7 @@ exports[`ComboboxStory Component renders ComboboxStory with both start and end i
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r8:--message"
           role="alert"
         >
@@ -15014,14 +15014,14 @@ exports[`ComboboxStory Component renders ComboboxStory with both start and end i
       <div
         class="c18"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-8-label"
           class="c19"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-8-menu"
           role="listbox"
         />
@@ -15632,30 +15632,30 @@ exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-0-input"
           id="downshift-0-label"
         >
@@ -15666,7 +15666,7 @@ exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r0:--hint"
         >
           Hint
@@ -15678,7 +15678,7 @@ exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
           aria-labelledby="downshift-0-label"
           class="c8 c9 c10"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
         >
           <input
@@ -15691,7 +15691,7 @@ exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
             data-garden-container-id="containers.field.input"
             data-garden-container-version="3.0.19"
             data-garden-id="forms.media_input"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="downshift-0-input"
             role="combobox"
             value=""
@@ -15702,7 +15702,7 @@ exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r0:--message"
           role="alert"
         >
@@ -15712,14 +15712,14 @@ exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
       <div
         class="c15"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-0-label"
           class="c16"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-0-menu"
           role="listbox"
         />

--- a/packages/dropdowns.legacy/demo/stories/__snapshots__/ComboboxStory.spec.tsx.snap
+++ b/packages/dropdowns.legacy/demo/stories/__snapshots__/ComboboxStory.spec.tsx.snap
@@ -1,0 +1,15730 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ComboboxStory Component renders ComboboxStory with a compact menu 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 11px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 32px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 4px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-9-input"
+          id="downshift-9-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r9:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-9-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r9:--hint :r9:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-9-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-9-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r9:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-9-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-9-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a controlled input value 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-20-input"
+          id="downshift-20-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rk:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-20-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rk:--hint :rk:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-20-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-20-input"
+            role="combobox"
+            value="Tomato"
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rk:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-20-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-20-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a controlled open state 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c15.is-animated > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c17 {
+  display: block;
+  position: relative;
+  z-index: 0;
+  cursor: pointer;
+  padding: 8px 36px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 20px;
+  word-wrap: break-word;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-color: inherit;
+  color: #293239;
+}
+
+.c17:first-child {
+  margin-top: 4px;
+}
+
+.c17:last-child {
+  margin-bottom: 4px;
+}
+
+.c17:focus {
+  outline: none;
+}
+
+.c17 a,
+.c17 a:hover,
+.c17 a:focus,
+.c17 a:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17 a,
+.c17 a:hover,
+.c17 a:focus,
+.c17 a:active {
+  color: inherit;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-21-input"
+          id="downshift-21-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rl:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="true"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-21-label"
+          aria-owns="downshift-21-menu"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-controls="downshift-21-menu"
+            aria-describedby=":rl:--hint :rl:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-21-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-21-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rl:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15 is-animated"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-21-label"
+          class="c16 is-animated"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-21-menu"
+          role="listbox"
+          style="width: 0px;"
+        >
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-0"
+            role="option"
+          >
+            Asparagus
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-1"
+            role="option"
+          >
+            Brussel sprouts
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-2"
+            role="option"
+          >
+            Cauliflower
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-3"
+            role="option"
+          >
+            Garlic
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-4"
+            role="option"
+          >
+            Jerusalem artichoke
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-5"
+            role="option"
+          >
+            Kale
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-6"
+            role="option"
+          >
+            Lettuce
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-7"
+            role="option"
+          >
+            Onion
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-8"
+            role="option"
+          >
+            Mushroom
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-9"
+            role="option"
+          >
+            Potato
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-10"
+            role="option"
+          >
+            Radish
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-11"
+            role="option"
+          >
+            Spinach
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-12"
+            role="option"
+          >
+            Tomato
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-13"
+            role="option"
+          >
+            Yam
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-14"
+            role="option"
+          >
+            Zucchini
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom placement 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-10-input"
+          id="downshift-10-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":ra:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-10-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":ra:--hint :ra:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-10-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-10-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":ra:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-10-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-10-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a disabled input 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-19-input"
+          id="downshift-19-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rj:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-disabled="true"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-19-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rj:--hint :rj:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-19-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            disabled=""
+            id="downshift-19-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rj:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-19-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-19-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c11 + .c7.c7,
+.c13 + .c7.c7,
+.c7.c7 + .c11,
+.c7.c7 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c11 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c11,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-3-input"
+          hidden=""
+          id="downshift-3-label"
+        >
+          Vegetables
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-3-label"
+          class="c6 c7 c8"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r3:--hint :r3:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-3-label"
+            autocomplete="off"
+            class="c6 c9 c10"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-3-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c11 c12"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r3:--hint"
+        >
+          Hint
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r3:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-3-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-3-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-4-input"
+          id="downshift-4-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r4:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-4-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r4:--hint :r4:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-4-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-4-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r4:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-4-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-4-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-1-input"
+          id="downshift-1-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r1:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-1-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r1:--hint :r1:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-1-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-1-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r1:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-1-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-1-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, hidden label, and start icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c14 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c13 + .c7.c7,
+.c15 + .c7.c7,
+.c7.c7 + .c13,
+.c7.c7 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c13 + .c11.c11,
+.c15 + .c11.c11,
+.c11.c11 + .c13,
+.c11.c11 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 > .c9 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c18 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c17 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c17 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c17 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-12-input"
+          hidden=""
+          id="downshift-12-label"
+        >
+          Vegetables
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-12-label"
+          class="c6 c7 c8"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <svg
+            class="c9  c10"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rc:--hint :rc:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-12-label"
+            autocomplete="off"
+            class="c6 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-12-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rc:--hint"
+        >
+          Hint
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rc:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c17"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-12-label"
+          class="c18"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-12-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, hidden label, hint, and end icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c14 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c13 + .c7.c7,
+.c15 + .c7.c7,
+.c7.c7 + .c13,
+.c7.c7 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c13 + .c9.c9,
+.c15 + .c9.c9,
+.c9.c9 + .c13,
+.c9.c9 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 > .c11 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c10 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c18 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c17 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c17 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c17 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-14-input"
+          hidden=""
+          id="downshift-14-label"
+        >
+          Vegetables
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-14-label"
+          class="c6 c7 c8"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":re:--hint :re:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-14-label"
+            autocomplete="off"
+            class="c6 c9 c10"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-14-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            class="c11  c12"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":re:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":re:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c17"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-14-label"
+          class="c18"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-14-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, hidden label, hint, message, and custom placement 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c11 + .c7.c7,
+.c13 + .c7.c7,
+.c7.c7 + .c11,
+.c7.c7 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c11 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c11,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-16-input"
+          hidden=""
+          id="downshift-16-label"
+        >
+          Vegetables
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-16-label"
+          class="c6 c7 c8"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rg:--hint :rg:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-16-label"
+            autocomplete="off"
+            class="c6 c9 c10"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-16-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c11 c12"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rg:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rg:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-16-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-16-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, hidden label, hint, message, compact menu, and custom placement 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 11px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 32px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c11 + .c7.c7,
+.c13 + .c7.c7,
+.c7.c7 + .c11,
+.c7.c7 ~ .c13 {
+  margin-top: 4px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c11 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c11,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-18-input"
+          hidden=""
+          id="downshift-18-label"
+        >
+          Vegetables
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-18-label"
+          class="c6 c7 c8"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":ri:--hint :ri:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-18-label"
+            autocomplete="off"
+            class="c6 c9 c10"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-18-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c11 c12"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":ri:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":ri:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-18-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-18-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, hint, and message 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-11-input"
+          id="downshift-11-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rb:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-11-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rb:--hint :rb:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-11-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-11-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rb:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-11-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-11-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, regular label, hint, and message 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-13-input"
+          id="downshift-13-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rd:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-13-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rd:--hint :rd:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-13-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-13-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rd:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-13-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-13-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, regular label, hint, message, and compact menu 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 11px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 32px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 4px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-15-input"
+          id="downshift-15-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rf:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-15-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rf:--hint :rf:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-15-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-15-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rf:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-15-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-15-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, regular label, hint, message, start icon, and end icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c17 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c16 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c16 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c16 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c16 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c16 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c16 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c15 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c11 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c14 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c19 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c18 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c18 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c18 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-17-input"
+          id="downshift-17-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rh:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-17-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <svg
+            class="c11  c12"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rh:--hint :rh:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-17-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-17-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            class="c11  c15"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+        </div>
+        <div
+          class="c16 c17"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rh:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+      <div
+        class="c18"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-17-label"
+          class="c19"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-17-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-5-input"
+          id="downshift-5-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r5:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-5-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r5:--hint :r5:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-5-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-5-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r5:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-5-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-5-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a regular label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-2-input"
+          id="downshift-2-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r2:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-2-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r2:--hint :r2:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-2-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-2-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r2:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-2-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-2-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a start icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c15 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c15 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c11 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c14 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c18 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c17 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c17 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c17 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-6-input"
+          id="downshift-6-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r6:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-6-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <svg
+            class="c11  c12"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r6:--hint :r6:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-6-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-6-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r6:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c17"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-6-label"
+          class="c18"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-6-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with an end icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c15 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c15 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c14 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c18 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c17 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c17 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c17 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-7-input"
+          id="downshift-7-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r7:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-7-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r7:--hint :r7:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-7-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-7-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            class="c13  c14"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r7:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c17"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-7-label"
+          class="c18"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-7-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with both start and end icons 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c17 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c16 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c16 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c16 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c16 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c16 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c16 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c15 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c11 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c14 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c19 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c18 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c18 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c18 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-8-input"
+          id="downshift-8-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r8:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-8-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <svg
+            class="c11  c12"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r8:--hint :r8:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-8-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-8-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            class="c11  c15"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+        </div>
+        <div
+          class="c16 c17"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r8:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c18"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-8-label"
+          class="c19"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-8-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-0-input"
+          id="downshift-0-label"
+        >
+          Label
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r0:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-0-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r0:--hint :r0:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-0-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-0-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r0:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-0-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-0-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/dropdowns.legacy/demo/stories/__snapshots__/MenuStory.spec.tsx.snap
+++ b/packages/dropdowns.legacy/demo/stories/__snapshots__/MenuStory.spec.tsx.snap
@@ -44,14 +44,14 @@ exports[`MenuStory Component renders MenuStory with a custom itemProps (disabled
 <div
   class="c0"
   data-garden-id="dropdowns.menu_wrapper"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
 >
   <ul
     aria-labelledby="downshift-12-label"
     class="c1"
     data-garden-id="dropdowns.menu"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id="downshift-12-menu"
     role="listbox"
   />
@@ -102,14 +102,14 @@ exports[`MenuStory Component renders MenuStory with a custom itemProps (disabled
 <div
   class="c0"
   data-garden-id="dropdowns.menu_wrapper"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
 >
   <ul
     aria-labelledby="downshift-6-label"
     class="c1"
     data-garden-id="dropdowns.menu"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id="downshift-6-menu"
     role="listbox"
   />
@@ -160,14 +160,14 @@ exports[`MenuStory Component renders MenuStory with a custom itemProps (isActive
 <div
   class="c0"
   data-garden-id="dropdowns.menu_wrapper"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
 >
   <ul
     aria-labelledby="downshift-9-label"
     class="c1"
     data-garden-id="dropdowns.menu"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id="downshift-9-menu"
     role="listbox"
   />
@@ -218,14 +218,14 @@ exports[`MenuStory Component renders MenuStory with a custom itemProps (isCompac
 <div
   class="c0"
   data-garden-id="dropdowns.menu_wrapper"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
 >
   <ul
     aria-labelledby="downshift-11-label"
     class="c1"
     data-garden-id="dropdowns.menu"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id="downshift-11-menu"
     role="listbox"
   />
@@ -276,14 +276,14 @@ exports[`MenuStory Component renders MenuStory with a custom itemProps (isCompac
 <div
   class="c0"
   data-garden-id="dropdowns.menu_wrapper"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
 >
   <ul
     aria-labelledby="downshift-10-label"
     class="c1"
     data-garden-id="dropdowns.menu"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id="downshift-10-menu"
     role="listbox"
   />
@@ -334,14 +334,14 @@ exports[`MenuStory Component renders MenuStory with a custom itemProps (isFocuse
 <div
   class="c0"
   data-garden-id="dropdowns.menu_wrapper"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
 >
   <ul
     aria-labelledby="downshift-7-label"
     class="c1"
     data-garden-id="dropdowns.menu"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id="downshift-7-menu"
     role="listbox"
   />
@@ -392,14 +392,14 @@ exports[`MenuStory Component renders MenuStory with a custom itemProps (isHovere
 <div
   class="c0"
   data-garden-id="dropdowns.menu_wrapper"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
 >
   <ul
     aria-labelledby="downshift-8-label"
     class="c1"
     data-garden-id="dropdowns.menu"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id="downshift-8-menu"
     role="listbox"
   />
@@ -450,14 +450,14 @@ exports[`MenuStory Component renders MenuStory with a custom maxHeight 1`] = `
 <div
   class="c0"
   data-garden-id="dropdowns.menu_wrapper"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
 >
   <ul
     aria-labelledby="downshift-3-label"
     class="c1"
     data-garden-id="dropdowns.menu"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id="downshift-3-menu"
     role="listbox"
   />
@@ -508,14 +508,14 @@ exports[`MenuStory Component renders MenuStory with a custom maxHeight and compa
 <div
   class="c0"
   data-garden-id="dropdowns.menu_wrapper"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
 >
   <ul
     aria-labelledby="downshift-4-label"
     class="c1"
     data-garden-id="dropdowns.menu"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id="downshift-4-menu"
     role="listbox"
   />
@@ -566,14 +566,14 @@ exports[`MenuStory Component renders MenuStory with a custom maxHeight, compact 
 <div
   class="c0"
   data-garden-id="dropdowns.menu_wrapper"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
 >
   <ul
     aria-labelledby="downshift-5-label"
     class="c1"
     data-garden-id="dropdowns.menu"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id="downshift-5-menu"
     role="listbox"
   />
@@ -624,14 +624,14 @@ exports[`MenuStory Component renders MenuStory with a custom placement 1`] = `
 <div
   class="c0"
   data-garden-id="dropdowns.menu_wrapper"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
 >
   <ul
     aria-labelledby="downshift-2-label"
     class="c1"
     data-garden-id="dropdowns.menu"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id="downshift-2-menu"
     role="listbox"
   />
@@ -682,14 +682,14 @@ exports[`MenuStory Component renders MenuStory with compact styling 1`] = `
 <div
   class="c0"
   data-garden-id="dropdowns.menu_wrapper"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
 >
   <ul
     aria-labelledby="downshift-1-label"
     class="c1"
     data-garden-id="dropdowns.menu"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id="downshift-1-menu"
     role="listbox"
   />
@@ -740,14 +740,14 @@ exports[`MenuStory Component renders default MenuStory 1`] = `
 <div
   class="c0"
   data-garden-id="dropdowns.menu_wrapper"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
 >
   <ul
     aria-labelledby="downshift-0-label"
     class="c1"
     data-garden-id="dropdowns.menu"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id="downshift-0-menu"
     role="listbox"
   />

--- a/packages/dropdowns.legacy/demo/stories/__snapshots__/MenuStory.spec.tsx.snap
+++ b/packages/dropdowns.legacy/demo/stories/__snapshots__/MenuStory.spec.tsx.snap
@@ -1,0 +1,755 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MenuStory Component renders MenuStory with a custom itemProps (disabled and isCompact) 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-12-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-12-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom itemProps (disabled) 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-6-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-6-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom itemProps (isActive) 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-9-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-9-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom itemProps (isCompact and isActive) 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-11-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-11-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom itemProps (isCompact) 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-10-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-10-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom itemProps (isFocused) 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-7-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-7-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom itemProps (isHovered) 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-8-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-8-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom maxHeight 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-3-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-3-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom maxHeight and compact styling 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-4-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-4-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom maxHeight, compact styling, and animated transitions 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-5-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-5-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom placement 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-2-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-2-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with compact styling 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-1-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-1-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders default MenuStory 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-0-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-0-menu"
+    role="listbox"
+  />
+</div>
+`;

--- a/packages/dropdowns.legacy/demo/stories/__snapshots__/MultiSelectStory.spec.tsx.snap
+++ b/packages/dropdowns.legacy/demo/stories/__snapshots__/MultiSelectStory.spec.tsx.snap
@@ -797,30 +797,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom "show
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-15-input"
           id="downshift-15-label"
         >
@@ -831,7 +831,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom "show
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rf:--hint"
         >
           Hint
@@ -845,25 +845,25 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom "show
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <div
               class="c13"
               data-garden-id="dropdowns.multiselect_item_wrapper"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 aria-selected="false"
                 class="c14"
                 data-garden-id="tags.tag_view"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 role="option"
                 tabindex="-1"
               >
@@ -874,7 +874,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom "show
                   aria-label="Remove"
                   class="c15 c16"
                   data-garden-id="tags.close"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   tabindex="-1"
                   type="button"
                 >
@@ -898,13 +898,13 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom "show
             <div
               class="c13"
               data-garden-id="dropdowns.multiselect_item_wrapper"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 aria-selected="false"
                 class="c14"
                 data-garden-id="tags.tag_view"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 role="option"
                 tabindex="-1"
               >
@@ -915,7 +915,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom "show
                   aria-label="Remove"
                   class="c15 c16"
                   data-garden-id="tags.close"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   tabindex="-1"
                   type="button"
                 >
@@ -939,13 +939,13 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom "show
             <div
               class="c13"
               data-garden-id="dropdowns.multiselect_item_wrapper"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 aria-selected="false"
                 class="c14"
                 data-garden-id="tags.tag_view"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 role="option"
                 tabindex="-1"
               >
@@ -956,7 +956,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom "show
                   aria-label="Remove"
                   class="c15 c16"
                   data-garden-id="tags.close"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   tabindex="-1"
                   type="button"
                 >
@@ -987,7 +987,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom "show
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-15-input"
               role="combobox"
               value=""
@@ -997,7 +997,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom "show
             aria-hidden="true"
             class="c19  c20"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -1015,7 +1015,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom "show
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rf:--message"
           role="alert"
         >
@@ -1025,14 +1025,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom "show
       <div
         class="c23"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-15-label"
           class="c24"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-15-menu"
           role="listbox"
         />
@@ -1691,30 +1691,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom input
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-14-input"
           id="downshift-14-label"
         >
@@ -1725,7 +1725,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom input
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":re:--hint"
         >
           Hint
@@ -1739,14 +1739,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom input
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -1758,7 +1758,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom input
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-14-input"
               role="combobox"
               value="Aster"
@@ -1768,7 +1768,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom input
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -1786,7 +1786,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom input
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":re:--message"
           role="alert"
         >
@@ -1796,14 +1796,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom input
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-14-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-14-menu"
           role="listbox"
         />
@@ -2462,30 +2462,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom place
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-17-input"
           id="downshift-17-label"
         >
@@ -2496,7 +2496,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom place
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rh:--hint"
         >
           Hint
@@ -2510,14 +2510,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom place
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -2529,7 +2529,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom place
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-17-input"
               role="combobox"
               value=""
@@ -2539,7 +2539,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom place
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -2557,7 +2557,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom place
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rh:--message"
           role="alert"
         >
@@ -2567,14 +2567,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a custom place
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-17-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-17-menu"
           role="listbox"
         />
@@ -3233,30 +3233,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a hidden label
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-3-input"
           hidden=""
           id="downshift-3-label"
@@ -3272,14 +3272,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a hidden label
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c10"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -3291,7 +3291,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a hidden label
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-3-input"
               role="combobox"
               value=""
@@ -3301,7 +3301,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a hidden label
             aria-hidden="true"
             class="c13  c14"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -3319,7 +3319,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a hidden label
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r3:--hint"
         >
           Hint
@@ -3329,7 +3329,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a hidden label
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r3:--message"
           role="alert"
         >
@@ -3339,14 +3339,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a hidden label
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-3-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-3-menu"
           role="listbox"
         />
@@ -4005,30 +4005,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a hint 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-4-input"
           id="downshift-4-label"
         >
@@ -4039,7 +4039,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a hint 1`] = `
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r4:--hint"
         >
           Select your favorite flowers
@@ -4053,14 +4053,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a hint 1`] = `
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -4072,7 +4072,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a hint 1`] = `
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-4-input"
               role="combobox"
               value=""
@@ -4082,7 +4082,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a hint 1`] = `
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -4100,7 +4100,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a hint 1`] = `
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r4:--message"
           role="alert"
         >
@@ -4110,14 +4110,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a hint 1`] = `
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-4-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-4-menu"
           role="listbox"
         />
@@ -4776,30 +4776,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a label 1`] = 
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-1-input"
           id="downshift-1-label"
         >
@@ -4810,7 +4810,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label 1`] = 
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r1:--hint"
         >
           Hint
@@ -4824,14 +4824,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label 1`] = 
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -4843,7 +4843,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label 1`] = 
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-1-input"
               role="combobox"
               value=""
@@ -4853,7 +4853,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label 1`] = 
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -4871,7 +4871,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label 1`] = 
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r1:--message"
           role="alert"
         >
@@ -4881,14 +4881,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label 1`] = 
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-1-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-1-menu"
           role="listbox"
         />
@@ -5547,30 +5547,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-8-input"
           hidden=""
           id="downshift-8-label"
@@ -5586,14 +5586,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c10"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -5605,7 +5605,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-8-input"
               role="combobox"
               value=""
@@ -5615,7 +5615,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
             aria-hidden="true"
             class="c13  c14"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -5633,7 +5633,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r8:--hint"
         >
           Hint
@@ -5643,7 +5643,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r8:--message"
           role="alert"
         >
@@ -5653,14 +5653,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-8-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-8-menu"
           role="listbox"
         />
@@ -6319,30 +6319,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-10-input"
           hidden=""
           id="downshift-10-label"
@@ -6358,14 +6358,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c10"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -6377,7 +6377,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-10-input"
               role="combobox"
               value=""
@@ -6387,7 +6387,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
             aria-hidden="true"
             class="c13  c14"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -6405,7 +6405,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":ra:--hint"
         >
           Select your favorite flowers
@@ -6415,7 +6415,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":ra:--message"
           role="alert"
         >
@@ -6425,14 +6425,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-10-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-10-menu"
           role="listbox"
         />
@@ -7091,30 +7091,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-20-input"
           hidden=""
           id="downshift-20-label"
@@ -7130,14 +7130,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c10"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -7149,7 +7149,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-20-input"
               role="combobox"
               value=""
@@ -7159,7 +7159,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
             aria-hidden="true"
             class="c13  c14"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -7177,7 +7177,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rk:--hint"
         >
           Hint
@@ -7187,7 +7187,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rk:--message"
           role="alert"
         >
@@ -7197,14 +7197,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hidde
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-20-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-20-menu"
           role="listbox"
         />
@@ -7863,30 +7863,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hint,
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-7-input"
           id="downshift-7-label"
         >
@@ -7897,7 +7897,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hint,
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r7:--hint"
         >
           Select your favorite flowers
@@ -7911,14 +7911,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hint,
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -7930,7 +7930,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hint,
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-7-input"
               role="combobox"
               value=""
@@ -7940,7 +7940,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hint,
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -7958,7 +7958,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hint,
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r7:--message"
           role="alert"
         >
@@ -7968,14 +7968,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hint,
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-7-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-7-menu"
           role="listbox"
         />
@@ -8634,30 +8634,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hint,
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-19-input"
           id="downshift-19-label"
         >
@@ -8668,7 +8668,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hint,
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rj:--hint"
         >
           Select your favorite flowers
@@ -8682,14 +8682,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hint,
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -8701,7 +8701,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hint,
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-19-input"
               role="combobox"
               value=""
@@ -8711,7 +8711,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hint,
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -8729,7 +8729,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hint,
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rj:--message"
           role="alert"
         >
@@ -8739,14 +8739,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, hint,
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-19-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-19-menu"
           role="listbox"
         />
@@ -9405,30 +9405,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-9-input"
           id="downshift-9-label"
         >
@@ -9439,7 +9439,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r9:--hint"
         >
           Select your favorite flowers
@@ -9453,14 +9453,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -9472,7 +9472,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-9-input"
               role="combobox"
               value=""
@@ -9482,7 +9482,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -9500,7 +9500,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r9:--message"
           role="alert"
         >
@@ -9510,14 +9510,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-9-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-9-menu"
           role="listbox"
         />
@@ -10176,30 +10176,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-11-input"
           id="downshift-11-label"
         >
@@ -10210,7 +10210,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rb:--hint"
         >
           Select your favorite flowers
@@ -10224,14 +10224,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -10243,7 +10243,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-11-input"
               role="combobox"
               value=""
@@ -10253,7 +10253,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -10271,7 +10271,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rb:--message"
           role="alert"
         >
@@ -10281,14 +10281,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-11-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-11-menu"
           role="listbox"
         />
@@ -10957,30 +10957,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-21-input"
           id="downshift-21-label"
         >
@@ -10991,7 +10991,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rl:--hint"
         >
           Select your favorite flowers
@@ -11005,20 +11005,20 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <svg
             class="c12  c13"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             xmlns="http://www.w3.org/2000/svg"
           />
           <div
             class="c14"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -11030,7 +11030,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-21-input"
               role="combobox"
               value=""
@@ -11040,7 +11040,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
             aria-hidden="true"
             class="c12  c17"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -11058,7 +11058,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rl:--message"
           role="alert"
         >
@@ -11068,14 +11068,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a label, regul
       <div
         class="c20"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-21-label"
           class="c21"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-21-menu"
           role="listbox"
         />
@@ -11734,30 +11734,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a message 1`] 
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-5-input"
           id="downshift-5-label"
         >
@@ -11768,7 +11768,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a message 1`] 
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r5:--hint"
         >
           Hint
@@ -11782,14 +11782,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a message 1`] 
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -11801,7 +11801,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a message 1`] 
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-5-input"
               role="combobox"
               value=""
@@ -11811,7 +11811,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a message 1`] 
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -11829,7 +11829,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a message 1`] 
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r5:--message"
           role="alert"
         >
@@ -11839,14 +11839,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a message 1`] 
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-5-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-5-menu"
           role="listbox"
         />
@@ -12505,30 +12505,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a placeholder 
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-13-input"
           id="downshift-13-label"
         >
@@ -12539,7 +12539,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a placeholder 
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rd:--hint"
         >
           Hint
@@ -12553,14 +12553,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a placeholder 
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -12572,7 +12572,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a placeholder 
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-13-input"
               placeholder="Select flowers"
               role="combobox"
@@ -12583,7 +12583,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a placeholder 
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -12601,7 +12601,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a placeholder 
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rd:--message"
           role="alert"
         >
@@ -12611,14 +12611,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a placeholder 
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-13-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-13-menu"
           role="listbox"
         />
@@ -13277,30 +13277,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a regular labe
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-2-input"
           id="downshift-2-label"
         >
@@ -13311,7 +13311,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a regular labe
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r2:--hint"
         >
           Hint
@@ -13325,14 +13325,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a regular labe
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -13344,7 +13344,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a regular labe
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-2-input"
               role="combobox"
               value=""
@@ -13354,7 +13354,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a regular labe
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -13372,7 +13372,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a regular labe
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r2:--message"
           role="alert"
         >
@@ -13382,14 +13382,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a regular labe
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-2-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-2-menu"
           role="listbox"
         />
@@ -14048,30 +14048,30 @@ exports[`MultiselectStory Component renders MultiselectStory with a validation l
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-6-input"
           id="downshift-6-label"
         >
@@ -14082,7 +14082,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a validation l
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r6:--hint"
         >
           Hint
@@ -14096,14 +14096,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a validation l
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -14115,7 +14115,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a validation l
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-6-input"
               role="combobox"
               value=""
@@ -14125,7 +14125,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a validation l
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -14143,7 +14143,7 @@ exports[`MultiselectStory Component renders MultiselectStory with a validation l
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r6:--message"
           role="alert"
         >
@@ -14153,14 +14153,14 @@ exports[`MultiselectStory Component renders MultiselectStory with a validation l
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-6-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-6-menu"
           role="listbox"
         />
@@ -14829,30 +14829,30 @@ exports[`MultiselectStory Component renders MultiselectStory with an icon 1`] = 
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-18-input"
           id="downshift-18-label"
         >
@@ -14863,7 +14863,7 @@ exports[`MultiselectStory Component renders MultiselectStory with an icon 1`] = 
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":ri:--hint"
         >
           Hint
@@ -14877,20 +14877,20 @@ exports[`MultiselectStory Component renders MultiselectStory with an icon 1`] = 
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <svg
             class="c12  c13"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             xmlns="http://www.w3.org/2000/svg"
           />
           <div
             class="c14"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -14902,7 +14902,7 @@ exports[`MultiselectStory Component renders MultiselectStory with an icon 1`] = 
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-18-input"
               role="combobox"
               value=""
@@ -14912,7 +14912,7 @@ exports[`MultiselectStory Component renders MultiselectStory with an icon 1`] = 
             aria-hidden="true"
             class="c12  c17"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -14930,7 +14930,7 @@ exports[`MultiselectStory Component renders MultiselectStory with an icon 1`] = 
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":ri:--message"
           role="alert"
         >
@@ -14940,14 +14940,14 @@ exports[`MultiselectStory Component renders MultiselectStory with an icon 1`] = 
       <div
         class="c20"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-18-label"
           class="c21"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-18-menu"
           role="listbox"
         />
@@ -15606,30 +15606,30 @@ exports[`MultiselectStory Component renders MultiselectStory with compact stylin
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-16-input"
           id="downshift-16-label"
         >
@@ -15640,7 +15640,7 @@ exports[`MultiselectStory Component renders MultiselectStory with compact stylin
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rg:--hint"
         >
           Hint
@@ -15654,14 +15654,14 @@ exports[`MultiselectStory Component renders MultiselectStory with compact stylin
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -15673,7 +15673,7 @@ exports[`MultiselectStory Component renders MultiselectStory with compact stylin
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-16-input"
               role="combobox"
               value=""
@@ -15683,7 +15683,7 @@ exports[`MultiselectStory Component renders MultiselectStory with compact stylin
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -15701,7 +15701,7 @@ exports[`MultiselectStory Component renders MultiselectStory with compact stylin
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rg:--message"
           role="alert"
         >
@@ -15711,14 +15711,14 @@ exports[`MultiselectStory Component renders MultiselectStory with compact stylin
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-16-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-16-menu"
           role="listbox"
         />
@@ -16525,30 +16525,30 @@ exports[`MultiselectStory Component renders MultiselectStory with selected items
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-12-input"
           id="downshift-12-label"
         >
@@ -16559,7 +16559,7 @@ exports[`MultiselectStory Component renders MultiselectStory with selected items
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rc:--hint"
         >
           Hint
@@ -16573,25 +16573,25 @@ exports[`MultiselectStory Component renders MultiselectStory with selected items
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <div
               class="c13"
               data-garden-id="dropdowns.multiselect_item_wrapper"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 aria-selected="false"
                 class="c14"
                 data-garden-id="tags.tag_view"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 role="option"
                 tabindex="-1"
               >
@@ -16602,7 +16602,7 @@ exports[`MultiselectStory Component renders MultiselectStory with selected items
                   aria-label="Remove"
                   class="c15 c16"
                   data-garden-id="tags.close"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   tabindex="-1"
                   type="button"
                 >
@@ -16626,13 +16626,13 @@ exports[`MultiselectStory Component renders MultiselectStory with selected items
             <div
               class="c13"
               data-garden-id="dropdowns.multiselect_item_wrapper"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 aria-selected="false"
                 class="c14"
                 data-garden-id="tags.tag_view"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 role="option"
                 tabindex="-1"
               >
@@ -16643,7 +16643,7 @@ exports[`MultiselectStory Component renders MultiselectStory with selected items
                   aria-label="Remove"
                   class="c15 c16"
                   data-garden-id="tags.close"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   tabindex="-1"
                   type="button"
                 >
@@ -16674,7 +16674,7 @@ exports[`MultiselectStory Component renders MultiselectStory with selected items
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-12-input"
               role="combobox"
               value=""
@@ -16684,7 +16684,7 @@ exports[`MultiselectStory Component renders MultiselectStory with selected items
             aria-hidden="true"
             class="c19  c20"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -16702,7 +16702,7 @@ exports[`MultiselectStory Component renders MultiselectStory with selected items
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rc:--message"
           role="alert"
         >
@@ -16712,14 +16712,14 @@ exports[`MultiselectStory Component renders MultiselectStory with selected items
       <div
         class="c23"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-12-label"
           class="c24"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-12-menu"
           role="listbox"
         />
@@ -17378,30 +17378,30 @@ exports[`MultiselectStory Component renders default MultiselectStory 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="forms.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="downshift-0-input"
           id="downshift-0-label"
         >
@@ -17412,7 +17412,7 @@ exports[`MultiselectStory Component renders default MultiselectStory 1`] = `
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r0:--hint"
         >
           Hint
@@ -17426,14 +17426,14 @@ exports[`MultiselectStory Component renders default MultiselectStory 1`] = `
           data-garden-container-id="containers.selection"
           data-garden-container-version="2.0.6"
           data-garden-id="forms.faux_input"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           data-toggle="true"
           tabindex="-1"
         >
           <div
             class="c12"
             data-garden-id="dropdowns.multiselect_items_container"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <input
               aria-autocomplete="list"
@@ -17445,7 +17445,7 @@ exports[`MultiselectStory Component renders default MultiselectStory 1`] = `
               data-garden-container-id="containers.field.input"
               data-garden-container-version="3.0.19"
               data-garden-id="forms.input"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="downshift-0-input"
               role="combobox"
               value=""
@@ -17455,7 +17455,7 @@ exports[`MultiselectStory Component renders default MultiselectStory 1`] = `
             aria-hidden="true"
             class="c15  c16"
             data-garden-id="forms.media_figure"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -17473,7 +17473,7 @@ exports[`MultiselectStory Component renders default MultiselectStory 1`] = `
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="forms.input_message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r0:--message"
           role="alert"
         >
@@ -17483,14 +17483,14 @@ exports[`MultiselectStory Component renders default MultiselectStory 1`] = `
       <div
         class="c19"
         data-garden-id="dropdowns.menu_wrapper"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <ul
           aria-labelledby="downshift-0-label"
           class="c20"
           data-garden-id="dropdowns.menu"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="downshift-0-menu"
           role="listbox"
         />

--- a/packages/dropdowns.legacy/demo/stories/__snapshots__/MultiSelectStory.spec.tsx.snap
+++ b/packages/dropdowns.legacy/demo/stories/__snapshots__/MultiSelectStory.spec.tsx.snap
@@ -1,0 +1,17501 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MultiselectStory Component renders MultiselectStory with a custom "show more" text 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c22 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c21 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c21 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c21 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c21 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c17 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c17::-ms-browse {
+  border-radius: 2px;
+}
+
+.c17::-ms-clear,
+.c17::-ms-reveal {
+  display: none;
+}
+
+.c17::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c17::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c17::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c17::-webkit-clear-button,
+.c17::-webkit-inner-spin-button,
+.c17::-webkit-search-cancel-button,
+.c17::-webkit-search-results-button {
+  display: none;
+}
+
+.c17::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c17::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c17:invalid {
+  box-shadow: none;
+}
+
+.c17[type='file']::-ms-value {
+  display: none;
+}
+
+.c17::-ms-browse {
+  font-size: 12px;
+}
+
+.c17[type='date'],
+.c17[type='datetime-local'],
+.c17[type='file'],
+.c17[type='month'],
+.c17[type='time'],
+.c17[type='week'] {
+  max-height: 40px;
+}
+
+.c17[type='file'] {
+  line-height: 1;
+}
+
+.c17::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c17::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c17::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c17.c17,
+.c6 + .c17.c17,
+.c21 + .c17.c17,
+.c17.c17 + .c6,
+.c17.c17 ~ .c21 {
+  margin-top: 8px;
+}
+
+.c17::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c17::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c17:hover {
+  border-color: #1f73b7;
+}
+
+.c17:focus {
+  outline: none;
+}
+
+.c17:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c17::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c17::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c17:disabled,
+.c17[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c17:disabled {
+  cursor: default;
+}
+
+.c20 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c19 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c24 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c23 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c23 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c23 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c18 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  opacity: 0;
+  margin: 0;
+  width: 0;
+  min-width: 0;
+  height: 0;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c13 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin: 2px;
+  max-width: 100%;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  color: inherit;
+  font-size: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c16:hover {
+  opacity: 0.88;
+}
+
+.c16:focus {
+  outline: none;
+}
+
+.c16:active {
+  opacity: 0.96;
+}
+
+.c14 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 0;
+  max-width: 100%;
+  overflow: hidden;
+  vertical-align: middle;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  font-weight: 600;
+  direction: ltr;
+  border-radius: 4px;
+  padding: 0 12px;
+  min-width: calc(24px + 1ch);
+  height: 32px;
+  line-height: 2.6666666666666665;
+  font-size: 12px;
+  background-color: #e8eaec;
+  color: #293239;
+}
+
+.c14 > * {
+  width: 100%;
+  min-width: 1ch;
+}
+
+.c14 .c15 {
+  margin-right: -12px;
+  border-radius: 4px;
+  width: 32px;
+  height: 32px;
+}
+
+.c14:hover {
+  cursor: default;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c14:link:hover,
+.c14:visited:hover {
+  cursor: pointer;
+}
+
+.c14:any-link:hover {
+  cursor: pointer;
+}
+
+.c14:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c14:hover {
+  color: #293239;
+}
+
+.c14:focus {
+  outline: none;
+}
+
+.c14:focus {
+  outline: 1px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px #1f73b7;
+}
+
+.c14 > * {
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c14 b {
+  font-weight: 600;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c17[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c17[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-15-input"
+          id="downshift-15-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rf:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-15-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <div
+              class="c13"
+              data-garden-id="dropdowns.multiselect_item_wrapper"
+              data-garden-version="9.0.0"
+            >
+              <div
+                aria-selected="false"
+                class="c14"
+                data-garden-id="tags.tag_view"
+                data-garden-version="9.0.0"
+                role="option"
+                tabindex="-1"
+              >
+                <span>
+                  Aster
+                </span>
+                <button
+                  aria-label="Remove"
+                  class="c15 c16"
+                  data-garden-id="tags.close"
+                  data-garden-version="9.0.0"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3 9l6-6m0 6L3 3"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              class="c13"
+              data-garden-id="dropdowns.multiselect_item_wrapper"
+              data-garden-version="9.0.0"
+            >
+              <div
+                aria-selected="false"
+                class="c14"
+                data-garden-id="tags.tag_view"
+                data-garden-version="9.0.0"
+                role="option"
+                tabindex="-1"
+              >
+                <span>
+                  Bachelor's button
+                </span>
+                <button
+                  aria-label="Remove"
+                  class="c15 c16"
+                  data-garden-id="tags.close"
+                  data-garden-version="9.0.0"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3 9l6-6m0 6L3 3"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              class="c13"
+              data-garden-id="dropdowns.multiselect_item_wrapper"
+              data-garden-version="9.0.0"
+            >
+              <div
+                aria-selected="false"
+                class="c14"
+                data-garden-id="tags.tag_view"
+                data-garden-version="9.0.0"
+                role="option"
+                tabindex="-1"
+              >
+                <span>
+                  Celosia
+                </span>
+                <button
+                  aria-label="Remove"
+                  class="c15 c16"
+                  data-garden-id="tags.close"
+                  data-garden-version="9.0.0"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3 9l6-6m0 6L3 3"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rf:--hint :rf:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-15-label"
+              autocomplete="off"
+              class="c8 c17 c18"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-15-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c19  c20"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c21 c22"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rf:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c23"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-15-label"
+          class="c24"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-15-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a custom input value 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-14-input"
+          id="downshift-14-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":re:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-14-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":re:--hint :re:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-14-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-14-input"
+              role="combobox"
+              value="Aster"
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":re:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-14-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-14-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a custom placement 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-17-input"
+          id="downshift-17-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rh:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-17-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rh:--hint :rh:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-17-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-17-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rh:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-17-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-17-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a hidden label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c15 + .c7.c7,
+.c17 + .c7.c7,
+.c7.c7 + .c15,
+.c7.c7 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c15 + .c11.c11,
+.c17 + .c11.c11,
+.c11.c11 + .c15,
+.c11.c11 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c14 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 > .c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c9 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c12 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-3-input"
+          hidden=""
+          id="downshift-3-label"
+        >
+          Flowers
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-3-label"
+          class="c6 c7 c8 c9"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c10"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r3:--hint :r3:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-3-label"
+              autocomplete="off"
+              class="c6 c11 c12"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-3-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c13  c14"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r3:--hint"
+        >
+          Hint
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r3:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-3-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-3-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a hint 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-4-input"
+          id="downshift-4-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r4:--hint"
+        >
+          Select your favorite flowers
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-4-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r4:--hint :r4:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-4-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-4-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r4:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-4-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-4-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-1-input"
+          id="downshift-1-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r1:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-1-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r1:--hint :r1:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-1-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-1-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r1:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-1-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-1-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, hidden label, and validation label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c15 + .c7.c7,
+.c17 + .c7.c7,
+.c7.c7 + .c15,
+.c7.c7 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c15 + .c11.c11,
+.c17 + .c11.c11,
+.c11.c11 + .c15,
+.c11.c11 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c14 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 > .c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c9 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c12 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-8-input"
+          hidden=""
+          id="downshift-8-label"
+        >
+          Flowers
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-8-label"
+          class="c6 c7 c8 c9"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c10"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r8:--hint :r8:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-8-label"
+              autocomplete="off"
+              class="c6 c11 c12"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-8-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c13  c14"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r8:--hint"
+        >
+          Hint
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r8:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-8-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-8-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, hidden label, hint, and validation label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c15 + .c7.c7,
+.c17 + .c7.c7,
+.c7.c7 + .c15,
+.c7.c7 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c15 + .c11.c11,
+.c17 + .c11.c11,
+.c11.c11 + .c15,
+.c11.c11 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c14 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 > .c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c9 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c12 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-10-input"
+          hidden=""
+          id="downshift-10-label"
+        >
+          Flowers
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-10-label"
+          class="c6 c7 c8 c9"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c10"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":ra:--hint :ra:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-10-label"
+              autocomplete="off"
+              class="c6 c11 c12"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-10-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c13  c14"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":ra:--hint"
+        >
+          Select your favorite flowers
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":ra:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-10-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-10-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, hidden label, validation label, and custom placement 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c15 + .c7.c7,
+.c17 + .c7.c7,
+.c7.c7 + .c15,
+.c7.c7 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c15 + .c11.c11,
+.c17 + .c11.c11,
+.c11.c11 + .c15,
+.c11.c11 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c14 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 > .c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c9 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c12 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-20-input"
+          hidden=""
+          id="downshift-20-label"
+        >
+          Flowers
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-20-label"
+          class="c6 c7 c8 c9"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c10"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rk:--hint :rk:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-20-label"
+              autocomplete="off"
+              class="c6 c11 c12"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-20-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c13  c14"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rk:--hint"
+        >
+          Hint
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rk:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-20-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-20-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, hint, and message 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-7-input"
+          id="downshift-7-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r7:--hint"
+        >
+          Select your favorite flowers
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-7-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r7:--hint :r7:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-7-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-7-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r7:--message"
+          role="alert"
+        >
+          Please select at least one flower
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-7-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-7-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, hint, message, and compact styling 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 11px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 32px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 4px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 11px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 32px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 4px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 100px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 20px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -6px 0;
+  padding: 3px 4px 3px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-19-input"
+          id="downshift-19-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rj:--hint"
+        >
+          Select your favorite flowers
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-19-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rj:--hint :rj:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-19-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-19-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rj:--message"
+          role="alert"
+        >
+          Please select at least one flower
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-19-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-19-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, regular label, hint, and message 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-9-input"
+          id="downshift-9-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r9:--hint"
+        >
+          Select your favorite flowers
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-9-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r9:--hint :r9:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-9-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-9-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r9:--message"
+          role="alert"
+        >
+          Please select at least one flower
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-9-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-9-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, regular label, hint, message, and validation label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-11-input"
+          id="downshift-11-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rb:--hint"
+        >
+          Select your favorite flowers
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-11-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rb:--hint :rb:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-11-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-11-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rb:--message"
+          role="alert"
+        >
+          Please select at least one flower
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-11-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-11-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, regular label, hint, message, validation label, and icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c19 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c18 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c18 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c18 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c18 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c15 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c15::-ms-browse {
+  border-radius: 2px;
+}
+
+.c15::-ms-clear,
+.c15::-ms-reveal {
+  display: none;
+}
+
+.c15::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c15::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c15::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c15::-webkit-clear-button,
+.c15::-webkit-inner-spin-button,
+.c15::-webkit-search-cancel-button,
+.c15::-webkit-search-results-button {
+  display: none;
+}
+
+.c15::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c15:invalid {
+  box-shadow: none;
+}
+
+.c15[type='file']::-ms-value {
+  display: none;
+}
+
+.c15::-ms-browse {
+  font-size: 12px;
+}
+
+.c15[type='date'],
+.c15[type='datetime-local'],
+.c15[type='file'],
+.c15[type='month'],
+.c15[type='time'],
+.c15[type='week'] {
+  max-height: 40px;
+}
+
+.c15[type='file'] {
+  line-height: 1;
+}
+
+.c15::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c15::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c15.c15,
+.c6 + .c15.c15,
+.c18 + .c15.c15,
+.c15.c15 + .c6,
+.c15.c15 ~ .c18 {
+  margin-top: 8px;
+}
+
+.c15::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c15:hover {
+  border-color: #1f73b7;
+}
+
+.c15:focus {
+  outline: none;
+}
+
+.c15:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c15::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c15::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c15:disabled,
+.c15[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c15:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c17 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c12 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c21 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c20 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c20 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c20 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c16 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c14 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c15[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c15[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-21-input"
+          id="downshift-21-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rl:--hint"
+        >
+          Select your favorite flowers
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-21-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <svg
+            class="c12  c13"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <div
+            class="c14"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rl:--hint :rl:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-21-label"
+              autocomplete="off"
+              class="c8 c15 c16"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-21-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c12  c17"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c18 c19"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rl:--message"
+          role="alert"
+        >
+          Please select at least one flower
+        </div>
+      </div>
+      <div
+        class="c20"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-21-label"
+          class="c21"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-21-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a message 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-5-input"
+          id="downshift-5-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r5:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-5-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r5:--hint :r5:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-5-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-5-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r5:--message"
+          role="alert"
+        >
+          Please select at least one flower
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-5-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-5-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a placeholder 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-13-input"
+          id="downshift-13-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rd:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-13-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rd:--hint :rd:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-13-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-13-input"
+              placeholder="Select flowers"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rd:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-13-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-13-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a regular label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-2-input"
+          id="downshift-2-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r2:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-2-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r2:--hint :r2:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-2-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-2-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r2:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-2-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-2-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a validation label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-6-input"
+          id="downshift-6-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r6:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-6-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r6:--hint :r6:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-6-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-6-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r6:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-6-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-6-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with an icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c19 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c18 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c18 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c18 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c18 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c15 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c15::-ms-browse {
+  border-radius: 2px;
+}
+
+.c15::-ms-clear,
+.c15::-ms-reveal {
+  display: none;
+}
+
+.c15::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c15::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c15::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c15::-webkit-clear-button,
+.c15::-webkit-inner-spin-button,
+.c15::-webkit-search-cancel-button,
+.c15::-webkit-search-results-button {
+  display: none;
+}
+
+.c15::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c15:invalid {
+  box-shadow: none;
+}
+
+.c15[type='file']::-ms-value {
+  display: none;
+}
+
+.c15::-ms-browse {
+  font-size: 12px;
+}
+
+.c15[type='date'],
+.c15[type='datetime-local'],
+.c15[type='file'],
+.c15[type='month'],
+.c15[type='time'],
+.c15[type='week'] {
+  max-height: 40px;
+}
+
+.c15[type='file'] {
+  line-height: 1;
+}
+
+.c15::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c15::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c15.c15,
+.c6 + .c15.c15,
+.c18 + .c15.c15,
+.c15.c15 + .c6,
+.c15.c15 ~ .c18 {
+  margin-top: 8px;
+}
+
+.c15::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c15:hover {
+  border-color: #1f73b7;
+}
+
+.c15:focus {
+  outline: none;
+}
+
+.c15:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c15::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c15::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c15:disabled,
+.c15[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c15:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c17 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c12 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c21 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c20 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c20 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c20 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c16 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c14 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c15[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c15[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-18-input"
+          id="downshift-18-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":ri:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-18-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <svg
+            class="c12  c13"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <div
+            class="c14"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":ri:--hint :ri:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-18-label"
+              autocomplete="off"
+              class="c8 c15 c16"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-18-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c12  c17"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c18 c19"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":ri:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c20"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-18-label"
+          class="c21"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-18-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with compact styling 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 11px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 32px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 4px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 11px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 32px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 4px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 100px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 20px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -6px 0;
+  padding: 3px 4px 3px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-16-input"
+          id="downshift-16-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rg:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-16-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rg:--hint :rg:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-16-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-16-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rg:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-16-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-16-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with selected items 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c22 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c21 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c21 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c21 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c21 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c17 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c17::-ms-browse {
+  border-radius: 2px;
+}
+
+.c17::-ms-clear,
+.c17::-ms-reveal {
+  display: none;
+}
+
+.c17::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c17::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c17::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c17::-webkit-clear-button,
+.c17::-webkit-inner-spin-button,
+.c17::-webkit-search-cancel-button,
+.c17::-webkit-search-results-button {
+  display: none;
+}
+
+.c17::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c17::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c17:invalid {
+  box-shadow: none;
+}
+
+.c17[type='file']::-ms-value {
+  display: none;
+}
+
+.c17::-ms-browse {
+  font-size: 12px;
+}
+
+.c17[type='date'],
+.c17[type='datetime-local'],
+.c17[type='file'],
+.c17[type='month'],
+.c17[type='time'],
+.c17[type='week'] {
+  max-height: 40px;
+}
+
+.c17[type='file'] {
+  line-height: 1;
+}
+
+.c17::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c17::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c17::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c17.c17,
+.c6 + .c17.c17,
+.c21 + .c17.c17,
+.c17.c17 + .c6,
+.c17.c17 ~ .c21 {
+  margin-top: 8px;
+}
+
+.c17::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c17::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c17:hover {
+  border-color: #1f73b7;
+}
+
+.c17:focus {
+  outline: none;
+}
+
+.c17:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c17::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c17::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c17:disabled,
+.c17[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c17:disabled {
+  cursor: default;
+}
+
+.c20 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c19 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c24 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c23 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c23 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c23 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c18 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  opacity: 0;
+  margin: 0;
+  width: 0;
+  min-width: 0;
+  height: 0;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c13 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin: 2px;
+  max-width: 100%;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  color: inherit;
+  font-size: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c16:hover {
+  opacity: 0.88;
+}
+
+.c16:focus {
+  outline: none;
+}
+
+.c16:active {
+  opacity: 0.96;
+}
+
+.c14 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 0;
+  max-width: 100%;
+  overflow: hidden;
+  vertical-align: middle;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  font-weight: 600;
+  direction: ltr;
+  border-radius: 4px;
+  padding: 0 12px;
+  min-width: calc(24px + 1ch);
+  height: 32px;
+  line-height: 2.6666666666666665;
+  font-size: 12px;
+  background-color: #e8eaec;
+  color: #293239;
+}
+
+.c14 > * {
+  width: 100%;
+  min-width: 1ch;
+}
+
+.c14 .c15 {
+  margin-right: -12px;
+  border-radius: 4px;
+  width: 32px;
+  height: 32px;
+}
+
+.c14:hover {
+  cursor: default;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c14:link:hover,
+.c14:visited:hover {
+  cursor: pointer;
+}
+
+.c14:any-link:hover {
+  cursor: pointer;
+}
+
+.c14:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c14:hover {
+  color: #293239;
+}
+
+.c14:focus {
+  outline: none;
+}
+
+.c14:focus {
+  outline: 1px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px #1f73b7;
+}
+
+.c14 > * {
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c14 b {
+  font-weight: 600;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c17[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c17[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-12-input"
+          id="downshift-12-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rc:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-12-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <div
+              class="c13"
+              data-garden-id="dropdowns.multiselect_item_wrapper"
+              data-garden-version="9.0.0"
+            >
+              <div
+                aria-selected="false"
+                class="c14"
+                data-garden-id="tags.tag_view"
+                data-garden-version="9.0.0"
+                role="option"
+                tabindex="-1"
+              >
+                <span>
+                  Aster
+                </span>
+                <button
+                  aria-label="Remove"
+                  class="c15 c16"
+                  data-garden-id="tags.close"
+                  data-garden-version="9.0.0"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3 9l6-6m0 6L3 3"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              class="c13"
+              data-garden-id="dropdowns.multiselect_item_wrapper"
+              data-garden-version="9.0.0"
+            >
+              <div
+                aria-selected="false"
+                class="c14"
+                data-garden-id="tags.tag_view"
+                data-garden-version="9.0.0"
+                role="option"
+                tabindex="-1"
+              >
+                <span>
+                  Bachelor's button
+                </span>
+                <button
+                  aria-label="Remove"
+                  class="c15 c16"
+                  data-garden-id="tags.close"
+                  data-garden-version="9.0.0"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3 9l6-6m0 6L3 3"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rc:--hint :rc:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-12-label"
+              autocomplete="off"
+              class="c8 c17 c18"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-12-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c19  c20"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c21 c22"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rc:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c23"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-12-label"
+          class="c24"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-12-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders default MultiselectStory 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-0-input"
+          id="downshift-0-label"
+        >
+          Label
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r0:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-0-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r0:--hint :r0:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-0-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-0-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r0:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-0-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-0-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/dropdowns/demo/stories/ComboboxStory.spec.tsx
+++ b/packages/dropdowns/demo/stories/ComboboxStory.spec.tsx
@@ -1,0 +1,320 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { ComboboxStory } from './ComboboxStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<ComboboxStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('ComboboxStory Component', () => {
+  it('renders default ComboboxStory', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: []
+    });
+  });
+
+  it('renders ComboboxStory with a label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      isLabelRegular: true
+    });
+  });
+
+  it('renders ComboboxStory with a hidden label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      isLabelHidden: true
+    });
+  });
+
+  it('renders ComboboxStory with a hint', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      hint: 'Choose wisely'
+    });
+  });
+
+  it('renders ComboboxStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      message: 'This field is required'
+    });
+  });
+
+  it('renders ComboboxStory with validation success', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      validation: 'success',
+      validationLabel: 'Looks good!'
+    });
+  });
+
+  it('renders ComboboxStory with validation error', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      validation: 'error',
+      validationLabel: 'Something went wrong'
+    });
+  });
+
+  it('renders ComboboxStory with validation warning', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      validation: 'warning',
+      validationLabel: 'Be careful'
+    });
+  });
+
+  it('renders ComboboxStory with start icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      startIcon: true
+    });
+  });
+
+  it('renders ComboboxStory with end icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      endIcon: true
+    });
+  });
+
+  it('renders ComboboxStory with renderValue enabled', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      renderValue: true
+    });
+  });
+
+  it('renders ComboboxStory with options', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ]
+    });
+  });
+
+  it('renders ComboboxStory with grouped options', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        {
+          label: 'Group 1',
+          options: [
+            { label: 'Option 1', value: '1' },
+            { label: 'Option 2', value: '2' }
+          ]
+        },
+        {
+          label: 'Group 2',
+          options: [
+            { label: 'Option 3', value: '3' },
+            { label: 'Option 4', value: '4' }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('renders ComboboxStory with a multiselectable combobox', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      isMultiselectable: true
+    });
+  });
+
+  it('renders ComboboxStory with a compact combobox', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      isCompact: true
+    });
+  });
+
+  it('renders ComboboxStory with a bare combobox', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      isBare: true
+    });
+  });
+
+  it('renders ComboboxStory with an editable combobox', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      isEditable: true
+    });
+  });
+
+  it('renders ComboboxStory with an autocomplete combobox', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      isAutocomplete: true
+    });
+  });
+
+  it('renders ComboboxStory with a disabled combobox', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      isDisabled: true
+    });
+  });
+
+  it('renders ComboboxStory with a custom placeholder', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      placeholder: 'Choose an option'
+    });
+  });
+
+  it('renders ComboboxStory with a custom maxTags value', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' },
+        { label: 'Option 3', value: '3' }
+      ],
+      isMultiselectable: true,
+      maxTags: 2
+    });
+  });
+
+  it('renders ComboboxStory with a custom listbox max height', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      listboxMaxHeight: '200px'
+    });
+  });
+
+  it('renders ComboboxStory with a custom listbox min height', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      listboxMinHeight: '100px'
+    });
+  });
+
+  it('renders ComboboxStory with a custom listbox z-index', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      listboxZIndex: 1000
+    });
+  });
+
+  it('renders ComboboxStory with a custom max height', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      maxHeight: '300px'
+    });
+  });
+
+  it('renders ComboboxStory with a custom listbox aria-label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      listboxAriaLabel: 'Custom aria label'
+    });
+  });
+
+  it('renders ComboboxStory with a custom id', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      id: 'custom-id'
+    });
+  });
+
+  it('renders ComboboxStory with a custom input value', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      inputValue: 'Custom input'
+    });
+  });
+
+  it('renders ComboboxStory with a custom active index', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      activeIndex: 1
+    });
+  });
+
+  it('renders ComboboxStory with a custom default active index', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      defaultActiveIndex: 0
+    });
+  });
+
+  it('renders ComboboxStory with a custom default expanded state', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      defaultExpanded: true
+    });
+  });
+
+  it('renders ComboboxStory with a custom focus inset', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      focusInset: true
+    });
+  });
+});

--- a/packages/dropdowns/demo/stories/MenuStory.spec.tsx
+++ b/packages/dropdowns/demo/stories/MenuStory.spec.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { MenuStory } from './MenuStory';
+import { Items } from './types';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<MenuStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+const mockItems: Items = [
+  { value: 'item-1', label: 'Item 1' },
+  { value: 'item-2', label: 'Item 2', icon: true },
+  { value: 'item-3', label: 'Item 3', meta: 'Meta' },
+  {
+    legend: 'Group 1',
+    'aria-label': 'Group 1',
+    items: [
+      { value: 'group-item-1', label: 'Group Item 1' },
+      { value: 'group-item-2', label: 'Group Item 2', icon: true }
+    ]
+  },
+  { isSeparator: true, value: 'separator' },
+  { value: 'item-4', label: 'Item 4' }
+];
+
+describe('MenuStory Component', () => {
+  it('renders default MenuStory', () => {
+    renderAndMatchSnapshot({ items: mockItems });
+  });
+
+  it('renders MenuStory with compact styling', () => {
+    renderAndMatchSnapshot({ items: mockItems, isCompact: true });
+  });
+
+  it('renders MenuStory with an arrow', () => {
+    renderAndMatchSnapshot({ items: mockItems, hasArrow: true });
+  });
+
+  it('renders MenuStory with expanded state', () => {
+    renderAndMatchSnapshot({ items: mockItems, isExpanded: true });
+  });
+
+  it('renders MenuStory with a custom maxHeight', () => {
+    renderAndMatchSnapshot({ items: mockItems, maxHeight: 300 });
+  });
+
+  it('renders MenuStory with a custom minHeight', () => {
+    renderAndMatchSnapshot({ items: mockItems, minHeight: 100 });
+  });
+
+  it('renders MenuStory with a custom zIndex', () => {
+    renderAndMatchSnapshot({ items: mockItems, zIndex: 500 });
+  });
+
+  it('renders MenuStory with a custom placement', () => {
+    renderAndMatchSnapshot({ items: mockItems, placement: 'top' });
+  });
+
+  it('renders MenuStory with fallback placements', () => {
+    renderAndMatchSnapshot({ items: mockItems, fallbackPlacements: ['top', 'bottom'] });
+  });
+
+  it('renders MenuStory with a custom triggerRef', () => {
+    const triggerRef = React.createRef<HTMLElement>();
+    renderAndMatchSnapshot({ items: mockItems, triggerRef });
+  });
+
+  it('renders MenuStory with compact styling and an arrow', () => {
+    renderAndMatchSnapshot({ items: mockItems, isCompact: true, hasArrow: true });
+  });
+
+  it('renders MenuStory with expanded state and custom placement', () => {
+    renderAndMatchSnapshot({ items: mockItems, isExpanded: true, placement: 'bottom' });
+  });
+
+  it('renders MenuStory with custom maxHeight, minHeight, and zIndex', () => {
+    renderAndMatchSnapshot({ items: mockItems, maxHeight: 400, minHeight: 200, zIndex: 1000 });
+  });
+
+  it('renders MenuStory with fallback placements and a custom triggerRef', () => {
+    const triggerRef = React.createRef<HTMLElement>();
+    renderAndMatchSnapshot({ items: mockItems, fallbackPlacements: ['left', 'right'], triggerRef });
+  });
+
+  it('renders MenuStory with compact styling, an arrow, and expanded state', () => {
+    renderAndMatchSnapshot({ items: mockItems, isCompact: true, hasArrow: true, isExpanded: true });
+  });
+
+  it('renders MenuStory with all custom props', () => {
+    const triggerRef = React.createRef<HTMLElement>();
+    renderAndMatchSnapshot({
+      items: mockItems,
+      isCompact: true,
+      hasArrow: true,
+      isExpanded: true,
+      maxHeight: 500,
+      minHeight: 150,
+      zIndex: 2000,
+      placement: 'right',
+      fallbackPlacements: ['top', 'bottom'],
+      triggerRef
+    });
+  });
+});

--- a/packages/dropdowns/demo/stories/__snapshots__/ComboboxStory.spec.tsx.snap
+++ b/packages/dropdowns/demo/stories/__snapshots__/ComboboxStory.spec.tsx.snap
@@ -1,0 +1,14973 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ComboboxStory Component renders ComboboxStory with a bare combobox 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: visible;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 0px 0;
+  min-height: 20px;
+  max-height: 20px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1d:--input"
+          id=":r1d:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1d:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r1d:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1d:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r1d:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1d:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a compact combobox 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 100px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 5px 12px;
+  min-height: 32px;
+  max-height: 32px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 36px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1a:--input"
+          id=":r1a:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1a:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r1a:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1a:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r1a:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1a:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom active index 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r2k:--input"
+          id=":r2k:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r2k:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r2k:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r2k:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r2k:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r2k:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom default active index 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r2n:--input"
+          id=":r2n:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r2n:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r2n:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r2n:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r2n:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r2n:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom default expanded state 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 8px 36px;
+  min-height: 36px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c15:focus {
+  outline: none;
+}
+
+.c15[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c15[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c15[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c17 {
+  position: absolute;
+  -webkit-transition: opacity 0.1s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
+  top: 10px;
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  opacity: 0;
+  color: #1f73b7;
+}
+
+.c14[aria-selected='true'] > .c16 {
+  opacity: 1;
+}
+
+.c14[aria-disabled='true'] > .c16 {
+  color: inherit;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r2q:--input"
+          id=":r2q:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r2q:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r2q:--listbox"
+                  aria-expanded="true"
+                  aria-invalid="false"
+                  aria-labelledby=":r2q:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  id=":r2q:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="true"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r2q:--listbox"
+              role="listbox"
+            >
+              <li
+                aria-selected="false"
+                class="c14 c15"
+                data-garden-container-id="containers.combobox.option"
+                data-garden-container-version="2.0.4"
+                data-garden-id="dropdowns.combobox.option"
+                data-garden-version="9.0.0"
+                id=":r2q:--option-0"
+                role="option"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="c16  c17"
+                  data-garden-id="dropdowns.combobox.option.type_icon"
+                  data-garden-version="9.0.0"
+                  focusable="false"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M1 9l4 4L15 3"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                <div
+                  class="c18"
+                  data-garden-id="dropdowns.combobox.option.content"
+                  data-garden-version="9.0.0"
+                >
+                  Option 1
+                </div>
+              </li>
+              <li
+                aria-selected="false"
+                class="c14 c15"
+                data-garden-container-id="containers.combobox.option"
+                data-garden-container-version="2.0.4"
+                data-garden-id="dropdowns.combobox.option"
+                data-garden-version="9.0.0"
+                id=":r2q:--option-1"
+                role="option"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="c16  c17"
+                  data-garden-id="dropdowns.combobox.option.type_icon"
+                  data-garden-version="9.0.0"
+                  focusable="false"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M1 9l4 4L15 3"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                <div
+                  class="c18"
+                  data-garden-id="dropdowns.combobox.option.content"
+                  data-garden-version="9.0.0"
+                >
+                  Option 2
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom focus inset 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r2t:--input"
+          id=":r2t:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r2t:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r2t:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r2t:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r2t:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r2t:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom id 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for="custom-id--input"
+          id="custom-id--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          id="custom-id"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id="custom-id--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls="custom-id--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby="custom-id--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id="custom-id--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id="custom-id--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom input value 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r2h:--input"
+          id=":r2h:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r2h:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                >
+                  Custom input
+                </div>
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r2h:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r2h:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r2h:--input"
+                  role="combobox"
+                  value="Custom input"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r2h:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom listbox aria-label 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r2b:--input"
+          id=":r2b:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r2b:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r2b:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r2b:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r2b:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Custom aria label"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r2b:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom listbox max height 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 200px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1v:--input"
+          id=":r1v:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1v:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r1v:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1v:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r1v:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1v:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom listbox min height 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 100px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r22:--input"
+          id=":r22:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r22:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r22:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r22:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r22:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r22:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom listbox z-index 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r25:--input"
+          id=":r25:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r25:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r25:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r25:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r25:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r25:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom max height 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 300px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r28:--input"
+          id=":r28:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r28:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r28:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r28:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r28:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r28:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom maxTags value 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1s:--input"
+          id=":r1s:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1s:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r1s:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1s:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r1s:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              aria-multiselectable="true"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1s:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom placeholder 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1p:--input"
+          id=":r1p:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1p:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                >
+                  Choose an option
+                </div>
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r1p:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1p:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r1p:--input"
+                  placeholder="Choose an option"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1p:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a disabled combobox 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: default;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1m:--input"
+          id=":r1m:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            aria-disabled="true"
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1m:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r1m:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1m:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  disabled=""
+                  hidden=""
+                  id=":r1m:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1m:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r6:--input"
+          hidden=""
+          id=":r6:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r6:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r6:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r6:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r6:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r6:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c6 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c7 {
+  min-width: 144px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c13 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c13 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c13 > *:focus {
+  outline: none;
+}
+
+.c13[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c12 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c12:focus {
+  outline: none;
+}
+
+.c12.c12 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c12::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c12[aria-hidden='true'] {
+  display: none;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c10 > * {
+  margin: 2px;
+}
+
+.c8 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within:not([aria-disabled='true']),
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c8[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c14 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c14.c14.c14 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c14.c14.c14 {
+  display: block;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r9:--input"
+          id=":r9:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6 "
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.hint"
+          data-garden-version="9.0.0"
+          id=":r9:--hint"
+        >
+          Choose wisely
+        </div>
+        <div
+          class="c7"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c8"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r9:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c9"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c10"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c11"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r9:--listbox"
+                  aria-describedby=":r9:--hint"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r9:--label"
+                  autocomplete="off"
+                  class="c12"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r9:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c13"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c14"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r9:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r3:--input"
+          id=":r3:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r3:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r3:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r3:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r3:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r3:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c6 {
+  vertical-align: revert;
+}
+
+.c7 {
+  min-width: 144px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c13 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c13 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c13 > *:focus {
+  outline: none;
+}
+
+.c13[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c12 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c12:focus {
+  outline: none;
+}
+
+.c12.c12 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c12::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c12[aria-hidden='true'] {
+  display: none;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c10 > * {
+  margin: 2px;
+}
+
+.c8 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within:not([aria-disabled='true']),
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c8[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c14 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c14.c14.c14 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c14.c14.c14 {
+  display: block;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5 c6"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":rc:--input"
+          id=":rc:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c7"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c8"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":rc:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c9"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c10"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c11"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":rc:--listbox"
+                  aria-describedby=":rc:--message"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":rc:--label"
+                  autocomplete="off"
+                  class="c12"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":rc:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c13"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c14"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":rc:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+        <div
+          class="c15 c16 "
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.message"
+          data-garden-version="9.0.0"
+          id=":rc:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a multiselectable combobox 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r17:--input"
+          id=":r17:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r17:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r17:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r17:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r17:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              aria-multiselectable="true"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r17:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with an autocomplete combobox 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c14 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c14 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c14 > *:focus {
+  outline: none;
+}
+
+.c14[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c12 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c12:focus {
+  outline: none;
+}
+
+.c12.c12 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c12::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c12[aria-hidden='true'] {
+  display: none;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c10 > * {
+  margin: 2px;
+}
+
+.c8 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: pointer;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within:not([aria-disabled='true']),
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c8[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  position: -webkit-sticky;
+  position: sticky;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  top: 8px;
+  margin-left: 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7:hover .c13.c13,
+.c7:focus-within .c13.c13,
+.c7:focus .c13.c13 {
+  color: #39434b;
+}
+
+.c7[aria-disabled='true'] .c13.c13 {
+  color: #848f99;
+}
+
+.c15 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c15.c15.c15 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c15.c15.c15 {
+  display: block;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1j:--input"
+          id=":r1j:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            aria-controls=":r1j:--listbox"
+            class="c7 c8"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1j:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c9"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c10"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c11"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls=":r1j:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1j:--label"
+                  autocomplete="off"
+                  class="c12"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r1j:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+              <svg
+                aria-hidden="true"
+                class=" c13"
+                data-garden-id="dropdowns.combobox.input_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="c14"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c15"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1j:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with an editable combobox 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1g:--input"
+          id=":r1g:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1g:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r1g:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1g:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r1g:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1g:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with end icon 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c14 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c14 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c14 > *:focus {
+  outline: none;
+}
+
+.c14[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c12 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c12:focus {
+  outline: none;
+}
+
+.c12.c12 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c12::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c12[aria-hidden='true'] {
+  display: none;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c10 > * {
+  margin: 2px;
+}
+
+.c8 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within:not([aria-disabled='true']),
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c8[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  position: -webkit-sticky;
+  position: sticky;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  top: 8px;
+  margin-left: 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7:hover .c13.c13,
+.c7:focus-within .c13.c13,
+.c7:focus .c13.c13 {
+  color: #39434b;
+}
+
+.c7[aria-disabled='true'] .c13.c13 {
+  color: #848f99;
+}
+
+.c15 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c15.c15.c15 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c15.c15.c15 {
+  display: block;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":rr:--input"
+          id=":rr:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7 c8"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":rr:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c9"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c10"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c11"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":rr:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":rr:--label"
+                  autocomplete="off"
+                  class="c12"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":rr:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+              <svg
+                class=" c13"
+                data-garden-id="dropdowns.combobox.input_icon"
+                data-garden-version="9.0.0"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+            </div>
+          </div>
+          <div
+            class="c14"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c15"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":rr:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with grouped options 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r14:--input"
+          id=":r14:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r14:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r14:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r14:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r14:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r14:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with options 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r11:--input"
+          id=":r11:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r11:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r11:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r11:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r11:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r11:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with renderValue enabled 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":ru:--input"
+          id=":ru:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":ru:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":ru:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":ru:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":ru:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":ru:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with start icon 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c14 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c14 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c14 > *:focus {
+  outline: none;
+}
+
+.c14[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c13 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13.c13 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c13[aria-hidden='true'] {
+  display: none;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c11 > * {
+  margin: 2px;
+}
+
+.c8 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within:not([aria-disabled='true']),
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c8[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c10 {
+  position: -webkit-sticky;
+  position: sticky;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  top: 8px;
+  margin-right: 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7:hover .c10.c10,
+.c7:focus-within .c10.c10,
+.c7:focus .c10.c10 {
+  color: #39434b;
+}
+
+.c7[aria-disabled='true'] .c10.c10 {
+  color: #848f99;
+}
+
+.c15 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c15.c15.c15 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c15.c15.c15 {
+  display: block;
+}
+
+.c12 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c12.c12 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c12[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":ro:--input"
+          id=":ro:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7 c8"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":ro:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c9"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <svg
+                class=" c10"
+                data-garden-id="dropdowns.combobox.input_icon"
+                data-garden-version="9.0.0"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="c11"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c12"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":ro:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":ro:--label"
+                  autocomplete="off"
+                  class="c13"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":ro:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c14"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c15"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":ro:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with validation error 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #cd3642;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #cd3642;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":ri:--input"
+          id=":ri:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":ri:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":ri:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="true"
+                  aria-labelledby=":ri:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":ri:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":ri:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with validation success 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #037f52;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #037f52;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":rf:--input"
+          id=":rf:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":rf:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":rf:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":rf:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":rf:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":rf:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with validation warning 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #ac5918;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #ac5918;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":rl:--input"
+          id=":rl:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":rl:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":rl:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="true"
+                  aria-labelledby=":rl:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":rl:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":rl:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r0:--input"
+          id=":r0:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r0:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r0:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r0:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r0:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r0:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/dropdowns/demo/stories/__snapshots__/ComboboxStory.spec.tsx.snap
+++ b/packages/dropdowns/demo/stories/__snapshots__/ComboboxStory.spec.tsx.snap
@@ -352,30 +352,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a bare combobox 1`] 
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r1d:--input"
           id=":r1d:--label"
         >
@@ -384,7 +384,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a bare combobox 1`] 
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -392,24 +392,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a bare combobox 1`] 
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r1d:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -422,7 +422,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a bare combobox 1`] 
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r1d:--input"
                   role="combobox"
@@ -435,7 +435,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a bare combobox 1`] 
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -444,7 +444,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a bare combobox 1`] 
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r1d:--listbox"
               role="listbox"
             />
@@ -810,30 +810,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a compact combobox 1
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r1a:--input"
           id=":r1a:--label"
         >
@@ -842,7 +842,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a compact combobox 1
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -850,24 +850,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a compact combobox 1
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r1a:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -880,7 +880,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a compact combobox 1
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r1a:--input"
                   role="combobox"
@@ -893,7 +893,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a compact combobox 1
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -902,7 +902,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a compact combobox 1
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r1a:--listbox"
               role="listbox"
             />
@@ -1268,30 +1268,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom active inde
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r2k:--input"
           id=":r2k:--label"
         >
@@ -1300,7 +1300,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom active inde
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -1308,24 +1308,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom active inde
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r2k:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -1338,7 +1338,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom active inde
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r2k:--input"
                   role="combobox"
@@ -1351,7 +1351,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom active inde
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -1360,7 +1360,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom active inde
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r2k:--listbox"
               role="listbox"
             />
@@ -1726,30 +1726,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default act
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r2n:--input"
           id=":r2n:--label"
         >
@@ -1758,7 +1758,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default act
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -1766,24 +1766,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default act
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r2n:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -1796,7 +1796,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default act
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r2n:--input"
                   role="combobox"
@@ -1809,7 +1809,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default act
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -1818,7 +1818,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default act
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r2n:--listbox"
               role="listbox"
             />
@@ -2262,30 +2262,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default exp
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r2q:--input"
           id=":r2q:--label"
         >
@@ -2294,7 +2294,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default exp
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -2302,24 +2302,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default exp
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r2q:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                 />
                 <input
@@ -2333,7 +2333,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default exp
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   id=":r2q:--input"
                   role="combobox"
                   value=""
@@ -2345,7 +2345,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default exp
             class="c12"
             data-garden-animate="true"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -2354,7 +2354,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default exp
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r2q:--listbox"
               role="listbox"
             >
@@ -2364,7 +2364,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default exp
                 data-garden-container-id="containers.combobox.option"
                 data-garden-container-version="2.0.4"
                 data-garden-id="dropdowns.combobox.option"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 id=":r2q:--option-0"
                 role="option"
               >
@@ -2372,7 +2372,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default exp
                   aria-hidden="true"
                   class="c16  c17"
                   data-garden-id="dropdowns.combobox.option.type_icon"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   focusable="false"
                   height="16"
                   viewBox="0 0 16 16"
@@ -2390,7 +2390,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default exp
                 <div
                   class="c18"
                   data-garden-id="dropdowns.combobox.option.content"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 >
                   Option 1
                 </div>
@@ -2401,7 +2401,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default exp
                 data-garden-container-id="containers.combobox.option"
                 data-garden-container-version="2.0.4"
                 data-garden-id="dropdowns.combobox.option"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 id=":r2q:--option-1"
                 role="option"
               >
@@ -2409,7 +2409,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default exp
                   aria-hidden="true"
                   class="c16  c17"
                   data-garden-id="dropdowns.combobox.option.type_icon"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   focusable="false"
                   height="16"
                   viewBox="0 0 16 16"
@@ -2427,7 +2427,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom default exp
                 <div
                   class="c18"
                   data-garden-id="dropdowns.combobox.option.content"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 >
                   Option 2
                 </div>
@@ -2795,30 +2795,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom focus inset
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r2t:--input"
           id=":r2t:--label"
         >
@@ -2827,7 +2827,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom focus inset
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -2835,24 +2835,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom focus inset
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r2t:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -2865,7 +2865,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom focus inset
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r2t:--input"
                   role="combobox"
@@ -2878,7 +2878,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom focus inset
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -2887,7 +2887,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom focus inset
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r2t:--listbox"
               role="listbox"
             />
@@ -3253,30 +3253,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom id 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for="custom-id--input"
           id="custom-id--label"
         >
@@ -3285,7 +3285,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom id 1`] = `
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id="custom-id"
           tabindex="-1"
         >
@@ -3294,24 +3294,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom id 1`] = `
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id="custom-id--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -3324,7 +3324,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom id 1`] = `
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id="custom-id--input"
                   role="combobox"
@@ -3337,7 +3337,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom id 1`] = `
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -3346,7 +3346,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom id 1`] = `
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id="custom-id--listbox"
               role="listbox"
             />
@@ -3711,30 +3711,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom input value
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r2h:--input"
           id=":r2h:--label"
         >
@@ -3743,7 +3743,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom input value
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -3751,24 +3751,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom input value
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r2h:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 >
                   Custom input
                 </div>
@@ -3783,7 +3783,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom input value
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r2h:--input"
                   role="combobox"
@@ -3796,7 +3796,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom input value
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -3805,7 +3805,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom input value
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r2h:--listbox"
               role="listbox"
             />
@@ -4171,30 +4171,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox ari
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r2b:--input"
           id=":r2b:--label"
         >
@@ -4203,7 +4203,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox ari
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -4211,24 +4211,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox ari
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r2b:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -4241,7 +4241,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox ari
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r2b:--input"
                   role="combobox"
@@ -4254,7 +4254,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox ari
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -4263,7 +4263,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox ari
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r2b:--listbox"
               role="listbox"
             />
@@ -4629,30 +4629,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox max
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r1v:--input"
           id=":r1v:--label"
         >
@@ -4661,7 +4661,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox max
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -4669,24 +4669,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox max
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r1v:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -4699,7 +4699,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox max
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r1v:--input"
                   role="combobox"
@@ -4712,7 +4712,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox max
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -4721,7 +4721,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox max
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r1v:--listbox"
               role="listbox"
             />
@@ -5087,30 +5087,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox min
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r22:--input"
           id=":r22:--label"
         >
@@ -5119,7 +5119,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox min
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -5127,24 +5127,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox min
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r22:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -5157,7 +5157,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox min
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r22:--input"
                   role="combobox"
@@ -5170,7 +5170,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox min
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -5179,7 +5179,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox min
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r22:--listbox"
               role="listbox"
             />
@@ -5545,30 +5545,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox z-i
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r25:--input"
           id=":r25:--label"
         >
@@ -5577,7 +5577,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox z-i
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -5585,24 +5585,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox z-i
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r25:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -5615,7 +5615,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox z-i
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r25:--input"
                   role="combobox"
@@ -5628,7 +5628,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox z-i
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -5637,7 +5637,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom listbox z-i
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r25:--listbox"
               role="listbox"
             />
@@ -6003,30 +6003,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom max height 
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r28:--input"
           id=":r28:--label"
         >
@@ -6035,7 +6035,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom max height 
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -6043,24 +6043,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom max height 
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r28:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -6073,7 +6073,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom max height 
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r28:--input"
                   role="combobox"
@@ -6086,7 +6086,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom max height 
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -6095,7 +6095,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom max height 
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r28:--listbox"
               role="listbox"
             />
@@ -6461,30 +6461,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom maxTags val
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r1s:--input"
           id=":r1s:--label"
         >
@@ -6493,7 +6493,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom maxTags val
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -6501,24 +6501,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom maxTags val
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r1s:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -6531,7 +6531,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom maxTags val
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r1s:--input"
                   role="combobox"
@@ -6544,7 +6544,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom maxTags val
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -6554,7 +6554,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom maxTags val
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r1s:--listbox"
               role="listbox"
             />
@@ -6920,30 +6920,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom placeholder
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r1p:--input"
           id=":r1p:--label"
         >
@@ -6952,7 +6952,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom placeholder
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -6960,24 +6960,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom placeholder
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r1p:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 >
                   Choose an option
                 </div>
@@ -6992,7 +6992,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom placeholder
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r1p:--input"
                   placeholder="Choose an option"
@@ -7006,7 +7006,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom placeholder
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -7015,7 +7015,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a custom placeholder
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r1p:--listbox"
               role="listbox"
             />
@@ -7381,30 +7381,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a disabled combobox 
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r1m:--input"
           id=":r1m:--label"
         >
@@ -7413,7 +7413,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a disabled combobox 
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -7422,24 +7422,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a disabled combobox 
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r1m:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -7452,7 +7452,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a disabled combobox 
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   disabled=""
                   hidden=""
                   id=":r1m:--input"
@@ -7466,7 +7466,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a disabled combobox 
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -7475,7 +7475,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a disabled combobox 
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r1m:--listbox"
               role="listbox"
             />
@@ -7841,30 +7841,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] =
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r6:--input"
           hidden=""
           id=":r6:--label"
@@ -7874,7 +7874,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] =
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -7882,24 +7882,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] =
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r6:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -7912,7 +7912,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] =
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r6:--input"
                   role="combobox"
@@ -7925,7 +7925,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] =
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -7934,7 +7934,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] =
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r6:--listbox"
               role="listbox"
             />
@@ -8308,30 +8308,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r9:--input"
           id=":r9:--label"
         >
@@ -8342,7 +8342,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
           data-garden-container-id="containers.field.hint"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.hint"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r9:--hint"
         >
           Choose wisely
@@ -8350,7 +8350,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
         <div
           class="c7"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -8358,24 +8358,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r9:--trigger"
             tabindex="-1"
           >
             <div
               class="c9"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c10"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c11"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -8389,7 +8389,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r9:--input"
                   role="combobox"
@@ -8402,7 +8402,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
             class="c13"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -8411,7 +8411,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r9:--listbox"
               role="listbox"
             />
@@ -8777,30 +8777,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r3:--input"
           id=":r3:--label"
         >
@@ -8809,7 +8809,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -8817,24 +8817,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r3:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -8847,7 +8847,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r3:--input"
                   role="combobox"
@@ -8860,7 +8860,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -8869,7 +8869,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r3:--listbox"
               role="listbox"
             />
@@ -9252,30 +9252,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5 c6"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":rc:--input"
           id=":rc:--label"
         >
@@ -9284,7 +9284,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
         <div
           class="c7"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -9292,24 +9292,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":rc:--trigger"
             tabindex="-1"
           >
             <div
               class="c9"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c10"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c11"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -9323,7 +9323,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":rc:--input"
                   role="combobox"
@@ -9336,7 +9336,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
             class="c13"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -9345,7 +9345,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":rc:--listbox"
               role="listbox"
             />
@@ -9356,7 +9356,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
           data-garden-container-id="containers.field.message"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.message"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rc:--message"
           role="alert"
         >
@@ -9722,30 +9722,30 @@ exports[`ComboboxStory Component renders ComboboxStory with a multiselectable co
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r17:--input"
           id=":r17:--label"
         >
@@ -9754,7 +9754,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a multiselectable co
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -9762,24 +9762,24 @@ exports[`ComboboxStory Component renders ComboboxStory with a multiselectable co
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r17:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -9792,7 +9792,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a multiselectable co
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r17:--input"
                   role="combobox"
@@ -9805,7 +9805,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a multiselectable co
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -9815,7 +9815,7 @@ exports[`ComboboxStory Component renders ComboboxStory with a multiselectable co
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r17:--listbox"
               role="listbox"
             />
@@ -10207,30 +10207,30 @@ exports[`ComboboxStory Component renders ComboboxStory with an autocomplete comb
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r1j:--input"
           id=":r1j:--label"
         >
@@ -10239,7 +10239,7 @@ exports[`ComboboxStory Component renders ComboboxStory with an autocomplete comb
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -10248,24 +10248,24 @@ exports[`ComboboxStory Component renders ComboboxStory with an autocomplete comb
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r1j:--trigger"
             tabindex="-1"
           >
             <div
               class="c9"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c10"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c11"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -10279,7 +10279,7 @@ exports[`ComboboxStory Component renders ComboboxStory with an autocomplete comb
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r1j:--input"
                   role="combobox"
@@ -10290,7 +10290,7 @@ exports[`ComboboxStory Component renders ComboboxStory with an autocomplete comb
                 aria-hidden="true"
                 class=" c13"
                 data-garden-id="dropdowns.combobox.input_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -10308,7 +10308,7 @@ exports[`ComboboxStory Component renders ComboboxStory with an autocomplete comb
             class="c14"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -10317,7 +10317,7 @@ exports[`ComboboxStory Component renders ComboboxStory with an autocomplete comb
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r1j:--listbox"
               role="listbox"
             />
@@ -10683,30 +10683,30 @@ exports[`ComboboxStory Component renders ComboboxStory with an editable combobox
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r1g:--input"
           id=":r1g:--label"
         >
@@ -10715,7 +10715,7 @@ exports[`ComboboxStory Component renders ComboboxStory with an editable combobox
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -10723,24 +10723,24 @@ exports[`ComboboxStory Component renders ComboboxStory with an editable combobox
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r1g:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -10753,7 +10753,7 @@ exports[`ComboboxStory Component renders ComboboxStory with an editable combobox
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r1g:--input"
                   role="combobox"
@@ -10766,7 +10766,7 @@ exports[`ComboboxStory Component renders ComboboxStory with an editable combobox
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -10775,7 +10775,7 @@ exports[`ComboboxStory Component renders ComboboxStory with an editable combobox
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r1g:--listbox"
               role="listbox"
             />
@@ -11167,30 +11167,30 @@ exports[`ComboboxStory Component renders ComboboxStory with end icon 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":rr:--input"
           id=":rr:--label"
         >
@@ -11199,7 +11199,7 @@ exports[`ComboboxStory Component renders ComboboxStory with end icon 1`] = `
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -11207,24 +11207,24 @@ exports[`ComboboxStory Component renders ComboboxStory with end icon 1`] = `
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":rr:--trigger"
             tabindex="-1"
           >
             <div
               class="c9"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c10"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c11"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -11237,7 +11237,7 @@ exports[`ComboboxStory Component renders ComboboxStory with end icon 1`] = `
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":rr:--input"
                   role="combobox"
@@ -11247,7 +11247,7 @@ exports[`ComboboxStory Component renders ComboboxStory with end icon 1`] = `
               <svg
                 class=" c13"
                 data-garden-id="dropdowns.combobox.input_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 xmlns="http://www.w3.org/2000/svg"
               />
             </div>
@@ -11256,7 +11256,7 @@ exports[`ComboboxStory Component renders ComboboxStory with end icon 1`] = `
             class="c14"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -11265,7 +11265,7 @@ exports[`ComboboxStory Component renders ComboboxStory with end icon 1`] = `
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":rr:--listbox"
               role="listbox"
             />
@@ -11631,30 +11631,30 @@ exports[`ComboboxStory Component renders ComboboxStory with grouped options 1`] 
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r14:--input"
           id=":r14:--label"
         >
@@ -11663,7 +11663,7 @@ exports[`ComboboxStory Component renders ComboboxStory with grouped options 1`] 
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -11671,24 +11671,24 @@ exports[`ComboboxStory Component renders ComboboxStory with grouped options 1`] 
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r14:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -11701,7 +11701,7 @@ exports[`ComboboxStory Component renders ComboboxStory with grouped options 1`] 
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r14:--input"
                   role="combobox"
@@ -11714,7 +11714,7 @@ exports[`ComboboxStory Component renders ComboboxStory with grouped options 1`] 
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -11723,7 +11723,7 @@ exports[`ComboboxStory Component renders ComboboxStory with grouped options 1`] 
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r14:--listbox"
               role="listbox"
             />
@@ -12089,30 +12089,30 @@ exports[`ComboboxStory Component renders ComboboxStory with options 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r11:--input"
           id=":r11:--label"
         >
@@ -12121,7 +12121,7 @@ exports[`ComboboxStory Component renders ComboboxStory with options 1`] = `
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -12129,24 +12129,24 @@ exports[`ComboboxStory Component renders ComboboxStory with options 1`] = `
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r11:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -12159,7 +12159,7 @@ exports[`ComboboxStory Component renders ComboboxStory with options 1`] = `
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r11:--input"
                   role="combobox"
@@ -12172,7 +12172,7 @@ exports[`ComboboxStory Component renders ComboboxStory with options 1`] = `
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -12181,7 +12181,7 @@ exports[`ComboboxStory Component renders ComboboxStory with options 1`] = `
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r11:--listbox"
               role="listbox"
             />
@@ -12546,30 +12546,30 @@ exports[`ComboboxStory Component renders ComboboxStory with renderValue enabled 
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":ru:--input"
           id=":ru:--label"
         >
@@ -12578,7 +12578,7 @@ exports[`ComboboxStory Component renders ComboboxStory with renderValue enabled 
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -12586,24 +12586,24 @@ exports[`ComboboxStory Component renders ComboboxStory with renderValue enabled 
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":ru:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -12616,7 +12616,7 @@ exports[`ComboboxStory Component renders ComboboxStory with renderValue enabled 
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":ru:--input"
                   role="combobox"
@@ -12629,7 +12629,7 @@ exports[`ComboboxStory Component renders ComboboxStory with renderValue enabled 
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -12638,7 +12638,7 @@ exports[`ComboboxStory Component renders ComboboxStory with renderValue enabled 
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":ru:--listbox"
               role="listbox"
             />
@@ -13030,30 +13030,30 @@ exports[`ComboboxStory Component renders ComboboxStory with start icon 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":ro:--input"
           id=":ro:--label"
         >
@@ -13062,7 +13062,7 @@ exports[`ComboboxStory Component renders ComboboxStory with start icon 1`] = `
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -13070,30 +13070,30 @@ exports[`ComboboxStory Component renders ComboboxStory with start icon 1`] = `
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":ro:--trigger"
             tabindex="-1"
           >
             <div
               class="c9"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <svg
                 class=" c10"
                 data-garden-id="dropdowns.combobox.input_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 xmlns="http://www.w3.org/2000/svg"
               />
               <div
                 class="c11"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c12"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -13106,7 +13106,7 @@ exports[`ComboboxStory Component renders ComboboxStory with start icon 1`] = `
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":ro:--input"
                   role="combobox"
@@ -13119,7 +13119,7 @@ exports[`ComboboxStory Component renders ComboboxStory with start icon 1`] = `
             class="c14"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -13128,7 +13128,7 @@ exports[`ComboboxStory Component renders ComboboxStory with start icon 1`] = `
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":ro:--listbox"
               role="listbox"
             />
@@ -13494,30 +13494,30 @@ exports[`ComboboxStory Component renders ComboboxStory with validation error 1`]
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":ri:--input"
           id=":ri:--label"
         >
@@ -13526,7 +13526,7 @@ exports[`ComboboxStory Component renders ComboboxStory with validation error 1`]
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -13534,24 +13534,24 @@ exports[`ComboboxStory Component renders ComboboxStory with validation error 1`]
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":ri:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -13564,7 +13564,7 @@ exports[`ComboboxStory Component renders ComboboxStory with validation error 1`]
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":ri:--input"
                   role="combobox"
@@ -13577,7 +13577,7 @@ exports[`ComboboxStory Component renders ComboboxStory with validation error 1`]
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -13586,7 +13586,7 @@ exports[`ComboboxStory Component renders ComboboxStory with validation error 1`]
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":ri:--listbox"
               role="listbox"
             />
@@ -13952,30 +13952,30 @@ exports[`ComboboxStory Component renders ComboboxStory with validation success 1
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":rf:--input"
           id=":rf:--label"
         >
@@ -13984,7 +13984,7 @@ exports[`ComboboxStory Component renders ComboboxStory with validation success 1
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -13992,24 +13992,24 @@ exports[`ComboboxStory Component renders ComboboxStory with validation success 1
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":rf:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -14022,7 +14022,7 @@ exports[`ComboboxStory Component renders ComboboxStory with validation success 1
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":rf:--input"
                   role="combobox"
@@ -14035,7 +14035,7 @@ exports[`ComboboxStory Component renders ComboboxStory with validation success 1
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -14044,7 +14044,7 @@ exports[`ComboboxStory Component renders ComboboxStory with validation success 1
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":rf:--listbox"
               role="listbox"
             />
@@ -14410,30 +14410,30 @@ exports[`ComboboxStory Component renders ComboboxStory with validation warning 1
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":rl:--input"
           id=":rl:--label"
         >
@@ -14442,7 +14442,7 @@ exports[`ComboboxStory Component renders ComboboxStory with validation warning 1
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -14450,24 +14450,24 @@ exports[`ComboboxStory Component renders ComboboxStory with validation warning 1
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":rl:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -14480,7 +14480,7 @@ exports[`ComboboxStory Component renders ComboboxStory with validation warning 1
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":rl:--input"
                   role="combobox"
@@ -14493,7 +14493,7 @@ exports[`ComboboxStory Component renders ComboboxStory with validation warning 1
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -14502,7 +14502,7 @@ exports[`ComboboxStory Component renders ComboboxStory with validation warning 1
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":rl:--listbox"
               role="listbox"
             />
@@ -14868,30 +14868,30 @@ exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c3"
         data-garden-id="dropdowns.combobox.field"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           class="c4 c5"
           data-garden-container-id="containers.field.label"
           data-garden-container-version="3.0.19"
           data-garden-id="dropdowns.combobox.label"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           for=":r0:--input"
           id=":r0:--label"
         >
@@ -14900,7 +14900,7 @@ exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
         <div
           class="c6"
           data-garden-id="dropdowns.combobox"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           tabindex="-1"
         >
           <div
@@ -14908,24 +14908,24 @@ exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
             data-garden-container-id="containers.combobox"
             data-garden-container-version="2.0.4"
             data-garden-id="dropdowns.combobox.trigger"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             id=":r0:--trigger"
             tabindex="-1"
           >
             <div
               class="c8"
               data-garden-id="dropdowns.combobox.container"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
             >
               <div
                 class="c9"
                 data-garden-id="dropdowns.combobox.input_group"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c10"
                   data-garden-id="dropdowns.combobox.value"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 />
                 <input
                   aria-activedescendant=""
@@ -14938,7 +14938,7 @@ exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
                   data-garden-container-id="containers.field.input"
                   data-garden-container-version="3.0.19"
                   data-garden-id="dropdowns.combobox.input"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   hidden=""
                   id=":r0:--input"
                   role="combobox"
@@ -14951,7 +14951,7 @@ exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
             class="c12"
             data-garden-animate="false"
             data-garden-id="dropdowns.combobox.floating"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             style="transform: translate(0px, 0px);"
           >
             <ul
@@ -14960,7 +14960,7 @@ exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
               data-garden-container-id="containers.combobox.listbox"
               data-garden-container-version="2.0.4"
               data-garden-id="dropdowns.combobox.listbox"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               id=":r0:--listbox"
               role="listbox"
             />

--- a/packages/dropdowns/demo/stories/__snapshots__/MenuStory.spec.tsx.snap
+++ b/packages/dropdowns/demo/stories/__snapshots__/MenuStory.spec.tsx.snap
@@ -1,0 +1,7615 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MenuStory Component renders MenuStory with a custom maxHeight 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 300;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r4:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r4:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom minHeight 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 100;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r5:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r5:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom placement 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) dVyxoq;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) dVyxoq;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r7:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r7:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom triggerRef 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r9:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r9:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom zIndex 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 500;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r6:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r6:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 2000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) ivZgAS;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) ivZgAS;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 4px 36px;
+  min-height: 28px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c11[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c11[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 0 0;
+  min-height: 28px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c19[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c19[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 600;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 4px 36px;
+  min-height: 28px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c20:focus {
+  outline: none;
+}
+
+.c20[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c20[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c20[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c22 {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.c24 {
+  cursor: default;
+  margin: 4px 0;
+  height: 1px;
+  background-color: #e8eaec;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 150;
+  max-height: 500;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c7 .c9:first-child .c15 .c21:first-child .c23[role='none']:first-child {
+  display: none;
+}
+
+.c17 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-top: 2px;
+  margin-right: 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c18 {
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  font-weight: 400;
+  line-height: 16px;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c14 {
+  position: absolute;
+  -webkit-transition: opacity 0.1s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
+  top: 10px;
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  opacity: 0;
+  color: #1f73b7;
+}
+
+.c9[aria-selected='true'] > .c12 {
+  opacity: 1;
+}
+
+.c9[aria-disabled='true'] > .c12 {
+  color: inherit;
+}
+
+.c8 {
+  position: static !important;
+  position: relative;
+}
+
+.c8::before,
+.c8::after {
+  position: absolute;
+  border-width: inherit;
+  border-style: inherit;
+  background-color: inherit;
+  width: 10.49px;
+  height: 10.49px;
+  content: '';
+  box-sizing: inherit;
+}
+
+.c8::before {
+  border-color: inherit;
+  -webkit-clip-path: polygon(100% 2px,2px 100%,100% 100%);
+  clip-path: polygon(100% 2px,2px 100%,100% 100%);
+}
+
+.c8::after {
+  border-color: transparent;
+  background-clip: content-box;
+  -webkit-clip-path: polygon(100% 0px,0px 100%,100% 100%);
+  clip-path: polygon(100% 0px,0px 100%,100% 100%);
+}
+
+.c8::before,
+.c8::after {
+  -webkit-transform: rotate(135deg);
+  -ms-transform: rotate(135deg);
+  transform: rotate(135deg);
+  top: 50%;
+  bottom: 10.49px;
+  left: -3.94px;
+  margin-top: -5.245px;
+}
+
+.c8[data-garden-animate-arrow="true"]::before,
+.c8[data-garden-animate-arrow="true"]::after {
+  -webkit-animation: 0.3s ease-in-out jKmejG;
+  animation: 0.3s ease-in-out jKmejG;
+}
+
+.c10[aria-checked='true'] > .c13 {
+  opacity: 1;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="true"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":rf:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="true"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":rf:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="true"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          >
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="0"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 1
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <svg
+                class=" c17 "
+                data-garden-id="dropdowns.menu.item.icon"
+                data-garden-version="9.0.0"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 2
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 3
+                <div
+                  class="c18 "
+                  data-garden-id="dropdowns.menu.item.meta"
+                  data-garden-version="9.0.0"
+                >
+                  Meta
+                </div>
+              </div>
+            </li>
+            <li
+              class="c9 c10 c19 "
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="none"
+            >
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c9 c10 c20 "
+                  data-garden-id="dropdowns.menu.item"
+                  data-garden-version="9.0.0"
+                >
+                  Group 1
+                </div>
+                <ul
+                  aria-label="Group 1"
+                  class="c21 c22 "
+                  data-garden-container-id="containers.menu.item_group"
+                  data-garden-container-version="0.5.0"
+                  data-garden-id="dropdowns.menu.item_group"
+                  data-garden-version="9.0.0"
+                  role="group"
+                >
+                  <li
+                    class="c23 c24 "
+                    data-garden-id="dropdowns.menu.separator"
+                    data-garden-version="9.0.0"
+                    role="none"
+                  />
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 1
+                    </div>
+                  </li>
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <svg
+                      class=" c17 "
+                      data-garden-id="dropdowns.menu.item.icon"
+                      data-garden-version="9.0.0"
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 2
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li
+              class="c23 c24 "
+              data-garden-container-id="containers.menu.separator"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.separator"
+              data-garden-version="9.0.0"
+              role="separator"
+            />
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 4
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with an arrow 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+  position: relative;
+}
+
+.c8::before,
+.c8::after {
+  position: absolute;
+  border-width: inherit;
+  border-style: inherit;
+  background-color: inherit;
+  width: 10.49px;
+  height: 10.49px;
+  content: '';
+  box-sizing: inherit;
+}
+
+.c8::before {
+  border-color: inherit;
+  -webkit-clip-path: polygon(100% 2px,2px 100%,100% 100%);
+  clip-path: polygon(100% 2px,2px 100%,100% 100%);
+}
+
+.c8::after {
+  border-color: transparent;
+  background-clip: content-box;
+  -webkit-clip-path: polygon(100% 0px,0px 100%,100% 100%);
+  clip-path: polygon(100% 0px,0px 100%,100% 100%);
+}
+
+.c8::before,
+.c8::after {
+  -webkit-transform: rotate(-135deg);
+  -ms-transform: rotate(-135deg);
+  transform: rotate(-135deg);
+  top: -3.94px;
+  left: 10.49px;
+}
+
+.c8[data-garden-animate-arrow="true"]::before,
+.c8[data-garden-animate-arrow="true"]::after {
+  -webkit-animation: 0.3s ease-in-out jAsLVO;
+  animation: 0.3s ease-in-out jAsLVO;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r2:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r2:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with compact styling 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 36px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r1:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r1:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with compact styling and an arrow 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 36px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+  position: relative;
+}
+
+.c8::before,
+.c8::after {
+  position: absolute;
+  border-width: inherit;
+  border-style: inherit;
+  background-color: inherit;
+  width: 10.49px;
+  height: 10.49px;
+  content: '';
+  box-sizing: inherit;
+}
+
+.c8::before {
+  border-color: inherit;
+  -webkit-clip-path: polygon(100% 2px,2px 100%,100% 100%);
+  clip-path: polygon(100% 2px,2px 100%,100% 100%);
+}
+
+.c8::after {
+  border-color: transparent;
+  background-clip: content-box;
+  -webkit-clip-path: polygon(100% 0px,0px 100%,100% 100%);
+  clip-path: polygon(100% 0px,0px 100%,100% 100%);
+}
+
+.c8::before,
+.c8::after {
+  -webkit-transform: rotate(-135deg);
+  -ms-transform: rotate(-135deg);
+  transform: rotate(-135deg);
+  top: -3.94px;
+  left: 10.49px;
+}
+
+.c8[data-garden-animate-arrow="true"]::before,
+.c8[data-garden-animate-arrow="true"]::after {
+  -webkit-animation: 0.3s ease-in-out jAsLVO;
+  animation: 0.3s ease-in-out jAsLVO;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":ra:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":ra:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with compact styling, an arrow, and expanded state 1`] = `
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 4px 36px;
+  min-height: 28px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c11[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c11[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 0 0;
+  min-height: 28px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c19[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c19[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 600;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 4px 36px;
+  min-height: 28px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c20:focus {
+  outline: none;
+}
+
+.c20[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c20[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c20[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c22 {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.c24 {
+  cursor: default;
+  margin: 4px 0;
+  height: 1px;
+  background-color: #e8eaec;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 36px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c7 .c9:first-child .c15 .c21:first-child .c23[role='none']:first-child {
+  display: none;
+}
+
+.c17 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-top: 2px;
+  margin-right: 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c18 {
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  font-weight: 400;
+  line-height: 16px;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c14 {
+  position: absolute;
+  -webkit-transition: opacity 0.1s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
+  top: 10px;
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  opacity: 0;
+  color: #1f73b7;
+}
+
+.c9[aria-selected='true'] > .c12 {
+  opacity: 1;
+}
+
+.c9[aria-disabled='true'] > .c12 {
+  color: inherit;
+}
+
+.c8 {
+  position: static !important;
+  position: relative;
+}
+
+.c8::before,
+.c8::after {
+  position: absolute;
+  border-width: inherit;
+  border-style: inherit;
+  background-color: inherit;
+  width: 10.49px;
+  height: 10.49px;
+  content: '';
+  box-sizing: inherit;
+}
+
+.c8::before {
+  border-color: inherit;
+  -webkit-clip-path: polygon(100% 2px,2px 100%,100% 100%);
+  clip-path: polygon(100% 2px,2px 100%,100% 100%);
+}
+
+.c8::after {
+  border-color: transparent;
+  background-clip: content-box;
+  -webkit-clip-path: polygon(100% 0px,0px 100%,100% 100%);
+  clip-path: polygon(100% 0px,0px 100%,100% 100%);
+}
+
+.c8::before,
+.c8::after {
+  -webkit-transform: rotate(-135deg);
+  -ms-transform: rotate(-135deg);
+  transform: rotate(-135deg);
+  top: -3.94px;
+  left: 10.49px;
+}
+
+.c8[data-garden-animate-arrow="true"]::before,
+.c8[data-garden-animate-arrow="true"]::after {
+  -webkit-animation: 0.3s ease-in-out jAsLVO;
+  animation: 0.3s ease-in-out jAsLVO;
+}
+
+.c10[aria-checked='true'] > .c13 {
+  opacity: 1;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="true"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":re:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="true"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":re:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="true"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          >
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="0"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 1
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <svg
+                class=" c17 "
+                data-garden-id="dropdowns.menu.item.icon"
+                data-garden-version="9.0.0"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 2
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 3
+                <div
+                  class="c18 "
+                  data-garden-id="dropdowns.menu.item.meta"
+                  data-garden-version="9.0.0"
+                >
+                  Meta
+                </div>
+              </div>
+            </li>
+            <li
+              class="c9 c10 c19 "
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="none"
+            >
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c9 c10 c20 "
+                  data-garden-id="dropdowns.menu.item"
+                  data-garden-version="9.0.0"
+                >
+                  Group 1
+                </div>
+                <ul
+                  aria-label="Group 1"
+                  class="c21 c22 "
+                  data-garden-container-id="containers.menu.item_group"
+                  data-garden-container-version="0.5.0"
+                  data-garden-id="dropdowns.menu.item_group"
+                  data-garden-version="9.0.0"
+                  role="group"
+                >
+                  <li
+                    class="c23 c24 "
+                    data-garden-id="dropdowns.menu.separator"
+                    data-garden-version="9.0.0"
+                    role="none"
+                  />
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 1
+                    </div>
+                  </li>
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <svg
+                      class=" c17 "
+                      data-garden-id="dropdowns.menu.item.icon"
+                      data-garden-version="9.0.0"
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 2
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li
+              class="c23 c24 "
+              data-garden-container-id="containers.menu.separator"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.separator"
+              data-garden-version="9.0.0"
+              role="separator"
+            />
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 4
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with custom maxHeight, minHeight, and zIndex 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 200;
+  max-height: 400;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":rc:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":rc:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 8px 36px;
+  min-height: 36px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c11[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c11[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 0 0;
+  min-height: 36px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c19[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c19[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 600;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 8px 36px;
+  min-height: 36px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c20:focus {
+  outline: none;
+}
+
+.c20[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c20[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c20[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c22 {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.c24 {
+  cursor: default;
+  margin: 4px 0;
+  height: 1px;
+  background-color: #e8eaec;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c7 .c9:first-child .c15 .c21:first-child .c23[role='none']:first-child {
+  display: none;
+}
+
+.c17 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-top: 2px;
+  margin-right: 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c18 {
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  font-weight: 400;
+  line-height: 16px;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c14 {
+  position: absolute;
+  -webkit-transition: opacity 0.1s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
+  top: 10px;
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  opacity: 0;
+  color: #1f73b7;
+}
+
+.c9[aria-selected='true'] > .c12 {
+  opacity: 1;
+}
+
+.c9[aria-disabled='true'] > .c12 {
+  color: inherit;
+}
+
+.c8 {
+  position: static !important;
+}
+
+.c10[aria-checked='true'] > .c13 {
+  opacity: 1;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="true"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r3:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="true"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r3:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="true"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          >
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="0"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 1
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <svg
+                class=" c17 "
+                data-garden-id="dropdowns.menu.item.icon"
+                data-garden-version="9.0.0"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 2
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 3
+                <div
+                  class="c18 "
+                  data-garden-id="dropdowns.menu.item.meta"
+                  data-garden-version="9.0.0"
+                >
+                  Meta
+                </div>
+              </div>
+            </li>
+            <li
+              class="c9 c10 c19 "
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="none"
+            >
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c9 c10 c20 "
+                  data-garden-id="dropdowns.menu.item"
+                  data-garden-version="9.0.0"
+                >
+                  Group 1
+                </div>
+                <ul
+                  aria-label="Group 1"
+                  class="c21 c22 "
+                  data-garden-container-id="containers.menu.item_group"
+                  data-garden-container-version="0.5.0"
+                  data-garden-id="dropdowns.menu.item_group"
+                  data-garden-version="9.0.0"
+                  role="group"
+                >
+                  <li
+                    class="c23 c24 "
+                    data-garden-id="dropdowns.menu.separator"
+                    data-garden-version="9.0.0"
+                    role="none"
+                  />
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 1
+                    </div>
+                  </li>
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <svg
+                      class=" c17 "
+                      data-garden-id="dropdowns.menu.item.icon"
+                      data-garden-version="9.0.0"
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 2
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li
+              class="c23 c24 "
+              data-garden-container-id="containers.menu.separator"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.separator"
+              data-garden-version="9.0.0"
+              role="separator"
+            />
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 4
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with expanded state and custom placement 1`] = `
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 8px 36px;
+  min-height: 36px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c11[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c11[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 0 0;
+  min-height: 36px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c19[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c19[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 600;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 8px 36px;
+  min-height: 36px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c20:focus {
+  outline: none;
+}
+
+.c20[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c20[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c20[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c22 {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.c24 {
+  cursor: default;
+  margin: 4px 0;
+  height: 1px;
+  background-color: #e8eaec;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c7 .c9:first-child .c15 .c21:first-child .c23[role='none']:first-child {
+  display: none;
+}
+
+.c17 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-top: 2px;
+  margin-right: 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c18 {
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  font-weight: 400;
+  line-height: 16px;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c14 {
+  position: absolute;
+  -webkit-transition: opacity 0.1s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
+  top: 10px;
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  opacity: 0;
+  color: #1f73b7;
+}
+
+.c9[aria-selected='true'] > .c12 {
+  opacity: 1;
+}
+
+.c9[aria-disabled='true'] > .c12 {
+  color: inherit;
+}
+
+.c8 {
+  position: static !important;
+}
+
+.c10[aria-checked='true'] > .c13 {
+  opacity: 1;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="true"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":rb:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="true"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":rb:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="true"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          >
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="0"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 1
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <svg
+                class=" c17 "
+                data-garden-id="dropdowns.menu.item.icon"
+                data-garden-version="9.0.0"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 2
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 3
+                <div
+                  class="c18 "
+                  data-garden-id="dropdowns.menu.item.meta"
+                  data-garden-version="9.0.0"
+                >
+                  Meta
+                </div>
+              </div>
+            </li>
+            <li
+              class="c9 c10 c19 "
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="none"
+            >
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c9 c10 c20 "
+                  data-garden-id="dropdowns.menu.item"
+                  data-garden-version="9.0.0"
+                >
+                  Group 1
+                </div>
+                <ul
+                  aria-label="Group 1"
+                  class="c21 c22 "
+                  data-garden-container-id="containers.menu.item_group"
+                  data-garden-container-version="0.5.0"
+                  data-garden-id="dropdowns.menu.item_group"
+                  data-garden-version="9.0.0"
+                  role="group"
+                >
+                  <li
+                    class="c23 c24 "
+                    data-garden-id="dropdowns.menu.separator"
+                    data-garden-version="9.0.0"
+                    role="none"
+                  />
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 1
+                    </div>
+                  </li>
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <svg
+                      class=" c17 "
+                      data-garden-id="dropdowns.menu.item.icon"
+                      data-garden-version="9.0.0"
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 2
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li
+              class="c23 c24 "
+              data-garden-container-id="containers.menu.separator"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.separator"
+              data-garden-version="9.0.0"
+              role="separator"
+            />
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 4
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with fallback placements 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r8:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r8:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with fallback placements and a custom triggerRef 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":rd:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":rd:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders default MenuStory 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r0:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r0:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/dropdowns/demo/stories/__snapshots__/MenuStory.spec.tsx.snap
+++ b/packages/dropdowns/demo/stories/__snapshots__/MenuStory.spec.tsx.snap
@@ -270,18 +270,18 @@ exports[`MenuStory Component renders MenuStory with a custom maxHeight 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -293,7 +293,7 @@ exports[`MenuStory Component renders MenuStory with a custom maxHeight 1`] = `
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r4:-menu-trigger"
           role="button"
           tabindex="0"
@@ -303,7 +303,7 @@ exports[`MenuStory Component renders MenuStory with a custom maxHeight 1`] = `
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -320,7 +320,7 @@ exports[`MenuStory Component renders MenuStory with a custom maxHeight 1`] = `
           class="c6 "
           data-garden-animate="false"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -330,7 +330,7 @@ exports[`MenuStory Component renders MenuStory with a custom maxHeight 1`] = `
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           />
@@ -611,18 +611,18 @@ exports[`MenuStory Component renders MenuStory with a custom minHeight 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -634,7 +634,7 @@ exports[`MenuStory Component renders MenuStory with a custom minHeight 1`] = `
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r5:-menu-trigger"
           role="button"
           tabindex="0"
@@ -644,7 +644,7 @@ exports[`MenuStory Component renders MenuStory with a custom minHeight 1`] = `
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -661,7 +661,7 @@ exports[`MenuStory Component renders MenuStory with a custom minHeight 1`] = `
           class="c6 "
           data-garden-animate="false"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -671,7 +671,7 @@ exports[`MenuStory Component renders MenuStory with a custom minHeight 1`] = `
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           />
@@ -952,18 +952,18 @@ exports[`MenuStory Component renders MenuStory with a custom placement 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -975,7 +975,7 @@ exports[`MenuStory Component renders MenuStory with a custom placement 1`] = `
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r7:-menu-trigger"
           role="button"
           tabindex="0"
@@ -985,7 +985,7 @@ exports[`MenuStory Component renders MenuStory with a custom placement 1`] = `
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -1002,7 +1002,7 @@ exports[`MenuStory Component renders MenuStory with a custom placement 1`] = `
           class="c6 "
           data-garden-animate="false"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -1012,7 +1012,7 @@ exports[`MenuStory Component renders MenuStory with a custom placement 1`] = `
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           />
@@ -1293,18 +1293,18 @@ exports[`MenuStory Component renders MenuStory with a custom triggerRef 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -1316,7 +1316,7 @@ exports[`MenuStory Component renders MenuStory with a custom triggerRef 1`] = `
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r9:-menu-trigger"
           role="button"
           tabindex="0"
@@ -1326,7 +1326,7 @@ exports[`MenuStory Component renders MenuStory with a custom triggerRef 1`] = `
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -1343,7 +1343,7 @@ exports[`MenuStory Component renders MenuStory with a custom triggerRef 1`] = `
           class="c6 "
           data-garden-animate="false"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -1353,7 +1353,7 @@ exports[`MenuStory Component renders MenuStory with a custom triggerRef 1`] = `
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           />
@@ -1634,18 +1634,18 @@ exports[`MenuStory Component renders MenuStory with a custom zIndex 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -1657,7 +1657,7 @@ exports[`MenuStory Component renders MenuStory with a custom zIndex 1`] = `
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r6:-menu-trigger"
           role="button"
           tabindex="0"
@@ -1667,7 +1667,7 @@ exports[`MenuStory Component renders MenuStory with a custom zIndex 1`] = `
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -1684,7 +1684,7 @@ exports[`MenuStory Component renders MenuStory with a custom zIndex 1`] = `
           class="c6 "
           data-garden-animate="false"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -1694,7 +1694,7 @@ exports[`MenuStory Component renders MenuStory with a custom zIndex 1`] = `
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           />
@@ -2126,7 +2126,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
   position: absolute;
   -webkit-transition: opacity 0.1s ease-in-out;
   transition: opacity 0.1s ease-in-out;
-  top: 10px;
+  top: 6px;
   left: 12px;
   width: 16px;
   height: 16px;
@@ -2236,18 +2236,18 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -2259,7 +2259,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rf:-menu-trigger"
           role="button"
           tabindex="0"
@@ -2269,7 +2269,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -2286,7 +2286,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
           class="c6 "
           data-garden-animate="true"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -2296,7 +2296,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           >
@@ -2305,7 +2305,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="0"
             >
@@ -2313,7 +2313,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -2331,7 +2331,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 1
               </div>
@@ -2341,7 +2341,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="-1"
             >
@@ -2349,7 +2349,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -2367,13 +2367,13 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
               <svg
                 class=" c17 "
                 data-garden-id="dropdowns.menu.item.icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 xmlns="http://www.w3.org/2000/svg"
               />
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 2
               </div>
@@ -2383,7 +2383,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="-1"
             >
@@ -2391,7 +2391,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -2409,13 +2409,13 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 3
                 <div
                   class="c18 "
                   data-garden-id="dropdowns.menu.item.meta"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 >
                   Meta
                 </div>
@@ -2424,18 +2424,18 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
             <li
               class="c9 c10 c19 "
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="none"
             >
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c9 c10 c20 "
                   data-garden-id="dropdowns.menu.item"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 >
                   Group 1
                 </div>
@@ -2445,13 +2445,13 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
                   data-garden-container-id="containers.menu.item_group"
                   data-garden-container-version="0.5.0"
                   data-garden-id="dropdowns.menu.item_group"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   role="group"
                 >
                   <li
                     class="c23 c24 "
                     data-garden-id="dropdowns.menu.separator"
-                    data-garden-version="9.0.0"
+                    data-garden-version="9.1.0"
                     role="none"
                   />
                   <li
@@ -2459,7 +2459,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
                     data-garden-container-id="containers.menu.item"
                     data-garden-container-version="0.5.0"
                     data-garden-id="dropdowns.menu.item"
-                    data-garden-version="9.0.0"
+                    data-garden-version="9.1.0"
                     role="menuitem"
                     tabindex="-1"
                   >
@@ -2467,7 +2467,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
                       aria-hidden="true"
                       class="c12 c13  c14 "
                       data-garden-id="dropdowns.menu.item.type_icon"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                       focusable="false"
                       height="16"
                       viewBox="0 0 16 16"
@@ -2485,7 +2485,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
                     <div
                       class="c15 c16 "
                       data-garden-id="dropdowns.menu.item.content"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                     >
                       Group Item 1
                     </div>
@@ -2495,7 +2495,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
                     data-garden-container-id="containers.menu.item"
                     data-garden-container-version="0.5.0"
                     data-garden-id="dropdowns.menu.item"
-                    data-garden-version="9.0.0"
+                    data-garden-version="9.1.0"
                     role="menuitem"
                     tabindex="-1"
                   >
@@ -2503,7 +2503,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
                       aria-hidden="true"
                       class="c12 c13  c14 "
                       data-garden-id="dropdowns.menu.item.type_icon"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                       focusable="false"
                       height="16"
                       viewBox="0 0 16 16"
@@ -2521,13 +2521,13 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
                     <svg
                       class=" c17 "
                       data-garden-id="dropdowns.menu.item.icon"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                       xmlns="http://www.w3.org/2000/svg"
                     />
                     <div
                       class="c15 c16 "
                       data-garden-id="dropdowns.menu.item.content"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                     >
                       Group Item 2
                     </div>
@@ -2540,7 +2540,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
               data-garden-container-id="containers.menu.separator"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.separator"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="separator"
             />
             <li
@@ -2548,7 +2548,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="-1"
             >
@@ -2556,7 +2556,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -2574,7 +2574,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 4
               </div>
@@ -2898,18 +2898,18 @@ exports[`MenuStory Component renders MenuStory with an arrow 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -2921,7 +2921,7 @@ exports[`MenuStory Component renders MenuStory with an arrow 1`] = `
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r2:-menu-trigger"
           role="button"
           tabindex="0"
@@ -2931,7 +2931,7 @@ exports[`MenuStory Component renders MenuStory with an arrow 1`] = `
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -2948,7 +2948,7 @@ exports[`MenuStory Component renders MenuStory with an arrow 1`] = `
           class="c6 "
           data-garden-animate="false"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -2958,7 +2958,7 @@ exports[`MenuStory Component renders MenuStory with an arrow 1`] = `
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           />
@@ -3239,18 +3239,18 @@ exports[`MenuStory Component renders MenuStory with compact styling 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -3262,7 +3262,7 @@ exports[`MenuStory Component renders MenuStory with compact styling 1`] = `
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r1:-menu-trigger"
           role="button"
           tabindex="0"
@@ -3272,7 +3272,7 @@ exports[`MenuStory Component renders MenuStory with compact styling 1`] = `
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -3289,7 +3289,7 @@ exports[`MenuStory Component renders MenuStory with compact styling 1`] = `
           class="c6 "
           data-garden-animate="false"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -3299,7 +3299,7 @@ exports[`MenuStory Component renders MenuStory with compact styling 1`] = `
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           />
@@ -3621,18 +3621,18 @@ exports[`MenuStory Component renders MenuStory with compact styling and an arrow
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -3644,7 +3644,7 @@ exports[`MenuStory Component renders MenuStory with compact styling and an arrow
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":ra:-menu-trigger"
           role="button"
           tabindex="0"
@@ -3654,7 +3654,7 @@ exports[`MenuStory Component renders MenuStory with compact styling and an arrow
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -3671,7 +3671,7 @@ exports[`MenuStory Component renders MenuStory with compact styling and an arrow
           class="c6 "
           data-garden-animate="false"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -3681,7 +3681,7 @@ exports[`MenuStory Component renders MenuStory with compact styling and an arrow
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           />
@@ -4113,7 +4113,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
   position: absolute;
   -webkit-transition: opacity 0.1s ease-in-out;
   transition: opacity 0.1s ease-in-out;
-  top: 10px;
+  top: 6px;
   left: 12px;
   width: 16px;
   height: 16px;
@@ -4221,18 +4221,18 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -4244,7 +4244,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":re:-menu-trigger"
           role="button"
           tabindex="0"
@@ -4254,7 +4254,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -4271,7 +4271,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
           class="c6 "
           data-garden-animate="true"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -4281,7 +4281,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           >
@@ -4290,7 +4290,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="0"
             >
@@ -4298,7 +4298,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -4316,7 +4316,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 1
               </div>
@@ -4326,7 +4326,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="-1"
             >
@@ -4334,7 +4334,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -4352,13 +4352,13 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
               <svg
                 class=" c17 "
                 data-garden-id="dropdowns.menu.item.icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 xmlns="http://www.w3.org/2000/svg"
               />
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 2
               </div>
@@ -4368,7 +4368,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="-1"
             >
@@ -4376,7 +4376,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -4394,13 +4394,13 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 3
                 <div
                   class="c18 "
                   data-garden-id="dropdowns.menu.item.meta"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 >
                   Meta
                 </div>
@@ -4409,18 +4409,18 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
             <li
               class="c9 c10 c19 "
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="none"
             >
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c9 c10 c20 "
                   data-garden-id="dropdowns.menu.item"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 >
                   Group 1
                 </div>
@@ -4430,13 +4430,13 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
                   data-garden-container-id="containers.menu.item_group"
                   data-garden-container-version="0.5.0"
                   data-garden-id="dropdowns.menu.item_group"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   role="group"
                 >
                   <li
                     class="c23 c24 "
                     data-garden-id="dropdowns.menu.separator"
-                    data-garden-version="9.0.0"
+                    data-garden-version="9.1.0"
                     role="none"
                   />
                   <li
@@ -4444,7 +4444,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
                     data-garden-container-id="containers.menu.item"
                     data-garden-container-version="0.5.0"
                     data-garden-id="dropdowns.menu.item"
-                    data-garden-version="9.0.0"
+                    data-garden-version="9.1.0"
                     role="menuitem"
                     tabindex="-1"
                   >
@@ -4452,7 +4452,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
                       aria-hidden="true"
                       class="c12 c13  c14 "
                       data-garden-id="dropdowns.menu.item.type_icon"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                       focusable="false"
                       height="16"
                       viewBox="0 0 16 16"
@@ -4470,7 +4470,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
                     <div
                       class="c15 c16 "
                       data-garden-id="dropdowns.menu.item.content"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                     >
                       Group Item 1
                     </div>
@@ -4480,7 +4480,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
                     data-garden-container-id="containers.menu.item"
                     data-garden-container-version="0.5.0"
                     data-garden-id="dropdowns.menu.item"
-                    data-garden-version="9.0.0"
+                    data-garden-version="9.1.0"
                     role="menuitem"
                     tabindex="-1"
                   >
@@ -4488,7 +4488,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
                       aria-hidden="true"
                       class="c12 c13  c14 "
                       data-garden-id="dropdowns.menu.item.type_icon"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                       focusable="false"
                       height="16"
                       viewBox="0 0 16 16"
@@ -4506,13 +4506,13 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
                     <svg
                       class=" c17 "
                       data-garden-id="dropdowns.menu.item.icon"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                       xmlns="http://www.w3.org/2000/svg"
                     />
                     <div
                       class="c15 c16 "
                       data-garden-id="dropdowns.menu.item.content"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                     >
                       Group Item 2
                     </div>
@@ -4525,7 +4525,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
               data-garden-container-id="containers.menu.separator"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.separator"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="separator"
             />
             <li
@@ -4533,7 +4533,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="-1"
             >
@@ -4541,7 +4541,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -4559,7 +4559,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 4
               </div>
@@ -4842,18 +4842,18 @@ exports[`MenuStory Component renders MenuStory with custom maxHeight, minHeight,
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -4865,7 +4865,7 @@ exports[`MenuStory Component renders MenuStory with custom maxHeight, minHeight,
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rc:-menu-trigger"
           role="button"
           tabindex="0"
@@ -4875,7 +4875,7 @@ exports[`MenuStory Component renders MenuStory with custom maxHeight, minHeight,
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -4892,7 +4892,7 @@ exports[`MenuStory Component renders MenuStory with custom maxHeight, minHeight,
           class="c6 "
           data-garden-animate="false"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -4902,7 +4902,7 @@ exports[`MenuStory Component renders MenuStory with custom maxHeight, minHeight,
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           />
@@ -5401,18 +5401,18 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -5424,7 +5424,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r3:-menu-trigger"
           role="button"
           tabindex="0"
@@ -5434,7 +5434,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -5451,7 +5451,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
           class="c6 "
           data-garden-animate="true"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -5461,7 +5461,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           >
@@ -5470,7 +5470,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="0"
             >
@@ -5478,7 +5478,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -5496,7 +5496,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 1
               </div>
@@ -5506,7 +5506,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="-1"
             >
@@ -5514,7 +5514,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -5532,13 +5532,13 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
               <svg
                 class=" c17 "
                 data-garden-id="dropdowns.menu.item.icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 xmlns="http://www.w3.org/2000/svg"
               />
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 2
               </div>
@@ -5548,7 +5548,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="-1"
             >
@@ -5556,7 +5556,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -5574,13 +5574,13 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 3
                 <div
                   class="c18 "
                   data-garden-id="dropdowns.menu.item.meta"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 >
                   Meta
                 </div>
@@ -5589,18 +5589,18 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
             <li
               class="c9 c10 c19 "
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="none"
             >
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c9 c10 c20 "
                   data-garden-id="dropdowns.menu.item"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 >
                   Group 1
                 </div>
@@ -5610,13 +5610,13 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
                   data-garden-container-id="containers.menu.item_group"
                   data-garden-container-version="0.5.0"
                   data-garden-id="dropdowns.menu.item_group"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   role="group"
                 >
                   <li
                     class="c23 c24 "
                     data-garden-id="dropdowns.menu.separator"
-                    data-garden-version="9.0.0"
+                    data-garden-version="9.1.0"
                     role="none"
                   />
                   <li
@@ -5624,7 +5624,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
                     data-garden-container-id="containers.menu.item"
                     data-garden-container-version="0.5.0"
                     data-garden-id="dropdowns.menu.item"
-                    data-garden-version="9.0.0"
+                    data-garden-version="9.1.0"
                     role="menuitem"
                     tabindex="-1"
                   >
@@ -5632,7 +5632,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
                       aria-hidden="true"
                       class="c12 c13  c14 "
                       data-garden-id="dropdowns.menu.item.type_icon"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                       focusable="false"
                       height="16"
                       viewBox="0 0 16 16"
@@ -5650,7 +5650,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
                     <div
                       class="c15 c16 "
                       data-garden-id="dropdowns.menu.item.content"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                     >
                       Group Item 1
                     </div>
@@ -5660,7 +5660,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
                     data-garden-container-id="containers.menu.item"
                     data-garden-container-version="0.5.0"
                     data-garden-id="dropdowns.menu.item"
-                    data-garden-version="9.0.0"
+                    data-garden-version="9.1.0"
                     role="menuitem"
                     tabindex="-1"
                   >
@@ -5668,7 +5668,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
                       aria-hidden="true"
                       class="c12 c13  c14 "
                       data-garden-id="dropdowns.menu.item.type_icon"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                       focusable="false"
                       height="16"
                       viewBox="0 0 16 16"
@@ -5686,13 +5686,13 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
                     <svg
                       class=" c17 "
                       data-garden-id="dropdowns.menu.item.icon"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                       xmlns="http://www.w3.org/2000/svg"
                     />
                     <div
                       class="c15 c16 "
                       data-garden-id="dropdowns.menu.item.content"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                     >
                       Group Item 2
                     </div>
@@ -5705,7 +5705,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
               data-garden-container-id="containers.menu.separator"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.separator"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="separator"
             />
             <li
@@ -5713,7 +5713,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="-1"
             >
@@ -5721,7 +5721,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -5739,7 +5739,7 @@ exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 4
               </div>
@@ -6240,18 +6240,18 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -6263,7 +6263,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rb:-menu-trigger"
           role="button"
           tabindex="0"
@@ -6273,7 +6273,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -6290,7 +6290,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
           class="c6 "
           data-garden-animate="true"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -6300,7 +6300,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           >
@@ -6309,7 +6309,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="0"
             >
@@ -6317,7 +6317,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -6335,7 +6335,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 1
               </div>
@@ -6345,7 +6345,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="-1"
             >
@@ -6353,7 +6353,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -6371,13 +6371,13 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
               <svg
                 class=" c17 "
                 data-garden-id="dropdowns.menu.item.icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 xmlns="http://www.w3.org/2000/svg"
               />
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 2
               </div>
@@ -6387,7 +6387,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="-1"
             >
@@ -6395,7 +6395,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -6413,13 +6413,13 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 3
                 <div
                   class="c18 "
                   data-garden-id="dropdowns.menu.item.meta"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 >
                   Meta
                 </div>
@@ -6428,18 +6428,18 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
             <li
               class="c9 c10 c19 "
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="none"
             >
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 <div
                   class="c9 c10 c20 "
                   data-garden-id="dropdowns.menu.item"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                 >
                   Group 1
                 </div>
@@ -6449,13 +6449,13 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
                   data-garden-container-id="containers.menu.item_group"
                   data-garden-container-version="0.5.0"
                   data-garden-id="dropdowns.menu.item_group"
-                  data-garden-version="9.0.0"
+                  data-garden-version="9.1.0"
                   role="group"
                 >
                   <li
                     class="c23 c24 "
                     data-garden-id="dropdowns.menu.separator"
-                    data-garden-version="9.0.0"
+                    data-garden-version="9.1.0"
                     role="none"
                   />
                   <li
@@ -6463,7 +6463,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
                     data-garden-container-id="containers.menu.item"
                     data-garden-container-version="0.5.0"
                     data-garden-id="dropdowns.menu.item"
-                    data-garden-version="9.0.0"
+                    data-garden-version="9.1.0"
                     role="menuitem"
                     tabindex="-1"
                   >
@@ -6471,7 +6471,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
                       aria-hidden="true"
                       class="c12 c13  c14 "
                       data-garden-id="dropdowns.menu.item.type_icon"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                       focusable="false"
                       height="16"
                       viewBox="0 0 16 16"
@@ -6489,7 +6489,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
                     <div
                       class="c15 c16 "
                       data-garden-id="dropdowns.menu.item.content"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                     >
                       Group Item 1
                     </div>
@@ -6499,7 +6499,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
                     data-garden-container-id="containers.menu.item"
                     data-garden-container-version="0.5.0"
                     data-garden-id="dropdowns.menu.item"
-                    data-garden-version="9.0.0"
+                    data-garden-version="9.1.0"
                     role="menuitem"
                     tabindex="-1"
                   >
@@ -6507,7 +6507,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
                       aria-hidden="true"
                       class="c12 c13  c14 "
                       data-garden-id="dropdowns.menu.item.type_icon"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                       focusable="false"
                       height="16"
                       viewBox="0 0 16 16"
@@ -6525,13 +6525,13 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
                     <svg
                       class=" c17 "
                       data-garden-id="dropdowns.menu.item.icon"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                       xmlns="http://www.w3.org/2000/svg"
                     />
                     <div
                       class="c15 c16 "
                       data-garden-id="dropdowns.menu.item.content"
-                      data-garden-version="9.0.0"
+                      data-garden-version="9.1.0"
                     >
                       Group Item 2
                     </div>
@@ -6544,7 +6544,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
               data-garden-container-id="containers.menu.separator"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.separator"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="separator"
             />
             <li
@@ -6552,7 +6552,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
               data-garden-container-id="containers.menu.item"
               data-garden-container-version="0.5.0"
               data-garden-id="dropdowns.menu.item"
-              data-garden-version="9.0.0"
+              data-garden-version="9.1.0"
               role="menuitem"
               tabindex="-1"
             >
@@ -6560,7 +6560,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
                 aria-hidden="true"
                 class="c12 c13  c14 "
                 data-garden-id="dropdowns.menu.item.type_icon"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
                 focusable="false"
                 height="16"
                 viewBox="0 0 16 16"
@@ -6578,7 +6578,7 @@ exports[`MenuStory Component renders MenuStory with expanded state and custom pl
               <div
                 class="c15 c16 "
                 data-garden-id="dropdowns.menu.item.content"
-                data-garden-version="9.0.0"
+                data-garden-version="9.1.0"
               >
                 Item 4
               </div>
@@ -6861,18 +6861,18 @@ exports[`MenuStory Component renders MenuStory with fallback placements 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -6884,7 +6884,7 @@ exports[`MenuStory Component renders MenuStory with fallback placements 1`] = `
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r8:-menu-trigger"
           role="button"
           tabindex="0"
@@ -6894,7 +6894,7 @@ exports[`MenuStory Component renders MenuStory with fallback placements 1`] = `
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -6911,7 +6911,7 @@ exports[`MenuStory Component renders MenuStory with fallback placements 1`] = `
           class="c6 "
           data-garden-animate="false"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -6921,7 +6921,7 @@ exports[`MenuStory Component renders MenuStory with fallback placements 1`] = `
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           />
@@ -7202,18 +7202,18 @@ exports[`MenuStory Component renders MenuStory with fallback placements and a cu
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -7225,7 +7225,7 @@ exports[`MenuStory Component renders MenuStory with fallback placements and a cu
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":rd:-menu-trigger"
           role="button"
           tabindex="0"
@@ -7235,7 +7235,7 @@ exports[`MenuStory Component renders MenuStory with fallback placements and a cu
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -7252,7 +7252,7 @@ exports[`MenuStory Component renders MenuStory with fallback placements and a cu
           class="c6 "
           data-garden-animate="false"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -7262,7 +7262,7 @@ exports[`MenuStory Component renders MenuStory with fallback placements and a cu
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           />
@@ -7543,18 +7543,18 @@ exports[`MenuStory Component renders default MenuStory 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: 800px;"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         style="display: inline-block; position: relative; width: 200px;"
@@ -7566,7 +7566,7 @@ exports[`MenuStory Component renders default MenuStory 1`] = `
           data-garden-container-id="containers.menu.trigger"
           data-garden-container-version="0.5.0"
           data-garden-id="buttons.button"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           id=":r0:-menu-trigger"
           role="button"
           tabindex="0"
@@ -7576,7 +7576,7 @@ exports[`MenuStory Component renders default MenuStory 1`] = `
             aria-hidden="true"
             class="c4  c5"
             data-garden-id="buttons.icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
@@ -7593,7 +7593,7 @@ exports[`MenuStory Component renders default MenuStory 1`] = `
           class="c6 "
           data-garden-animate="false"
           data-garden-id="dropdowns.menu.floating"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="transform: translate(0px, 0px);"
         >
           <ul
@@ -7603,7 +7603,7 @@ exports[`MenuStory Component renders default MenuStory 1`] = `
             data-garden-container-id="containers.menu"
             data-garden-container-version="0.5.0"
             data-garden-id="dropdowns.menu"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             role="menu"
             tabindex="-1"
           />

--- a/packages/forms/demo/stories/CheckboxStory.spec.tsx
+++ b/packages/forms/demo/stories/CheckboxStory.spec.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { CheckboxStory } from './CheckboxStory';
+
+const renderAndMatchSnapshot = (Component: React.ComponentType<any>, props: any) => {
+  const { container } = render(<Component {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe(`CheckboxStory Component`, () => {
+  it('renders default component', () => {
+    renderAndMatchSnapshot(CheckboxStory, {});
+  });
+
+  it('renders component with a label', () => {
+    renderAndMatchSnapshot(CheckboxStory, { hasLabel: true, label: 'Accept Terms' });
+  });
+
+  it('renders component with a hidden label', () => {
+    renderAndMatchSnapshot(CheckboxStory, { hasLabel: false, label: 'Accept Terms' });
+  });
+
+  it('renders component with a hint', () => {
+    renderAndMatchSnapshot(CheckboxStory, { hasHint: true, hint: 'This is a hint' });
+  });
+
+  it('renders component with a message', () => {
+    renderAndMatchSnapshot(CheckboxStory, { hasMessage: true, message: 'This is a message' });
+  });
+
+  it('renders component with validation success', () => {
+    renderAndMatchSnapshot(CheckboxStory, { validation: 'success' });
+  });
+
+  it('renders component with validation error', () => {
+    renderAndMatchSnapshot(CheckboxStory, { validation: 'error' });
+  });
+
+  it('renders component with validation warning', () => {
+    renderAndMatchSnapshot(CheckboxStory, { validation: 'warning' });
+  });
+
+  it('renders component with a label, hint, and message', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message'
+    });
+  });
+
+  it('renders component with a label, hidden label, and validation success', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: false,
+      label: 'Accept Terms',
+      validation: 'success'
+    });
+  });
+
+  it('renders component with a label, hint, message, and validation error', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      validation: 'error'
+    });
+  });
+
+  it('renders component with a label, hidden label, hint, and validation warning', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: false,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      validation: 'warning'
+    });
+  });
+
+  it('renders component with a disabled state', () => {
+    renderAndMatchSnapshot(CheckboxStory, { disabled: true });
+  });
+
+  it('renders component with a read-only state', () => {
+    renderAndMatchSnapshot(CheckboxStory, { readOnly: true });
+  });
+
+  it('renders component with a required state', () => {
+    renderAndMatchSnapshot(CheckboxStory, { required: true });
+  });
+
+  it('renders component with a checked state', () => {
+    renderAndMatchSnapshot(CheckboxStory, { checked: true });
+  });
+
+  it('renders component with label, hint, message, and disabled state', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      disabled: true
+    });
+  });
+
+  it('renders component with label, hidden label, validation success, and read-only state', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: false,
+      label: 'Accept Terms',
+      validation: 'success',
+      readOnly: true
+    });
+  });
+
+  it('renders component with label, hint, message, validation error, and required state', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      validation: 'error',
+      required: true
+    });
+  });
+
+  it('renders component with compact styling', () => {
+    renderAndMatchSnapshot(CheckboxStory, { isCompact: true });
+  });
+
+  it('renders component with a label and compact styling', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      isCompact: true
+    });
+  });
+
+  it('renders component with a label, hint, and compact styling', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint',
+      isCompact: true
+    });
+  });
+
+  it('renders component with a label, message, and compact styling', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      hasMessage: true,
+      message: 'This is a message',
+      isCompact: true
+    });
+  });
+
+  it('renders component with a label, hint, message, and compact styling', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      isCompact: true
+    });
+  });
+});

--- a/packages/forms/demo/stories/FauxInputStory.spec.tsx
+++ b/packages/forms/demo/stories/FauxInputStory.spec.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { FauxInputStory } from './FauxInputStory';
+
+export const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<FauxInputStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('FauxInputStory Component', () => {
+  it('renders default FauxInputStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  it('renders FauxInputStory with a label', () => {
+    renderAndMatchSnapshot({ label: 'Username' });
+  });
+
+  it('renders FauxInputStory with a regular label', () => {
+    renderAndMatchSnapshot({ label: 'Username', isLabelRegular: true });
+  });
+
+  it('renders FauxInputStory with a hidden label', () => {
+    renderAndMatchSnapshot({ label: 'Username', isLabelHidden: true });
+  });
+
+  it('renders FauxInputStory with a hint', () => {
+    renderAndMatchSnapshot({ label: 'Username', hasHint: true, hint: 'Enter your username' });
+  });
+
+  it('renders FauxInputStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  it('renders FauxInputStory with a validation label', () => {
+    renderAndMatchSnapshot({ label: 'Username', validationLabel: 'Invalid username' });
+  });
+
+  it('renders FauxInputStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  it('renders FauxInputStory with a label, hidden label, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelHidden: true,
+      validationLabel: 'Invalid username'
+    });
+  });
+
+  it('renders FauxInputStory with a label, regular label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  it('renders FauxInputStory with a label, hidden label, hint, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      validationLabel: 'Invalid username'
+    });
+  });
+
+  it('renders FauxInputStory with a label, regular label, hint, message, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid username'
+    });
+  });
+
+  it('renders FauxInputStory with a placeholder', () => {
+    renderAndMatchSnapshot({ placeholder: 'Enter your username' });
+  });
+
+  it('renders FauxInputStory with a value', () => {
+    renderAndMatchSnapshot({ value: 'JohnDoe' });
+  });
+
+  it('renders FauxInputStory with a disabled input', () => {
+    renderAndMatchSnapshot({ disabled: true });
+  });
+
+  it('renders FauxInputStory with compact styling', () => {
+    renderAndMatchSnapshot({ isCompact: true });
+  });
+
+  it('renders FauxInputStory with bare styling', () => {
+    renderAndMatchSnapshot({ isBare: true });
+  });
+
+  it('renders FauxInputStory with a read-only input', () => {
+    renderAndMatchSnapshot({ readOnly: true });
+  });
+
+  it('renders FauxInputStory with a required input', () => {
+    renderAndMatchSnapshot({ required: true });
+  });
+
+  it('renders FauxInputStory with validation success', () => {
+    renderAndMatchSnapshot({ validation: 'success' });
+  });
+
+  it('renders FauxInputStory with validation error', () => {
+    renderAndMatchSnapshot({ validation: 'error' });
+  });
+
+  it('renders FauxInputStory with validation warning', () => {
+    renderAndMatchSnapshot({ validation: 'warning' });
+  });
+
+  it('renders FauxInputStory with label, hint, message, and compact input', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required',
+      isCompact: true
+    });
+  });
+
+  it('renders FauxInputStory with label, hidden label, validation label, and bare input', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelHidden: true,
+      validationLabel: 'Invalid username',
+      isBare: true
+    });
+  });
+
+  it('renders FauxInputStory with label, regular label, hint, message, validation label, and disabled input', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid username',
+      disabled: true
+    });
+  });
+});

--- a/packages/forms/demo/stories/FileListStory.spec.tsx
+++ b/packages/forms/demo/stories/FileListStory.spec.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { FileListStory } from './FileListStory';
+import { FILELIST_ITEMS } from './data';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<FileListStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('FileListStory Component', () => {
+  it('renders default FileListStory with no items', () => {
+    renderAndMatchSnapshot({ items: [] });
+  });
+
+  it('renders FileListStory with a single item', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[0]]
+    });
+  });
+
+  it('renders FileListStory with multiple items', () => {
+    renderAndMatchSnapshot({
+      items: FILELIST_ITEMS
+    });
+  });
+
+  it('renders FileListStory with compact styling', () => {
+    renderAndMatchSnapshot({
+      items: FILELIST_ITEMS,
+      isCompact: true
+    });
+  });
+
+  it('renders FileListStory with an item that has a close button', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[1]]
+    });
+  });
+
+  it('renders FileListStory with an item that has a delete button', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[7]]
+    });
+  });
+
+  it('renders FileListStory with a file that has progress', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[2]]
+    });
+  });
+
+  it('renders FileListStory with multiple items, one with close and one with delete', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[1], FILELIST_ITEMS[7]]
+    });
+  });
+
+  it('renders FileListStory with multiple items, one with progress and one without', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[0], FILELIST_ITEMS[2]]
+    });
+  });
+
+  it('renders FileListStory with all file types', () => {
+    renderAndMatchSnapshot({
+      items: FILELIST_ITEMS
+    });
+  });
+
+  it('renders FileListStory with compact styling and a close button', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[1]],
+      isCompact: true
+    });
+  });
+
+  it('renders FileListStory with compact styling and a delete button', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[7]],
+      isCompact: true
+    });
+  });
+
+  it('renders FileListStory with compact styling and progress', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[2]],
+      isCompact: true
+    });
+  });
+
+  it('renders FileListStory with compact styling and multiple items', () => {
+    renderAndMatchSnapshot({
+      items: FILELIST_ITEMS,
+      isCompact: true
+    });
+  });
+
+  it('renders FileListStory with aria labels for close and delete buttons', () => {
+    renderAndMatchSnapshot({
+      items: FILELIST_ITEMS,
+      closeAriaLabel: 'Close file',
+      deleteAriaLabel: 'Delete file'
+    });
+  });
+
+  it('renders FileListStory with compact styling, aria labels, and multiple items', () => {
+    renderAndMatchSnapshot({
+      items: FILELIST_ITEMS,
+      isCompact: true,
+      closeAriaLabel: 'Close file',
+      deleteAriaLabel: 'Delete file'
+    });
+  });
+});

--- a/packages/forms/demo/stories/InputGroupStory.spec.tsx
+++ b/packages/forms/demo/stories/InputGroupStory.spec.tsx
@@ -1,0 +1,278 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { InputGroupStory } from './InputGroupStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<InputGroupStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('InputGroupStory Component', () => {
+  it('renders default InputGroupStory', () => {
+    renderAndMatchSnapshot({
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with a label', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with a hint', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      hint: 'Enter your username',
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with validation success', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      validation: 'success',
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with validation error', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      validation: 'error',
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with validation warning', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      validation: 'warning',
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with compact styling', () => {
+    renderAndMatchSnapshot({
+      isCompact: true,
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with bare styling', () => {
+    renderAndMatchSnapshot({
+      isBare: true,
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with disabled input group', () => {
+    renderAndMatchSnapshot({
+      disabled: true,
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with readOnly input group', () => {
+    renderAndMatchSnapshot({
+      readOnly: true,
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with isNeutral', () => {
+    renderAndMatchSnapshot({
+      isNeutral: true,
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with isPrimary', () => {
+    renderAndMatchSnapshot({
+      isPrimary: true,
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with isDanger', () => {
+    renderAndMatchSnapshot({
+      isDanger: true,
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with a single text input', () => {
+    renderAndMatchSnapshot({
+      items: [{ text: 'Enter text', isButton: false }]
+    });
+  });
+
+  it('renders InputGroupStory with a single button', () => {
+    renderAndMatchSnapshot({
+      items: [{ text: 'Submit', isButton: true }]
+    });
+  });
+
+  it('renders InputGroupStory with a text input and a button', () => {
+    renderAndMatchSnapshot({
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with isNeutral styling', () => {
+    renderAndMatchSnapshot({
+      isNeutral: true,
+      items: [{ text: 'Enter text', isButton: false }]
+    });
+  });
+
+  it('renders InputGroupStory with isPrimary styling', () => {
+    renderAndMatchSnapshot({
+      isPrimary: true,
+      items: [{ text: 'Enter text', isButton: false }]
+    });
+  });
+
+  it('renders InputGroupStory with isDanger styling', () => {
+    renderAndMatchSnapshot({
+      isDanger: true,
+      items: [{ text: 'Enter text', isButton: false }]
+    });
+  });
+
+  it('renders InputGroupStory with disabled input group', () => {
+    renderAndMatchSnapshot({
+      disabled: true,
+      items: [{ text: 'Enter text', isButton: false }]
+    });
+  });
+
+  it('renders InputGroupStory with readOnly input group', () => {
+    renderAndMatchSnapshot({
+      readOnly: true,
+      items: [{ text: 'Enter text', isButton: false }]
+    });
+  });
+
+  it('renders InputGroupStory with multiple buttons', () => {
+    renderAndMatchSnapshot({
+      items: [
+        { text: 'Button 1', isButton: true },
+        { text: 'Button 2', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with multiple text inputs', () => {
+    renderAndMatchSnapshot({
+      items: [
+        { text: 'First input', isButton: false },
+        { text: 'Second input', isButton: false }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with a mix of text inputs and buttons', () => {
+    renderAndMatchSnapshot({
+      items: [
+        { text: 'First input', isButton: false },
+        { text: 'Submit', isButton: true },
+        { text: 'Second input', isButton: false }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with isNeutral and multiple items', () => {
+    renderAndMatchSnapshot({
+      isNeutral: true,
+      items: [
+        { text: 'First input', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with isPrimary and multiple items', () => {
+    renderAndMatchSnapshot({
+      isPrimary: true,
+      items: [
+        { text: 'First input', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with isDanger and multiple items', () => {
+    renderAndMatchSnapshot({
+      isDanger: true,
+      items: [
+        { text: 'First input', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with disabled and multiple items', () => {
+    renderAndMatchSnapshot({
+      disabled: true,
+      items: [
+        { text: 'First input', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with readOnly and multiple items', () => {
+    renderAndMatchSnapshot({
+      readOnly: true,
+      items: [
+        { text: 'First input', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+});

--- a/packages/forms/demo/stories/InputStory.spec.tsx
+++ b/packages/forms/demo/stories/InputStory.spec.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { InputStory } from './InputStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<InputStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('InputStory Component', () => {
+  it('renders default InputStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  it('renders InputStory with a label', () => {
+    renderAndMatchSnapshot({ label: 'Username' });
+  });
+
+  it('renders InputStory with a regular label', () => {
+    renderAndMatchSnapshot({ label: 'Username', isLabelRegular: true });
+  });
+
+  it('renders InputStory with a hidden label', () => {
+    renderAndMatchSnapshot({ label: 'Username', isLabelHidden: true });
+  });
+
+  it('renders InputStory with a hint', () => {
+    renderAndMatchSnapshot({ label: 'Username', hasHint: true, hint: 'Enter your username' });
+  });
+
+  it('renders InputStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  it('renders InputStory with a validation label', () => {
+    renderAndMatchSnapshot({ label: 'Username', validationLabel: 'Invalid username' });
+  });
+
+  it('renders InputStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  it('renders InputStory with a label, hidden label, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelHidden: true,
+      validationLabel: 'Invalid username'
+    });
+  });
+
+  it('renders InputStory with a label, regular label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  it('renders InputStory with a label, hidden label, hint, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      validationLabel: 'Invalid username'
+    });
+  });
+
+  it('renders InputStory with a label, regular label, hint, message, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid username'
+    });
+  });
+
+  it('renders InputStory with a placeholder', () => {
+    renderAndMatchSnapshot({ placeholder: 'Enter your username' });
+  });
+
+  it('renders InputStory with a value', () => {
+    renderAndMatchSnapshot({ value: 'JohnDoe' });
+  });
+
+  it('renders InputStory with a disabled input', () => {
+    renderAndMatchSnapshot({ disabled: true });
+  });
+
+  it('renders InputStory with compact styling', () => {
+    renderAndMatchSnapshot({ isCompact: true });
+  });
+
+  it('renders InputStory with bare styling', () => {
+    renderAndMatchSnapshot({ isBare: true });
+  });
+
+  it('renders InputStory with type password', () => {
+    renderAndMatchSnapshot({ type: 'password' });
+  });
+
+  it('renders InputStory with a read-only input', () => {
+    renderAndMatchSnapshot({ readOnly: true });
+  });
+
+  it('renders InputStory with a required input', () => {
+    renderAndMatchSnapshot({ required: true });
+  });
+
+  it('renders InputStory with validation success', () => {
+    renderAndMatchSnapshot({ validation: 'success' });
+  });
+
+  it('renders InputStory with validation error', () => {
+    renderAndMatchSnapshot({ validation: 'error' });
+  });
+
+  it('renders InputStory with validation warning', () => {
+    renderAndMatchSnapshot({ validation: 'warning' });
+  });
+
+  it('renders InputStory with label, hint, message, and compact input', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required',
+      isCompact: true
+    });
+  });
+
+  it('renders InputStory with label, hidden label, validation label, and bare input', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelHidden: true,
+      validationLabel: 'Invalid username',
+      isBare: true
+    });
+  });
+
+  it('renders InputStory with label, regular label, hint, message, validation label, and disabled input', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid username',
+      disabled: true
+    });
+  });
+});

--- a/packages/forms/demo/stories/MediaInputStory.spec.tsx
+++ b/packages/forms/demo/stories/MediaInputStory.spec.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { MediaInputStory } from './MediaInputStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<MediaInputStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('MediaInputStory Component', () => {
+  // Test default rendering
+  it('renders default MediaInputStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  // Test with label
+  it('renders MediaInputStory with a label', () => {
+    renderAndMatchSnapshot({ label: 'Search' });
+  });
+
+  // Test with regular label
+  it('renders MediaInputStory with a regular label', () => {
+    renderAndMatchSnapshot({ label: 'Search', isLabelRegular: true });
+  });
+
+  // Test with hidden label
+  it('renders MediaInputStory with a hidden label', () => {
+    renderAndMatchSnapshot({ label: 'Search', isLabelHidden: true });
+  });
+
+  // Test with hint
+  it('renders MediaInputStory with a hint', () => {
+    renderAndMatchSnapshot({ label: 'Search', hasHint: true, hint: 'Enter a search term' });
+  });
+
+  // Test with message
+  it('renders MediaInputStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  // Test with validation label
+  it('renders MediaInputStory with a validation label', () => {
+    renderAndMatchSnapshot({ label: 'Search', validationLabel: 'Invalid search term' });
+  });
+
+  // Test with start icon
+  it('renders MediaInputStory with a start icon', () => {
+    renderAndMatchSnapshot({ start: true });
+  });
+
+  // Test with end icon
+  it('renders MediaInputStory with an end icon', () => {
+    renderAndMatchSnapshot({ end: true });
+  });
+
+  // Test with both start and end icons
+  it('renders MediaInputStory with both start and end icons', () => {
+    renderAndMatchSnapshot({ start: true, end: true });
+  });
+
+  // Test with label, hint, and message
+  it('renders MediaInputStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      hasHint: true,
+      hint: 'Enter a search term',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  // Test with label, hidden label, and validation label
+  it('renders MediaInputStory with a label, hidden label, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      isLabelHidden: true,
+      validationLabel: 'Invalid search term'
+    });
+  });
+
+  // Test with label, regular label, hint, and message
+  it('renders MediaInputStory with a label, regular label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter a search term',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  // Test with label, hidden label, hint, and validation label
+  it('renders MediaInputStory with a label, hidden label, hint, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Enter a search term',
+      validationLabel: 'Invalid search term'
+    });
+  });
+
+  // Test with label, regular label, hint, message, and validation label
+  it('renders MediaInputStory with a label, regular label, hint, message, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter a search term',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid search term'
+    });
+  });
+
+  // Test with Input props: disabled
+  it('renders MediaInputStory with a disabled input', () => {
+    renderAndMatchSnapshot({ disabled: true });
+  });
+
+  // Test with Input props: compact styling
+  it('renders MediaInputStory with compact styling', () => {
+    renderAndMatchSnapshot({ isCompact: true });
+  });
+
+  // Test with Input props: bare styling
+  it('renders MediaInputStory with bare styling', () => {
+    renderAndMatchSnapshot({ isBare: true });
+  });
+
+  // Test with Input props: readOnly
+  it('renders MediaInputStory with a read-only input', () => {
+    renderAndMatchSnapshot({ readOnly: true });
+  });
+
+  // Test with Input props: required
+  it('renders MediaInputStory with a required input', () => {
+    renderAndMatchSnapshot({ required: true });
+  });
+
+  // Test with Input props: validation success
+  it('renders MediaInputStory with validation success', () => {
+    renderAndMatchSnapshot({ validation: 'success' });
+  });
+
+  // Test with Input props: validation error
+  it('renders MediaInputStory with validation error', () => {
+    renderAndMatchSnapshot({ validation: 'error' });
+  });
+
+  // Test with Input props: validation warning
+  it('renders MediaInputStory with validation warning', () => {
+    renderAndMatchSnapshot({ validation: 'warning' });
+  });
+
+  // Test with combined FieldStory and MediaInput props
+  it('renders MediaInputStory with label, hint, message, and compact input', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      hasHint: true,
+      hint: 'Enter a search term',
+      hasMessage: true,
+      message: 'This field is required',
+      isCompact: true
+    });
+  });
+
+  it('renders MediaInputStory with label, hidden label, validation label, and bare input', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      isLabelHidden: true,
+      validationLabel: 'Invalid search term',
+      isBare: true
+    });
+  });
+
+  it('renders MediaInputStory with label, regular label, hint, message, validation label, and disabled input', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter a search term',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid search term',
+      disabled: true
+    });
+  });
+});

--- a/packages/forms/demo/stories/RadioStory.spec.tsx
+++ b/packages/forms/demo/stories/RadioStory.spec.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { RadioStory } from './RadioStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<RadioStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('RadioStory Component', () => {
+  it('renders default RadioStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  it('renders RadioStory with a label', () => {
+    renderAndMatchSnapshot({ hasLabel: true });
+  });
+
+  it('renders RadioStory without a label', () => {
+    renderAndMatchSnapshot({ hasLabel: false });
+  });
+
+  it('renders RadioStory with a hint', () => {
+    renderAndMatchSnapshot({ hasHint: true, hint: 'This is a hint' });
+  });
+
+  it('renders RadioStory with a message', () => {
+    renderAndMatchSnapshot({ hasMessage: true, message: 'This is a message' });
+  });
+
+  it('renders RadioStory with a label and hint', () => {
+    renderAndMatchSnapshot({
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint'
+    });
+  });
+
+  it('renders RadioStory with a label and message', () => {
+    renderAndMatchSnapshot({
+      hasLabel: true,
+      hasMessage: true,
+      message: 'This is a message'
+    });
+  });
+
+  it('renders RadioStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message'
+    });
+  });
+
+  it('renders RadioStory with compact styling', () => {
+    renderAndMatchSnapshot({ isCompact: true });
+  });
+
+  it('renders RadioStory with a label and compact styling', () => {
+    renderAndMatchSnapshot({
+      hasLabel: true,
+      isCompact: true
+    });
+  });
+
+  it('renders RadioStory with a label, hint, and compact styling', () => {
+    renderAndMatchSnapshot({
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint',
+      isCompact: true
+    });
+  });
+
+  it('renders RadioStory with a label, message, and compact styling', () => {
+    renderAndMatchSnapshot({
+      hasLabel: true,
+      hasMessage: true,
+      message: 'This is a message',
+      isCompact: true
+    });
+  });
+
+  it('renders RadioStory with a label, hint, message, and compact styling', () => {
+    renderAndMatchSnapshot({
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      isCompact: true
+    });
+  });
+});

--- a/packages/forms/demo/stories/SelectStory.spec.tsx
+++ b/packages/forms/demo/stories/SelectStory.spec.tsx
@@ -1,0 +1,239 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components'; // For styled-components snapshot testing
+import { SelectStory } from './SelectStory'; // Assuming SelectStory is the default export
+
+// Define a helper function to render the component and match snapshot
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<SelectStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('SelectStory Component', () => {
+  // Test default rendering
+  it('renders default SelectStory', () => {
+    renderAndMatchSnapshot({ options: ['Option 1', 'Option 2', 'Option 3'] });
+  });
+
+  // Test with label
+  it('renders SelectStory with a label', () => {
+    renderAndMatchSnapshot({ label: 'Select an option', options: ['Option 1', 'Option 2'] });
+  });
+
+  // Test with regular label
+  it('renders SelectStory with a regular label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelRegular: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with hidden label
+  it('renders SelectStory with a hidden label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelHidden: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with hint
+  it('renders SelectStory with a hint', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      hasHint: true,
+      hint: 'Choose wisely',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with message
+  it('renders SelectStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      hasMessage: true,
+      message: 'This field is required',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with validation label
+  it('renders SelectStory with a validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      validationLabel: 'Invalid selection',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with label, hint, and message
+  it('renders SelectStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      hasHint: true,
+      hint: 'Choose wisely',
+      hasMessage: true,
+      message: 'This field is required',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with label, hidden label, and validation label
+  it('renders SelectStory with a label, hidden label, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelHidden: true,
+      validationLabel: 'Invalid selection',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with label, regular label, hint, and message
+  it('renders SelectStory with a label, regular label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Choose wisely',
+      hasMessage: true,
+      message: 'This field is required',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with label, hidden label, hint, and validation label
+  it('renders SelectStory with a label, hidden label, hint, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Choose wisely',
+      validationLabel: 'Invalid selection',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with label, regular label, hint, message, and validation label
+  it('renders SelectStory with a label, regular label, hint, message, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Choose wisely',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid selection',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with Select props: disabled
+  it('renders SelectStory with a disabled select', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      disabled: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with Select props: compact styling
+  it('renders SelectStory with compact styling', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isCompact: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with Select props: bare styling
+  it('renders SelectStory with bare styling', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isBare: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with Select props: open state
+  it('renders SelectStory with the select open', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isOpen: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with Select props: focus inset
+  it('renders SelectStory with focus inset', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      focusInset: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with validation success
+  it('renders SelectStory with validation success', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      validation: 'success',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with validation error
+  it('renders SelectStory with validation error', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      validation: 'error',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with validation warning
+  it('renders SelectStory with validation warning', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      validation: 'warning',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with combined FieldStory and Select props
+  it('renders SelectStory with label, hint, message, and compact select', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      hasHint: true,
+      hint: 'Choose wisely',
+      hasMessage: true,
+      message: 'This field is required',
+      isCompact: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  it('renders SelectStory with label, hidden label, validation label, and bare select', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelHidden: true,
+      validationLabel: 'Invalid selection',
+      isBare: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  it('renders SelectStory with label, regular label, hint, message, validation label, and disabled select', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Choose wisely',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid selection',
+      disabled: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+});

--- a/packages/forms/demo/stories/TextareaStory.spec.tsx
+++ b/packages/forms/demo/stories/TextareaStory.spec.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components'; // For styled-components snapshot testing
+import { TextareaStory } from './TextareaStory'; // Assuming TextareaStory is the default export
+
+// Define a helper function to render the component and match snapshot
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<TextareaStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('TextareaStory Component', () => {
+  // Test default rendering
+  it('renders default TextareaStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  // Test with label
+  it('renders TextareaStory with a label', () => {
+    renderAndMatchSnapshot({ label: 'Description' });
+  });
+
+  // Test with regular label
+  it('renders TextareaStory with a regular label', () => {
+    renderAndMatchSnapshot({ label: 'Description', isLabelRegular: true });
+  });
+
+  // Test with hidden label
+  it('renders TextareaStory with a hidden label', () => {
+    renderAndMatchSnapshot({ label: 'Description', isLabelHidden: true });
+  });
+
+  // Test with hint
+  it('renders TextareaStory with a hint', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      hasHint: true,
+      hint: 'Enter a brief description'
+    });
+  });
+
+  // Test with message
+  it('renders TextareaStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  // Test with validation label
+  it('renders TextareaStory with a validation label', () => {
+    renderAndMatchSnapshot({ label: 'Description', validationLabel: 'Invalid description' });
+  });
+
+  // Test with label, hint, and message
+  it('renders TextareaStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      hasHint: true,
+      hint: 'Enter a brief description',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  // Test with label, hidden label, and validation label
+  it('renders TextareaStory with a label, hidden label, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      isLabelHidden: true,
+      validationLabel: 'Invalid description'
+    });
+  });
+
+  // Test with label, regular label, hint, and message
+  it('renders TextareaStory with a label, regular label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter a brief description',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  // Test with label, hidden label, hint, and validation label
+  it('renders TextareaStory with a label, hidden label, hint, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Enter a brief description',
+      validationLabel: 'Invalid description'
+    });
+  });
+
+  // Test with label, regular label, hint, message, and validation label
+  it('renders TextareaStory with a label, regular label, hint, message, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter a brief description',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid description'
+    });
+  });
+
+  // Test with Textarea props: placeholder
+  it('renders TextareaStory with a placeholder', () => {
+    renderAndMatchSnapshot({ placeholder: 'Enter your description' });
+  });
+
+  // Test with Textarea props: value
+  it('renders TextareaStory with a value', () => {
+    renderAndMatchSnapshot({ value: 'This is a sample description' });
+  });
+
+  // Test with Textarea props: disabled
+  it('renders TextareaStory with a disabled textarea', () => {
+    renderAndMatchSnapshot({ disabled: true });
+  });
+
+  // Test with Textarea props: compact styling
+  it('renders TextareaStory with compact styling', () => {
+    renderAndMatchSnapshot({ isCompact: true });
+  });
+
+  // Test with Textarea props: bare styling
+  it('renders TextareaStory with bare styling', () => {
+    renderAndMatchSnapshot({ isBare: true });
+  });
+
+  // Test with Textarea props: readOnly
+  it('renders TextareaStory with a read-only textarea', () => {
+    renderAndMatchSnapshot({ readOnly: true });
+  });
+
+  // Test with Textarea props: required
+  it('renders TextareaStory with a required textarea', () => {
+    renderAndMatchSnapshot({ required: true });
+  });
+
+  // Test with Textarea props: validation success
+  it('renders TextareaStory with validation success', () => {
+    renderAndMatchSnapshot({ validation: 'success' });
+  });
+
+  // Test with Textarea props: validation error
+  it('renders TextareaStory with validation error', () => {
+    renderAndMatchSnapshot({ validation: 'error' });
+  });
+
+  // Test with Textarea props: validation warning
+  it('renders TextareaStory with validation warning', () => {
+    renderAndMatchSnapshot({ validation: 'warning' });
+  });
+
+  // Test with Textarea props: resizable
+  it('renders TextareaStory with resizable textarea', () => {
+    renderAndMatchSnapshot({ isResizable: true });
+  });
+
+  // Test with Textarea props: minRows
+  it('renders TextareaStory with a minimum number of rows', () => {
+    renderAndMatchSnapshot({ minRows: 3 });
+  });
+
+  // Test with Textarea props: maxRows
+  it('renders TextareaStory with a maximum number of rows', () => {
+    renderAndMatchSnapshot({ maxRows: 6 });
+  });
+
+  // Test with combined FieldStory and Textarea props
+  it('renders TextareaStory with label, hint, message, and compact textarea', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      hasHint: true,
+      hint: 'Enter a brief description',
+      hasMessage: true,
+      message: 'This field is required',
+      isCompact: true
+    });
+  });
+
+  it('renders TextareaStory with label, hidden label, validation label, and bare textarea', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      isLabelHidden: true,
+      validationLabel: 'Invalid description',
+      isBare: true
+    });
+  });
+
+  it('renders TextareaStory with label, regular label, hint, message, validation label, and disabled textarea', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter a brief description',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid description',
+      disabled: true
+    });
+  });
+});

--- a/packages/forms/demo/stories/TilesStory.spec.tsx
+++ b/packages/forms/demo/stories/TilesStory.spec.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { TilesStory } from './TilesStory';
+import { TILES } from './data';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<TilesStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('TilesStory Component', () => {
+  it('renders default TilesStory', () => {
+    renderAndMatchSnapshot({ tiles: TILES, hasDescription: false });
+  });
+
+  it('renders TilesStory with centered tiles', () => {
+    renderAndMatchSnapshot({ tiles: TILES, isCentered: true, hasDescription: false });
+  });
+
+  it('renders TilesStory with description', () => {
+    renderAndMatchSnapshot({ tiles: TILES, hasDescription: true });
+  });
+
+  it('renders TilesStory with centered tiles and description', () => {
+    renderAndMatchSnapshot({ tiles: TILES, isCentered: true, hasDescription: true });
+  });
+
+  it('renders TilesStory with a disabled tile', () => {
+    const disabledTiles = TILES.map(tile => ({
+      ...tile,
+      disabled: tile.value === 'three'
+    }));
+    renderAndMatchSnapshot({ tiles: disabledTiles, hasDescription: false });
+  });
+
+  it('renders TilesStory with centered tiles and a disabled tile', () => {
+    const disabledTiles = TILES.map(tile => ({
+      ...tile,
+      disabled: tile.value === 'three'
+    }));
+    renderAndMatchSnapshot({ tiles: disabledTiles, isCentered: true, hasDescription: false });
+  });
+
+  it('renders TilesStory with description and a disabled tile', () => {
+    const disabledTiles = TILES.map(tile => ({
+      ...tile,
+      disabled: tile.value === 'three'
+    }));
+    renderAndMatchSnapshot({ tiles: disabledTiles, hasDescription: true });
+  });
+
+  it('renders TilesStory with centered tiles, description, and a disabled tile', () => {
+    const disabledTiles = TILES.map(tile => ({
+      ...tile,
+      disabled: tile.value === 'three'
+    }));
+    renderAndMatchSnapshot({ tiles: disabledTiles, isCentered: true, hasDescription: true });
+  });
+});

--- a/packages/forms/demo/stories/ToggleStory.spec.tsx
+++ b/packages/forms/demo/stories/ToggleStory.spec.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { ToggleStory } from './ToggleStory';
+
+const renderAndMatchSnapshot = (Component: React.ComponentType<any>, props: any) => {
+  const { container } = render(<Component {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe(`ToggleStory Component`, () => {
+  it('renders default component', () => {
+    renderAndMatchSnapshot(ToggleStory, {});
+  });
+
+  it('renders component with a label', () => {
+    renderAndMatchSnapshot(ToggleStory, { hasLabel: true, label: 'Accept Terms' });
+  });
+
+  it('renders component with a hidden label', () => {
+    renderAndMatchSnapshot(ToggleStory, { hasLabel: false, label: 'Accept Terms' });
+  });
+
+  it('renders component with a hint', () => {
+    renderAndMatchSnapshot(ToggleStory, { hasHint: true, hint: 'This is a hint' });
+  });
+
+  it('renders component with a message', () => {
+    renderAndMatchSnapshot(ToggleStory, { hasMessage: true, message: 'This is a message' });
+  });
+
+  it('renders component with validation success', () => {
+    renderAndMatchSnapshot(ToggleStory, { validation: 'success' });
+  });
+
+  it('renders component with validation error', () => {
+    renderAndMatchSnapshot(ToggleStory, { validation: 'error' });
+  });
+
+  it('renders component with validation warning', () => {
+    renderAndMatchSnapshot(ToggleStory, { validation: 'warning' });
+  });
+
+  it('renders component with a label, hint, and message', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message'
+    });
+  });
+
+  it('renders component with a label, hidden label, and validation success', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: false,
+      label: 'Accept Terms',
+      validation: 'success'
+    });
+  });
+
+  it('renders component with a label, hint, message, and validation error', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      validation: 'error'
+    });
+  });
+
+  it('renders component with a label, hidden label, hint, and validation warning', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: false,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      validation: 'warning'
+    });
+  });
+
+  it('renders component with a disabled state', () => {
+    renderAndMatchSnapshot(ToggleStory, { disabled: true });
+  });
+
+  it('renders component with a read-only state', () => {
+    renderAndMatchSnapshot(ToggleStory, { readOnly: true });
+  });
+
+  it('renders component with a required state', () => {
+    renderAndMatchSnapshot(ToggleStory, { required: true });
+  });
+
+  it('renders component with a checked state', () => {
+    renderAndMatchSnapshot(ToggleStory, { checked: true });
+  });
+
+  it('renders component with label, hint, message, and disabled state', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      disabled: true
+    });
+  });
+
+  it('renders component with label, hidden label, validation success, and read-only state', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: false,
+      label: 'Accept Terms',
+      validation: 'success',
+      readOnly: true
+    });
+  });
+
+  it('renders component with label, hint, message, validation error, and required state', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      validation: 'error',
+      required: true
+    });
+  });
+
+  it('renders component with compact styling', () => {
+    renderAndMatchSnapshot(ToggleStory, { isCompact: true });
+  });
+
+  it('renders component with a label and compact styling', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      isCompact: true
+    });
+  });
+
+  it('renders component with a label, hint, and compact styling', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint',
+      isCompact: true
+    });
+  });
+
+  it('renders component with a label, message, and compact styling', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      hasMessage: true,
+      message: 'This is a message',
+      isCompact: true
+    });
+  });
+
+  it('renders component with a label, hint, message, and compact styling', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      isCompact: true
+    });
+  });
+});

--- a/packages/forms/demo/stories/__snapshots__/CheckboxStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/CheckboxStory.spec.tsx.snap
@@ -193,7 +193,7 @@ exports[`CheckboxStory Component renders component with a checked state 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":rf:--label"
@@ -202,7 +202,7 @@ exports[`CheckboxStory Component renders component with a checked state 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rf:--input"
     type="checkbox"
   />
@@ -211,7 +211,7 @@ exports[`CheckboxStory Component renders component with a checked state 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rf:--input"
     id=":rf:--label"
   >
@@ -219,7 +219,7 @@ exports[`CheckboxStory Component renders component with a checked state 1`] = `
       aria-hidden="true"
       class="c8 c9"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -239,7 +239,7 @@ exports[`CheckboxStory Component renders component with a checked state 1`] = `
       aria-hidden="true"
       class="c10 c11"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -450,7 +450,7 @@ exports[`CheckboxStory Component renders component with a disabled state 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":rc:--label"
@@ -458,7 +458,7 @@ exports[`CheckboxStory Component renders component with a disabled state 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     disabled=""
     id=":rc:--input"
     type="checkbox"
@@ -468,7 +468,7 @@ exports[`CheckboxStory Component renders component with a disabled state 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rc:--input"
     id=":rc:--label"
   >
@@ -476,7 +476,7 @@ exports[`CheckboxStory Component renders component with a disabled state 1`] = `
       aria-hidden="true"
       class="c8 c9"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -496,7 +496,7 @@ exports[`CheckboxStory Component renders component with a disabled state 1`] = `
       aria-hidden="true"
       class="c10 c11"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -540,7 +540,7 @@ exports[`CheckboxStory Component renders component with a hidden label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r2:--label"
@@ -548,7 +548,7 @@ exports[`CheckboxStory Component renders component with a hidden label 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r2:--input"
     label="Accept Terms"
     type="checkbox"
@@ -761,7 +761,7 @@ exports[`CheckboxStory Component renders component with a hint 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":r3:--hint"
@@ -770,7 +770,7 @@ exports[`CheckboxStory Component renders component with a hint 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r3:--input"
     type="checkbox"
   />
@@ -779,7 +779,7 @@ exports[`CheckboxStory Component renders component with a hint 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r3:--input"
     id=":r3:--label"
   >
@@ -787,7 +787,7 @@ exports[`CheckboxStory Component renders component with a hint 1`] = `
       aria-hidden="true"
       class="c8 c9"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -807,7 +807,7 @@ exports[`CheckboxStory Component renders component with a hint 1`] = `
       aria-hidden="true"
       class="c10 c11"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -827,7 +827,7 @@ exports[`CheckboxStory Component renders component with a hint 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r3:--hint"
   >
     This is a hint
@@ -1028,7 +1028,7 @@ exports[`CheckboxStory Component renders component with a label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r1:--label"
@@ -1036,7 +1036,7 @@ exports[`CheckboxStory Component renders component with a label 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r1:--input"
     label="Accept Terms"
     type="checkbox"
@@ -1046,7 +1046,7 @@ exports[`CheckboxStory Component renders component with a label 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r1:--input"
     id=":r1:--label"
   >
@@ -1054,7 +1054,7 @@ exports[`CheckboxStory Component renders component with a label 1`] = `
       aria-hidden="true"
       class="c8 c9"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -1074,7 +1074,7 @@ exports[`CheckboxStory Component renders component with a label 1`] = `
       aria-hidden="true"
       class="c10 c11"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -1286,7 +1286,7 @@ exports[`CheckboxStory Component renders component with a label and compact styl
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":rk:--label"
@@ -1294,7 +1294,7 @@ exports[`CheckboxStory Component renders component with a label and compact styl
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rk:--input"
     type="checkbox"
   />
@@ -1303,7 +1303,7 @@ exports[`CheckboxStory Component renders component with a label and compact styl
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rk:--input"
     id=":rk:--label"
   >
@@ -1311,7 +1311,7 @@ exports[`CheckboxStory Component renders component with a label and compact styl
       aria-hidden="true"
       class="c8 c9"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -1331,7 +1331,7 @@ exports[`CheckboxStory Component renders component with a label and compact styl
       aria-hidden="true"
       class="c10 c11"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -1375,7 +1375,7 @@ exports[`CheckboxStory Component renders component with a label, hidden label, a
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r9:--label"
@@ -1383,7 +1383,7 @@ exports[`CheckboxStory Component renders component with a label, hidden label, a
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--input"
     label="Accept Terms"
     type="checkbox"
@@ -1429,7 +1429,7 @@ exports[`CheckboxStory Component renders component with a label, hidden label, h
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":rb:--hint"
@@ -1438,7 +1438,7 @@ exports[`CheckboxStory Component renders component with a label, hidden label, h
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--input"
     label="Accept Terms"
     type="checkbox"
@@ -1448,7 +1448,7 @@ exports[`CheckboxStory Component renders component with a label, hidden label, h
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--hint"
   >
     This is a hint
@@ -1661,7 +1661,7 @@ exports[`CheckboxStory Component renders component with a label, hint, and compa
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":rl:--hint"
@@ -1670,7 +1670,7 @@ exports[`CheckboxStory Component renders component with a label, hint, and compa
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rl:--input"
     type="checkbox"
   />
@@ -1679,7 +1679,7 @@ exports[`CheckboxStory Component renders component with a label, hint, and compa
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rl:--input"
     id=":rl:--label"
   >
@@ -1687,7 +1687,7 @@ exports[`CheckboxStory Component renders component with a label, hint, and compa
       aria-hidden="true"
       class="c8 c9"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -1707,7 +1707,7 @@ exports[`CheckboxStory Component renders component with a label, hint, and compa
       aria-hidden="true"
       class="c10 c11"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -1727,7 +1727,7 @@ exports[`CheckboxStory Component renders component with a label, hint, and compa
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rl:--hint"
   >
     This is a hint
@@ -1965,7 +1965,7 @@ exports[`CheckboxStory Component renders component with a label, hint, and messa
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":r8:--hint :r8:--message"
@@ -1974,7 +1974,7 @@ exports[`CheckboxStory Component renders component with a label, hint, and messa
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--input"
     label="Accept Terms"
     type="checkbox"
@@ -1984,7 +1984,7 @@ exports[`CheckboxStory Component renders component with a label, hint, and messa
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r8:--input"
     id=":r8:--label"
   >
@@ -1992,7 +1992,7 @@ exports[`CheckboxStory Component renders component with a label, hint, and messa
       aria-hidden="true"
       class="c9 c10"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -2012,7 +2012,7 @@ exports[`CheckboxStory Component renders component with a label, hint, and messa
       aria-hidden="true"
       class="c11 c12"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -2033,7 +2033,7 @@ exports[`CheckboxStory Component renders component with a label, hint, and messa
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--hint"
   >
     This is a hint
@@ -2043,7 +2043,7 @@ exports[`CheckboxStory Component renders component with a label, hint, and messa
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--message"
     role="alert"
   >
@@ -2282,7 +2282,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":rn:--hint :rn:--message"
@@ -2291,7 +2291,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--input"
     type="checkbox"
   />
@@ -2300,7 +2300,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rn:--input"
     id=":rn:--label"
   >
@@ -2308,7 +2308,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
       aria-hidden="true"
       class="c9 c10"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -2328,7 +2328,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
       aria-hidden="true"
       class="c11 c12"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -2348,7 +2348,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--hint"
   >
     This is a hint
@@ -2358,7 +2358,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--message"
     role="alert"
   >
@@ -2609,7 +2609,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":ra:--hint :ra:--message"
@@ -2618,7 +2618,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--input"
     label="Accept Terms"
     type="checkbox"
@@ -2628,7 +2628,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ra:--input"
     id=":ra:--label"
   >
@@ -2636,7 +2636,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
       aria-hidden="true"
       class="c9 c10"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -2656,7 +2656,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
       aria-hidden="true"
       class="c11 c12"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -2677,7 +2677,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--hint"
   >
     This is a hint
@@ -2687,7 +2687,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--message"
     role="alert"
   >
@@ -2695,7 +2695,7 @@ exports[`CheckboxStory Component renders component with a label, hint, message, 
       aria-label="error"
       class="c18  c19"
       data-garden-id="forms.input_message_icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       role="img"
@@ -2947,7 +2947,7 @@ exports[`CheckboxStory Component renders component with a label, message, and co
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":rm:--message"
@@ -2956,7 +2956,7 @@ exports[`CheckboxStory Component renders component with a label, message, and co
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rm:--input"
     type="checkbox"
   />
@@ -2965,7 +2965,7 @@ exports[`CheckboxStory Component renders component with a label, message, and co
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rm:--input"
     id=":rm:--label"
   >
@@ -2973,7 +2973,7 @@ exports[`CheckboxStory Component renders component with a label, message, and co
       aria-hidden="true"
       class="c9 c10"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -2993,7 +2993,7 @@ exports[`CheckboxStory Component renders component with a label, message, and co
       aria-hidden="true"
       class="c11 c12"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -3013,7 +3013,7 @@ exports[`CheckboxStory Component renders component with a label, message, and co
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rm:--message"
     role="alert"
   >
@@ -3240,7 +3240,7 @@ exports[`CheckboxStory Component renders component with a message 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":r4:--message"
@@ -3249,7 +3249,7 @@ exports[`CheckboxStory Component renders component with a message 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r4:--input"
     type="checkbox"
   />
@@ -3258,7 +3258,7 @@ exports[`CheckboxStory Component renders component with a message 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r4:--input"
     id=":r4:--label"
   >
@@ -3266,7 +3266,7 @@ exports[`CheckboxStory Component renders component with a message 1`] = `
       aria-hidden="true"
       class="c9 c10"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -3286,7 +3286,7 @@ exports[`CheckboxStory Component renders component with a message 1`] = `
       aria-hidden="true"
       class="c11 c12"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -3306,7 +3306,7 @@ exports[`CheckboxStory Component renders component with a message 1`] = `
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r4:--message"
     role="alert"
   >
@@ -3508,7 +3508,7 @@ exports[`CheckboxStory Component renders component with a read-only state 1`] = 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":rd:--label"
@@ -3516,7 +3516,7 @@ exports[`CheckboxStory Component renders component with a read-only state 1`] = 
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rd:--input"
     readonly=""
     type="checkbox"
@@ -3526,7 +3526,7 @@ exports[`CheckboxStory Component renders component with a read-only state 1`] = 
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rd:--input"
     id=":rd:--label"
   >
@@ -3534,7 +3534,7 @@ exports[`CheckboxStory Component renders component with a read-only state 1`] = 
       aria-hidden="true"
       class="c8 c9"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -3554,7 +3554,7 @@ exports[`CheckboxStory Component renders component with a read-only state 1`] = 
       aria-hidden="true"
       class="c10 c11"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -3765,7 +3765,7 @@ exports[`CheckboxStory Component renders component with a required state 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":re:--label"
@@ -3773,7 +3773,7 @@ exports[`CheckboxStory Component renders component with a required state 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":re:--input"
     required=""
     type="checkbox"
@@ -3783,7 +3783,7 @@ exports[`CheckboxStory Component renders component with a required state 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":re:--input"
     id=":re:--label"
   >
@@ -3791,7 +3791,7 @@ exports[`CheckboxStory Component renders component with a required state 1`] = `
       aria-hidden="true"
       class="c8 c9"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -3811,7 +3811,7 @@ exports[`CheckboxStory Component renders component with a required state 1`] = `
       aria-hidden="true"
       class="c10 c11"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -4022,7 +4022,7 @@ exports[`CheckboxStory Component renders component with compact styling 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":rj:--label"
@@ -4030,7 +4030,7 @@ exports[`CheckboxStory Component renders component with compact styling 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rj:--input"
     type="checkbox"
   />
@@ -4039,7 +4039,7 @@ exports[`CheckboxStory Component renders component with compact styling 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rj:--input"
     id=":rj:--label"
   >
@@ -4047,7 +4047,7 @@ exports[`CheckboxStory Component renders component with compact styling 1`] = `
       aria-hidden="true"
       class="c8 c9"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -4067,7 +4067,7 @@ exports[`CheckboxStory Component renders component with compact styling 1`] = `
       aria-hidden="true"
       class="c10 c11"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -4111,7 +4111,7 @@ exports[`CheckboxStory Component renders component with label, hidden label, val
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":rh:--label"
@@ -4119,7 +4119,7 @@ exports[`CheckboxStory Component renders component with label, hidden label, val
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rh:--input"
     label="Accept Terms"
     readonly=""
@@ -4358,7 +4358,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, an
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":rg:--hint :rg:--message"
@@ -4367,7 +4367,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, an
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     disabled=""
     id=":rg:--input"
     label="Accept Terms"
@@ -4378,7 +4378,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, an
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rg:--input"
     id=":rg:--label"
   >
@@ -4386,7 +4386,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, an
       aria-hidden="true"
       class="c9 c10"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -4406,7 +4406,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, an
       aria-hidden="true"
       class="c11 c12"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -4427,7 +4427,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, an
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rg:--hint"
   >
     This is a hint
@@ -4437,7 +4437,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, an
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rg:--message"
     role="alert"
   >
@@ -4688,7 +4688,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, va
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":ri:--hint :ri:--message"
@@ -4697,7 +4697,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, va
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ri:--input"
     label="Accept Terms"
     required=""
@@ -4708,7 +4708,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, va
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ri:--input"
     id=":ri:--label"
   >
@@ -4716,7 +4716,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, va
       aria-hidden="true"
       class="c9 c10"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -4736,7 +4736,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, va
       aria-hidden="true"
       class="c11 c12"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -4757,7 +4757,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, va
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ri:--hint"
   >
     This is a hint
@@ -4767,7 +4767,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, va
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ri:--message"
     role="alert"
   >
@@ -4775,7 +4775,7 @@ exports[`CheckboxStory Component renders component with label, hint, message, va
       aria-label="error"
       class="c18  c19"
       data-garden-id="forms.input_message_icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       role="img"
@@ -5002,7 +5002,7 @@ exports[`CheckboxStory Component renders component with validation error 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r6:--label"
@@ -5010,7 +5010,7 @@ exports[`CheckboxStory Component renders component with validation error 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r6:--input"
     type="checkbox"
   />
@@ -5019,7 +5019,7 @@ exports[`CheckboxStory Component renders component with validation error 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r6:--input"
     id=":r6:--label"
   >
@@ -5027,7 +5027,7 @@ exports[`CheckboxStory Component renders component with validation error 1`] = `
       aria-hidden="true"
       class="c8 c9"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -5047,7 +5047,7 @@ exports[`CheckboxStory Component renders component with validation error 1`] = `
       aria-hidden="true"
       class="c10 c11"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -5258,7 +5258,7 @@ exports[`CheckboxStory Component renders component with validation success 1`] =
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r5:--label"
@@ -5266,7 +5266,7 @@ exports[`CheckboxStory Component renders component with validation success 1`] =
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--input"
     type="checkbox"
   />
@@ -5275,7 +5275,7 @@ exports[`CheckboxStory Component renders component with validation success 1`] =
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r5:--input"
     id=":r5:--label"
   >
@@ -5283,7 +5283,7 @@ exports[`CheckboxStory Component renders component with validation success 1`] =
       aria-hidden="true"
       class="c8 c9"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -5303,7 +5303,7 @@ exports[`CheckboxStory Component renders component with validation success 1`] =
       aria-hidden="true"
       class="c10 c11"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -5514,7 +5514,7 @@ exports[`CheckboxStory Component renders component with validation warning 1`] =
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r7:--label"
@@ -5522,7 +5522,7 @@ exports[`CheckboxStory Component renders component with validation warning 1`] =
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--input"
     type="checkbox"
   />
@@ -5531,7 +5531,7 @@ exports[`CheckboxStory Component renders component with validation warning 1`] =
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r7:--input"
     id=":r7:--label"
   >
@@ -5539,7 +5539,7 @@ exports[`CheckboxStory Component renders component with validation warning 1`] =
       aria-hidden="true"
       class="c8 c9"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -5559,7 +5559,7 @@ exports[`CheckboxStory Component renders component with validation warning 1`] =
       aria-hidden="true"
       class="c10 c11"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -5770,7 +5770,7 @@ exports[`CheckboxStory Component renders default component 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r0:--label"
@@ -5778,7 +5778,7 @@ exports[`CheckboxStory Component renders default component 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r0:--input"
     type="checkbox"
   />
@@ -5787,7 +5787,7 @@ exports[`CheckboxStory Component renders default component 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.checkbox_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r0:--input"
     id=":r0:--label"
   >
@@ -5795,7 +5795,7 @@ exports[`CheckboxStory Component renders default component 1`] = `
       aria-hidden="true"
       class="c8 c9"
       data-garden-id="forms.check_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -5815,7 +5815,7 @@ exports[`CheckboxStory Component renders default component 1`] = `
       aria-hidden="true"
       class="c10 c11"
       data-garden-id="forms.dash_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"

--- a/packages/forms/demo/stories/__snapshots__/CheckboxStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/CheckboxStory.spec.tsx.snap
@@ -1,0 +1,5834 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CheckboxStory Component renders component with a checked state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rf:--label"
+    checked=""
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rf:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a disabled state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rc:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":rc:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a hidden label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r2:--label"
+    class="c1 "
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r2:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c13 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r3:--hint"
+    aria-labelledby=":r3:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r3:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    id=":r3:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c12 c13 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r1:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r1:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+    Accept Terms
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rk:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rk:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label, hidden label, and validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r9:--label"
+    class="c1 "
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r9:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label, hidden label, hint, and validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  padding-left: 24px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rb:--hint"
+    aria-labelledby=":rb:--label"
+    class="c1 "
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rb:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <div
+    class="c2 c3 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label, hint, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c13 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rl:--hint"
+    aria-labelledby=":rl:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rl:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    id=":rl:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c12 c13 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c13 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c14 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c5 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c5::before {
+  outline: none;
+}
+
+.c2 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c3 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c17 {
+  padding-left: 24px;
+}
+
+.c10 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c6 > .c9 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c6 > .c9 {
+  opacity: 0;
+}
+
+.c12 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c6 > .c11 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r8:--hint :r8:--message"
+    aria-labelledby=":r8:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r8:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    id=":r8:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c9 c10"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c11 c12"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c13 c14 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c15 c16 c17 "
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_message"
+    data-garden-version="9.0.0"
+    id=":r8:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label, hint, message, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c13 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c14 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c5 ~ .c15 {
+  margin-top: 4px;
+}
+
+.c2:focus ~ .c5::before {
+  outline: none;
+}
+
+.c2 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c3 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c17 {
+  padding-left: 24px;
+}
+
+.c10 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c6 > .c9 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c6 > .c9 {
+  opacity: 0;
+}
+
+.c12 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c6 > .c11 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rn:--hint :rn:--message"
+    aria-labelledby=":rn:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rn:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rn:--input"
+    id=":rn:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c9 c10"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c11 c12"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c13 c14 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":rn:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c15 c16 c17 "
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_message"
+    data-garden-version="9.0.0"
+    id=":rn:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label, hint, message, and validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c13 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c19 {
+  width: 16px;
+  height: 16px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 24px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #cd3642;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c16 .c18 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c14 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c5 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c5::before {
+  outline: none;
+}
+
+.c2 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c3 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c17 {
+  padding-left: 24px;
+}
+
+.c10 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c6 > .c9 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c6 > .c9 {
+  opacity: 0;
+}
+
+.c12 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c6 > .c11 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":ra:--hint :ra:--message"
+    aria-labelledby=":ra:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":ra:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    id=":ra:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c9 c10"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c11 c12"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c13 c14 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c15 c16 c17 "
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_message"
+    data-garden-version="9.0.0"
+    id=":ra:--message"
+    role="alert"
+  >
+    <svg
+      aria-label="error"
+      class="c18  c19"
+      data-garden-id="forms.input_message_icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      role="img"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        stroke="currentColor"
+      >
+        <circle
+          cx="7.5"
+          cy="8.5"
+          r="7"
+        />
+        <path
+          d="M7.5 4.5V9"
+          stroke-linecap="round"
+        />
+      </g>
+      <circle
+        cx="7.5"
+        cy="12"
+        fill="currentColor"
+        r="1"
+      />
+    </svg>
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label, message, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c5 ~ .c13 {
+  margin-top: 4px;
+}
+
+.c2:focus ~ .c5::before {
+  outline: none;
+}
+
+.c2 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c3 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c15 {
+  padding-left: 24px;
+}
+
+.c10 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c6 > .c9 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c6 > .c9 {
+  opacity: 0;
+}
+
+.c12 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c6 > .c11 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rm:--message"
+    aria-labelledby=":rm:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rm:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c9 c10"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c11 c12"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c13 c14 c15 "
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_message"
+    data-garden-version="9.0.0"
+    id=":rm:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c5 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c5::before {
+  outline: none;
+}
+
+.c2 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c3 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c15 {
+  padding-left: 24px;
+}
+
+.c10 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c6 > .c9 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c6 > .c9 {
+  opacity: 0;
+}
+
+.c12 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c6 > .c11 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r4:--message"
+    aria-labelledby=":r4:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r4:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c9 c10"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c11 c12"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c13 c14 c15 "
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_message"
+    data-garden-version="9.0.0"
+    id=":r4:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a read-only state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rd:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rd:--input"
+    readonly=""
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    id=":rd:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a required state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":re:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":re:--input"
+    required=""
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rj:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rj:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with label, hidden label, validation success, and read-only state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rh:--label"
+    class="c1 "
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rh:--input"
+    label="Accept Terms"
+    readonly=""
+    type="checkbox"
+  />
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with label, hint, message, and disabled state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c13 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c14 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c5 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c5::before {
+  outline: none;
+}
+
+.c2 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c3 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c17 {
+  padding-left: 24px;
+}
+
+.c10 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c6 > .c9 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c6 > .c9 {
+  opacity: 0;
+}
+
+.c12 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c6 > .c11 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rg:--hint :rg:--message"
+    aria-labelledby=":rg:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":rg:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c9 c10"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c11 c12"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c13 c14 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c15 c16 c17 "
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_message"
+    data-garden-version="9.0.0"
+    id=":rg:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with label, hint, message, validation error, and required state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c13 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c19 {
+  width: 16px;
+  height: 16px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 24px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #cd3642;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c16 .c18 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c14 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c5 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c5::before {
+  outline: none;
+}
+
+.c2 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c3 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c17 {
+  padding-left: 24px;
+}
+
+.c10 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c6 > .c9 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c6 > .c9 {
+  opacity: 0;
+}
+
+.c12 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c6 > .c11 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":ri:--hint :ri:--message"
+    aria-labelledby=":ri:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":ri:--input"
+    label="Accept Terms"
+    required=""
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c9 c10"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c11 c12"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c13 c14 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c15 c16 c17 "
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_message"
+    data-garden-version="9.0.0"
+    id=":ri:--message"
+    role="alert"
+  >
+    <svg
+      aria-label="error"
+      class="c18  c19"
+      data-garden-id="forms.input_message_icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      role="img"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        stroke="currentColor"
+      >
+        <circle
+          cx="7.5"
+          cy="8.5"
+          r="7"
+        />
+        <path
+          d="M7.5 4.5V9"
+          stroke-linecap="round"
+        />
+      </g>
+      <circle
+        cx="7.5"
+        cy="12"
+        fill="currentColor"
+        r="1"
+      />
+    </svg>
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r6:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r6:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r5:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r5:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r7:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r7:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders default component 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r0:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r0:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/FauxInputStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/FauxInputStory.spec.tsx.snap
@@ -1,0 +1,7384 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FauxInputStory Component renders FauxInputStory with a disabled input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":re:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-disabled="true"
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a hidden label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    hidden=""
+    id=":r3:--label"
+  >
+    Username
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c5"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r4:--hint"
+  >
+    Enter your username
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r1:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a label, hidden label, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    hidden=""
+    id=":r8:--label"
+  >
+    Username
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c5"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a label, hidden label, hint, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    hidden=""
+    id=":ra:--label"
+  >
+    Username
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c5"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    Enter your username
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c8 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c8 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c8 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c8 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r7:--hint"
+  >
+    Enter your username
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r7:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a label, regular label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c8 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c8 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c8 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c8 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r9:--input"
+    id=":r9:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r9:--hint"
+  >
+    Enter your username
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r9:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a label, regular label, hint, message, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c8 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c8 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c8 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c8 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rb:--input"
+    id=":rb:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    Enter your username
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rb:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c8 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c8 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c8 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c8 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r5:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r5:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a placeholder 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rc:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    placeholder="Enter your username"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a read-only input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rh:--input"
+    id=":rh:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rh:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    aria-readonly="true"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a regular label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r2:--input"
+    id=":r2:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r2:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a required input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    required=""
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r6:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a value 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    id=":rd:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rd:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+    value="JohnDoe"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with bare styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 11px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 32px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rf:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with label, hidden label, validation label, and bare input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rn:--input"
+    hidden=""
+    id=":rn:--label"
+  >
+    Username
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c5"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rn:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with label, hint, message, and compact input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c8 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c8 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 11px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 32px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c8 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c8 {
+  margin-top: 4px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rm:--hint"
+  >
+    Enter your username
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rm:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with label, regular label, hint, message, validation label, and disabled input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c8 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c8 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c8 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c8 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ro:--input"
+    id=":ro:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ro:--hint"
+  >
+    Enter your username
+  </div>
+  <div
+    aria-disabled="true"
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  />
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":ro:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #cd3642;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rk:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="true"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #037f52;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #037f52;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rj:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #ac5918;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #ac5918;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    id=":rl:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="true"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders default FauxInputStory 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r0:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/FauxInputStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/FauxInputStory.spec.tsx.snap
@@ -254,14 +254,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a disabled input 1
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":re:--input"
     id=":re:--label"
   >
@@ -272,7 +272,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a disabled input 1
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":re:--hint"
   >
     Hint
@@ -282,7 +282,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a disabled input 1
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   />
 </div>
 `;
@@ -541,14 +541,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a hidden label 1`]
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r3:--input"
     hidden=""
     id=":r3:--label"
@@ -559,7 +559,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a hidden label 1`]
     aria-invalid="false"
     class="c2 c3 c4"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
   <div
@@ -567,7 +567,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a hidden label 1`]
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r3:--hint"
   >
     Hint
@@ -829,14 +829,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a hint 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r4:--input"
     id=":r4:--label"
   >
@@ -847,7 +847,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a hint 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r4:--hint"
   >
     Enter your username
@@ -856,7 +856,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a hint 1`] = `
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
 </div>
@@ -1116,14 +1116,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r1:--input"
     id=":r1:--label"
   >
@@ -1134,7 +1134,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r1:--hint"
   >
     Hint
@@ -1143,7 +1143,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label 1`] = `
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
 </div>
@@ -1403,14 +1403,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, hidden la
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r8:--input"
     hidden=""
     id=":r8:--label"
@@ -1421,7 +1421,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, hidden la
     aria-invalid="false"
     class="c2 c3 c4"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
   <div
@@ -1429,7 +1429,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, hidden la
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--hint"
   >
     Hint
@@ -1691,14 +1691,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, hidden la
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ra:--input"
     hidden=""
     id=":ra:--label"
@@ -1709,7 +1709,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, hidden la
     aria-invalid="false"
     class="c2 c3 c4"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
   <div
@@ -1717,7 +1717,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, hidden la
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--hint"
   >
     Enter your username
@@ -2004,14 +2004,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, hint, and
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r7:--input"
     id=":r7:--label"
   >
@@ -2022,7 +2022,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, hint, and
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--hint"
   >
     Enter your username
@@ -2031,7 +2031,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, hint, and
     aria-invalid="false"
     class="c5 c6 c7"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
   <div
@@ -2039,7 +2039,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, hint, and
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--message"
     role="alert"
   >
@@ -2327,14 +2327,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, regular l
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r9:--input"
     id=":r9:--label"
   >
@@ -2345,7 +2345,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, regular l
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--hint"
   >
     Enter your username
@@ -2354,7 +2354,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, regular l
     aria-invalid="false"
     class="c5 c6 c7"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
   <div
@@ -2362,7 +2362,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, regular l
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--message"
     role="alert"
   >
@@ -2650,14 +2650,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, regular l
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rb:--input"
     id=":rb:--label"
   >
@@ -2668,7 +2668,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, regular l
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--hint"
   >
     Enter your username
@@ -2677,7 +2677,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, regular l
     aria-invalid="false"
     class="c5 c6 c7"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
   <div
@@ -2685,7 +2685,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a label, regular l
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--message"
     role="alert"
   >
@@ -2973,14 +2973,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a message 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r5:--input"
     id=":r5:--label"
   >
@@ -2991,7 +2991,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a message 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--hint"
   >
     Hint
@@ -3000,7 +3000,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a message 1`] = `
     aria-invalid="false"
     class="c5 c6 c7"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
   <div
@@ -3008,7 +3008,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a message 1`] = `
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--message"
     role="alert"
   >
@@ -3271,14 +3271,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a placeholder 1`] 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rc:--input"
     id=":rc:--label"
   >
@@ -3289,7 +3289,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a placeholder 1`] 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rc:--hint"
   >
     Hint
@@ -3298,7 +3298,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a placeholder 1`] 
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     placeholder="Enter your username"
     tabindex="0"
   />
@@ -3559,14 +3559,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a read-only input 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rh:--input"
     id=":rh:--label"
   >
@@ -3577,7 +3577,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a read-only input 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rh:--hint"
   >
     Hint
@@ -3587,7 +3587,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a read-only input 
     aria-readonly="true"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
 </div>
@@ -3847,14 +3847,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a regular label 1`
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r2:--input"
     id=":r2:--label"
   >
@@ -3865,7 +3865,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a regular label 1`
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r2:--hint"
   >
     Hint
@@ -3874,7 +3874,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a regular label 1`
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
 </div>
@@ -4134,14 +4134,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a required input 1
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ri:--input"
     id=":ri:--label"
   >
@@ -4152,7 +4152,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a required input 1
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ri:--hint"
   >
     Hint
@@ -4161,7 +4161,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a required input 1
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     required=""
     tabindex="0"
   />
@@ -4422,14 +4422,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a validation label
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r6:--input"
     id=":r6:--label"
   >
@@ -4440,7 +4440,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a validation label
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r6:--hint"
   >
     Hint
@@ -4449,7 +4449,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a validation label
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
 </div>
@@ -4709,14 +4709,14 @@ exports[`FauxInputStory Component renders FauxInputStory with a value 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rd:--input"
     id=":rd:--label"
   >
@@ -4727,7 +4727,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a value 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rd:--hint"
   >
     Hint
@@ -4736,7 +4736,7 @@ exports[`FauxInputStory Component renders FauxInputStory with a value 1`] = `
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
     value="JohnDoe"
   />
@@ -4989,14 +4989,14 @@ exports[`FauxInputStory Component renders FauxInputStory with bare styling 1`] =
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rg:--input"
     id=":rg:--label"
   >
@@ -5007,7 +5007,7 @@ exports[`FauxInputStory Component renders FauxInputStory with bare styling 1`] =
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rg:--hint"
   >
     Hint
@@ -5016,7 +5016,7 @@ exports[`FauxInputStory Component renders FauxInputStory with bare styling 1`] =
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
 </div>
@@ -5276,14 +5276,14 @@ exports[`FauxInputStory Component renders FauxInputStory with compact styling 1`
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rf:--input"
     id=":rf:--label"
   >
@@ -5294,7 +5294,7 @@ exports[`FauxInputStory Component renders FauxInputStory with compact styling 1`
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rf:--hint"
   >
     Hint
@@ -5303,7 +5303,7 @@ exports[`FauxInputStory Component renders FauxInputStory with compact styling 1`
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
 </div>
@@ -5555,14 +5555,14 @@ exports[`FauxInputStory Component renders FauxInputStory with label, hidden labe
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rn:--input"
     hidden=""
     id=":rn:--label"
@@ -5573,7 +5573,7 @@ exports[`FauxInputStory Component renders FauxInputStory with label, hidden labe
     aria-invalid="false"
     class="c2 c3 c4"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
   <div
@@ -5581,7 +5581,7 @@ exports[`FauxInputStory Component renders FauxInputStory with label, hidden labe
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--hint"
   >
     Hint
@@ -5868,14 +5868,14 @@ exports[`FauxInputStory Component renders FauxInputStory with label, hint, messa
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rm:--input"
     id=":rm:--label"
   >
@@ -5886,7 +5886,7 @@ exports[`FauxInputStory Component renders FauxInputStory with label, hint, messa
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rm:--hint"
   >
     Enter your username
@@ -5895,7 +5895,7 @@ exports[`FauxInputStory Component renders FauxInputStory with label, hint, messa
     aria-invalid="false"
     class="c5 c6 c7"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
   <div
@@ -5903,7 +5903,7 @@ exports[`FauxInputStory Component renders FauxInputStory with label, hint, messa
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rm:--message"
     role="alert"
   >
@@ -6191,14 +6191,14 @@ exports[`FauxInputStory Component renders FauxInputStory with label, regular lab
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ro:--input"
     id=":ro:--label"
   >
@@ -6209,7 +6209,7 @@ exports[`FauxInputStory Component renders FauxInputStory with label, regular lab
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ro:--hint"
   >
     Enter your username
@@ -6219,14 +6219,14 @@ exports[`FauxInputStory Component renders FauxInputStory with label, regular lab
     aria-invalid="false"
     class="c5 c6 c7"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   />
   <div
     class="c8 c9"
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ro:--message"
     role="alert"
   >
@@ -6489,14 +6489,14 @@ exports[`FauxInputStory Component renders FauxInputStory with validation error 1
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rk:--input"
     id=":rk:--label"
   >
@@ -6507,7 +6507,7 @@ exports[`FauxInputStory Component renders FauxInputStory with validation error 1
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rk:--hint"
   >
     Hint
@@ -6516,7 +6516,7 @@ exports[`FauxInputStory Component renders FauxInputStory with validation error 1
     aria-invalid="true"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
 </div>
@@ -6776,14 +6776,14 @@ exports[`FauxInputStory Component renders FauxInputStory with validation success
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rj:--input"
     id=":rj:--label"
   >
@@ -6794,7 +6794,7 @@ exports[`FauxInputStory Component renders FauxInputStory with validation success
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rj:--hint"
   >
     Hint
@@ -6803,7 +6803,7 @@ exports[`FauxInputStory Component renders FauxInputStory with validation success
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
 </div>
@@ -7063,14 +7063,14 @@ exports[`FauxInputStory Component renders FauxInputStory with validation warning
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rl:--input"
     id=":rl:--label"
   >
@@ -7081,7 +7081,7 @@ exports[`FauxInputStory Component renders FauxInputStory with validation warning
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rl:--hint"
   >
     Hint
@@ -7090,7 +7090,7 @@ exports[`FauxInputStory Component renders FauxInputStory with validation warning
     aria-invalid="true"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
 </div>
@@ -7350,14 +7350,14 @@ exports[`FauxInputStory Component renders default FauxInputStory 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r0:--input"
     id=":r0:--label"
   >
@@ -7368,7 +7368,7 @@ exports[`FauxInputStory Component renders default FauxInputStory 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r0:--hint"
   >
     Hint
@@ -7377,7 +7377,7 @@ exports[`FauxInputStory Component renders default FauxInputStory 1`] = `
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     tabindex="0"
   />
 </div>

--- a/packages/forms/demo/stories/__snapshots__/FileListStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/FileListStory.spec.tsx.snap
@@ -1,0 +1,6599 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FileListStory Component renders FileListStory with a file that has progress 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 16%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h7m-7 1.97h7m-7 2h7m3-7.27V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with a single item 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with all file types 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c12 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 0%;
+  height: 6px;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 16%;
+  height: 6px;
+}
+
+.c8 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 32%;
+  height: 6px;
+}
+
+.c9 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 48%;
+  height: 6px;
+}
+
+.c10 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 64%;
+  height: 6px;
+}
+
+.c11 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 80%;
+  height: 6px;
+}
+
+.c13 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 100%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h7m-7 1.97h7m-7 2h7m3-7.27V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5m-11 9l2.65-2.65c.2-.2.51-.2.71 0l1.79 1.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l1.65 1.65"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <circle
+          cx="10.5"
+          cy="8.5"
+          fill="currentColor"
+          r="1.5"
+        />
+      </svg>
+      <span>
+        Rose petals.jpg
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="32"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c8"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="32"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15a.5.5 0 01-.5.5H2a.5.5 0 01-.5-.5V1A.5.5 0 012 .5h8.85a.5.5 0 01.36.15l3.15 3.2a.5.5 0 01.14.35zm-10 8.3h7m-7-2h7m-1-10V4a.5.5 0 00.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <rect
+          fill="currentColor"
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="8"
+          x="4"
+          y="7"
+        />
+      </svg>
+      <span>
+        Basics of gardening.pdf
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="48"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c9"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="48"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5M7 9.5h4c.28 0 .5.22.5.5v3c0 .28-.22.5-.5.5H7c-.28 0-.5-.22-.5-.5v-3c0-.28.22-.5.5-.5zm-.5 2H5c-.28 0-.5-.22-.5-.5V8c0-.28.22-.5.5-.5h4c.28 0 .5.22.5.5v1.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Presentation bouquets.ppt
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="64"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c10"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="64"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h2m-2 2h2m-2 2h2m2-4h3m-3 2h3m-3 2h3m3-7.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Seed inventory.xlsx
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c11"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="80"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.5.5v11M5 2.5h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m8-6.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c12"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M3 2.5h10m-6.5 11v-8m3 8v-8m-6-1V15c0 .3.2.5.5.5h8c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c13"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with an item that has a close button 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 0%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with an item that has a delete button 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c5 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c6 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 100%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.5.5v11M5 2.5h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m8-6.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c5"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M3 2.5h10m-6.5 11v-8m3 8v-8m-6-1V15c0 .3.2.5.5.5h8c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c6"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with aria labels for close and delete buttons 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c12 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 0%;
+  height: 6px;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 16%;
+  height: 6px;
+}
+
+.c8 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 32%;
+  height: 6px;
+}
+
+.c9 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 48%;
+  height: 6px;
+}
+
+.c10 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 64%;
+  height: 6px;
+}
+
+.c11 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 80%;
+  height: 6px;
+}
+
+.c13 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 100%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h7m-7 1.97h7m-7 2h7m3-7.27V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5m-11 9l2.65-2.65c.2-.2.51-.2.71 0l1.79 1.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l1.65 1.65"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <circle
+          cx="10.5"
+          cy="8.5"
+          fill="currentColor"
+          r="1.5"
+        />
+      </svg>
+      <span>
+        Rose petals.jpg
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="32"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c8"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="32"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15a.5.5 0 01-.5.5H2a.5.5 0 01-.5-.5V1A.5.5 0 012 .5h8.85a.5.5 0 01.36.15l3.15 3.2a.5.5 0 01.14.35zm-10 8.3h7m-7-2h7m-1-10V4a.5.5 0 00.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <rect
+          fill="currentColor"
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="8"
+          x="4"
+          y="7"
+        />
+      </svg>
+      <span>
+        Basics of gardening.pdf
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="48"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c9"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="48"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5M7 9.5h4c.28 0 .5.22.5.5v3c0 .28-.22.5-.5.5H7c-.28 0-.5-.22-.5-.5v-3c0-.28.22-.5.5-.5zm-.5 2H5c-.28 0-.5-.22-.5-.5V8c0-.28.22-.5.5-.5h4c.28 0 .5.22.5.5v1.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Presentation bouquets.ppt
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="64"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c10"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="64"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h2m-2 2h2m-2 2h2m2-4h3m-3 2h3m-3 2h3m3-7.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Seed inventory.xlsx
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c11"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="80"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.5.5v11M5 2.5h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m8-6.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c12"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M3 2.5h10m-6.5 11v-8m3 8v-8m-6-1V15c0 .3.2.5.5.5h8c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c13"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with compact styling 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 8px;
+  height: 28px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 28px;
+  height: 28px;
+  margin-right: -8px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c12 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 12px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 1px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 0%;
+  height: 2px;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 16%;
+  height: 2px;
+}
+
+.c8 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 32%;
+  height: 2px;
+}
+
+.c9 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 48%;
+  height: 2px;
+}
+
+.c10 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 64%;
+  height: 2px;
+}
+
+.c11 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 80%;
+  height: 2px;
+}
+
+.c13 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 100%;
+  height: 2px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.5h5m-5 2h5m-5 2h5m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5m-7 6L5 8l1.5 1.5 1-1 1 1"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <circle
+          cx="8"
+          cy="6"
+          fill="currentColor"
+          r="1"
+        />
+      </svg>
+      <span>
+        Rose petals.jpg
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="32"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c8"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="32"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11a.5.5 0 01-.5.5H2a.5.5 0 01-.5-.5V1A.5.5 0 012 .5h5.79a.5.5 0 01.35.15l2.21 2.21a.5.5 0 01.15.35zM7.5.5V3a.5.5 0 00.5.5h2.5m-7 6h5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <rect
+          fill="currentColor"
+          height="3"
+          rx="0.5"
+          ry="0.5"
+          width="6"
+          x="3"
+          y="5"
+        />
+      </svg>
+      <span>
+        Basics of gardening.pdf
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="48"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c9"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="48"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM6 9.5h2c.28 0 .5-.22.5-.5V8c0-.28-.22-.5-.5-.5H6c-.28 0-.5.22-.5.5v1c0 .28.22.5.5.5zm-2-2h2c.28 0 .5-.22.5-.5V6c0-.28-.22-.5-.5-.5H4c-.28 0-.5.22-.5.5v1c0 .28.22.5.5.5zm3.5-7V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Presentation bouquets.ppt
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="64"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c10"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="64"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.5h1m-1 2h1m-1 2h1m2-4h2m-2 2h2m-2 2h2m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Seed inventory.xlsx
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c11"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="80"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5.5v8m0-6h1m-2 1h1m0 1h1m-2 1h1m0 1h1m-2 1h1m6-4.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c12"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M4.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M2 2.5h8m-5.5 7V5m3 4.5V5m-5-.5V11c0 .3.2.5.5.5h6c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c13"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with compact styling and a close button 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 8px;
+  height: 28px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 28px;
+  height: 28px;
+  margin-right: -8px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 12px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 1px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 0%;
+  height: 2px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with compact styling and a delete button 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 8px;
+  height: 28px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 28px;
+  height: 28px;
+  margin-right: -8px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c5 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 12px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c6 {
+  margin: 8px 0;
+  border-radius: 1px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 100%;
+  height: 2px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5.5v8m0-6h1m-2 1h1m0 1h1m-2 1h1m0 1h1m-2 1h1m6-4.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c5"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M4.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M2 2.5h8m-5.5 7V5m3 4.5V5m-5-.5V11c0 .3.2.5.5.5h6c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c6"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with compact styling and multiple items 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 8px;
+  height: 28px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 28px;
+  height: 28px;
+  margin-right: -8px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c12 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 12px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 1px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 0%;
+  height: 2px;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 16%;
+  height: 2px;
+}
+
+.c8 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 32%;
+  height: 2px;
+}
+
+.c9 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 48%;
+  height: 2px;
+}
+
+.c10 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 64%;
+  height: 2px;
+}
+
+.c11 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 80%;
+  height: 2px;
+}
+
+.c13 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 100%;
+  height: 2px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.5h5m-5 2h5m-5 2h5m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5m-7 6L5 8l1.5 1.5 1-1 1 1"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <circle
+          cx="8"
+          cy="6"
+          fill="currentColor"
+          r="1"
+        />
+      </svg>
+      <span>
+        Rose petals.jpg
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="32"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c8"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="32"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11a.5.5 0 01-.5.5H2a.5.5 0 01-.5-.5V1A.5.5 0 012 .5h5.79a.5.5 0 01.35.15l2.21 2.21a.5.5 0 01.15.35zM7.5.5V3a.5.5 0 00.5.5h2.5m-7 6h5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <rect
+          fill="currentColor"
+          height="3"
+          rx="0.5"
+          ry="0.5"
+          width="6"
+          x="3"
+          y="5"
+        />
+      </svg>
+      <span>
+        Basics of gardening.pdf
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="48"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c9"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="48"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM6 9.5h2c.28 0 .5-.22.5-.5V8c0-.28-.22-.5-.5-.5H6c-.28 0-.5.22-.5.5v1c0 .28.22.5.5.5zm-2-2h2c.28 0 .5-.22.5-.5V6c0-.28-.22-.5-.5-.5H4c-.28 0-.5.22-.5.5v1c0 .28.22.5.5.5zm3.5-7V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Presentation bouquets.ppt
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="64"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c10"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="64"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.5h1m-1 2h1m-1 2h1m2-4h2m-2 2h2m-2 2h2m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Seed inventory.xlsx
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c11"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="80"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5.5v8m0-6h1m-2 1h1m0 1h1m-2 1h1m0 1h1m-2 1h1m6-4.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c12"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M4.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M2 2.5h8m-5.5 7V5m3 4.5V5m-5-.5V11c0 .3.2.5.5.5h6c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c13"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with compact styling and progress 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 8px;
+  height: 28px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 28px;
+  height: 28px;
+  margin-right: -8px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 12px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 1px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 16%;
+  height: 2px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.5h5m-5 2h5m-5 2h5m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with compact styling, aria labels, and multiple items 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 8px;
+  height: 28px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 28px;
+  height: 28px;
+  margin-right: -8px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c12 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 12px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 1px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 0%;
+  height: 2px;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 16%;
+  height: 2px;
+}
+
+.c8 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 32%;
+  height: 2px;
+}
+
+.c9 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 48%;
+  height: 2px;
+}
+
+.c10 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 64%;
+  height: 2px;
+}
+
+.c11 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 80%;
+  height: 2px;
+}
+
+.c13 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 100%;
+  height: 2px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.5h5m-5 2h5m-5 2h5m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5m-7 6L5 8l1.5 1.5 1-1 1 1"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <circle
+          cx="8"
+          cy="6"
+          fill="currentColor"
+          r="1"
+        />
+      </svg>
+      <span>
+        Rose petals.jpg
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="32"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c8"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="32"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11a.5.5 0 01-.5.5H2a.5.5 0 01-.5-.5V1A.5.5 0 012 .5h5.79a.5.5 0 01.35.15l2.21 2.21a.5.5 0 01.15.35zM7.5.5V3a.5.5 0 00.5.5h2.5m-7 6h5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <rect
+          fill="currentColor"
+          height="3"
+          rx="0.5"
+          ry="0.5"
+          width="6"
+          x="3"
+          y="5"
+        />
+      </svg>
+      <span>
+        Basics of gardening.pdf
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="48"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c9"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="48"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM6 9.5h2c.28 0 .5-.22.5-.5V8c0-.28-.22-.5-.5-.5H6c-.28 0-.5.22-.5.5v1c0 .28.22.5.5.5zm-2-2h2c.28 0 .5-.22.5-.5V6c0-.28-.22-.5-.5-.5H4c-.28 0-.5.22-.5.5v1c0 .28.22.5.5.5zm3.5-7V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Presentation bouquets.ppt
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="64"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c10"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="64"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.5h1m-1 2h1m-1 2h1m2-4h2m-2 2h2m-2 2h2m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Seed inventory.xlsx
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c11"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="80"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5.5v8m0-6h1m-2 1h1m0 1h1m-2 1h1m0 1h1m-2 1h1m6-4.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c12"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M4.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M2 2.5h8m-5.5 7V5m3 4.5V5m-5-.5V11c0 .3.2.5.5.5h6c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c13"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with multiple items 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c12 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 0%;
+  height: 6px;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 16%;
+  height: 6px;
+}
+
+.c8 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 32%;
+  height: 6px;
+}
+
+.c9 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 48%;
+  height: 6px;
+}
+
+.c10 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 64%;
+  height: 6px;
+}
+
+.c11 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 80%;
+  height: 6px;
+}
+
+.c13 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 100%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h7m-7 1.97h7m-7 2h7m3-7.27V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5m-11 9l2.65-2.65c.2-.2.51-.2.71 0l1.79 1.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l1.65 1.65"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <circle
+          cx="10.5"
+          cy="8.5"
+          fill="currentColor"
+          r="1.5"
+        />
+      </svg>
+      <span>
+        Rose petals.jpg
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="32"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c8"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="32"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15a.5.5 0 01-.5.5H2a.5.5 0 01-.5-.5V1A.5.5 0 012 .5h8.85a.5.5 0 01.36.15l3.15 3.2a.5.5 0 01.14.35zm-10 8.3h7m-7-2h7m-1-10V4a.5.5 0 00.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <rect
+          fill="currentColor"
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="8"
+          x="4"
+          y="7"
+        />
+      </svg>
+      <span>
+        Basics of gardening.pdf
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="48"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c9"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="48"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5M7 9.5h4c.28 0 .5.22.5.5v3c0 .28-.22.5-.5.5H7c-.28 0-.5-.22-.5-.5v-3c0-.28.22-.5.5-.5zm-.5 2H5c-.28 0-.5-.22-.5-.5V8c0-.28.22-.5.5-.5h4c.28 0 .5.22.5.5v1.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Presentation bouquets.ppt
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="64"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c10"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="64"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h2m-2 2h2m-2 2h2m2-4h3m-3 2h3m-3 2h3m3-7.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Seed inventory.xlsx
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c11"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="80"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.5.5v11M5 2.5h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m8-6.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c12"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M3 2.5h10m-6.5 11v-8m3 8v-8m-6-1V15c0 .3.2.5.5.5h8c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c13"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with multiple items, one with close and one with delete 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c7 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 0%;
+  height: 6px;
+}
+
+.c8 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 100%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.5.5v11M5 2.5h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m8-6.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c7"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M3 2.5h10m-6.5 11v-8m3 8v-8m-6-1V15c0 .3.2.5.5.5h8c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c8"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with multiple items, one with progress and one without 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 16%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h7m-7 1.97h7m-7 2h7m3-7.27V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders default FileListStory with no items 1`] = `
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+/>
+`;

--- a/packages/forms/demo/stories/__snapshots__/FileListStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/FileListStory.spec.tsx.snap
@@ -145,24 +145,24 @@ exports[`FileListStory Component renders FileListStory with a file that has prog
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -183,7 +183,7 @@ exports[`FileListStory Component renders FileListStory with a file that has prog
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -209,13 +209,13 @@ exports[`FileListStory Component renders FileListStory with a file that has prog
         aria-valuenow="16"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c6"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="16"
         />
@@ -303,17 +303,17 @@ exports[`FileListStory Component renders FileListStory with a single item 1`] = 
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <span>
         Unknown.txt
@@ -526,17 +526,17 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <span>
         Unknown.txt
@@ -546,19 +546,19 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -578,7 +578,7 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -604,13 +604,13 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
         aria-valuenow="0"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c6"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="0"
         />
@@ -620,19 +620,19 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -653,7 +653,7 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -679,13 +679,13 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
         aria-valuenow="16"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c7"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="16"
         />
@@ -695,19 +695,19 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -734,7 +734,7 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -760,13 +760,13 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
         aria-valuenow="32"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c8"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="32"
         />
@@ -776,19 +776,19 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -818,7 +818,7 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -844,13 +844,13 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
         aria-valuenow="48"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c9"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="48"
         />
@@ -860,19 +860,19 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -892,7 +892,7 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -918,13 +918,13 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
         aria-valuenow="64"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c10"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="64"
         />
@@ -934,19 +934,19 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -967,7 +967,7 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -993,13 +993,13 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
         aria-valuenow="80"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c11"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="80"
         />
@@ -1009,19 +1009,19 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -1042,7 +1042,7 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
         aria-label="Press backspace to delete"
         class="c3 c4 c12"
         data-garden-id="forms.file.delete"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -1069,13 +1069,13 @@ exports[`FileListStory Component renders FileListStory with all file types 1`] =
         aria-valuenow="100"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c13"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="100"
         />
@@ -1230,24 +1230,24 @@ exports[`FileListStory Component renders FileListStory with an item that has a c
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -1267,7 +1267,7 @@ exports[`FileListStory Component renders FileListStory with an item that has a c
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -1293,13 +1293,13 @@ exports[`FileListStory Component renders FileListStory with an item that has a c
         aria-valuenow="0"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c6"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="0"
         />
@@ -1458,24 +1458,24 @@ exports[`FileListStory Component renders FileListStory with an item that has a d
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -1496,7 +1496,7 @@ exports[`FileListStory Component renders FileListStory with an item that has a d
         aria-label="Press backspace to delete"
         class="c3 c4 c5"
         data-garden-id="forms.file.delete"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -1523,13 +1523,13 @@ exports[`FileListStory Component renders FileListStory with an item that has a d
         aria-valuenow="100"
         class="c6"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c7"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="100"
         />
@@ -1742,17 +1742,17 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <span>
         Unknown.txt
@@ -1762,19 +1762,19 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -1794,7 +1794,7 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -1820,13 +1820,13 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
         aria-valuenow="0"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c6"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="0"
         />
@@ -1836,19 +1836,19 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -1869,7 +1869,7 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -1895,13 +1895,13 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
         aria-valuenow="16"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c7"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="16"
         />
@@ -1911,19 +1911,19 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -1950,7 +1950,7 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -1976,13 +1976,13 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
         aria-valuenow="32"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c8"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="32"
         />
@@ -1992,19 +1992,19 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -2034,7 +2034,7 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -2060,13 +2060,13 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
         aria-valuenow="48"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c9"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="48"
         />
@@ -2076,19 +2076,19 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -2108,7 +2108,7 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -2134,13 +2134,13 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
         aria-valuenow="64"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c10"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="64"
         />
@@ -2150,19 +2150,19 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -2183,7 +2183,7 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -2209,13 +2209,13 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
         aria-valuenow="80"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c11"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="80"
         />
@@ -2225,19 +2225,19 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -2258,7 +2258,7 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
         aria-label="Press backspace to delete"
         class="c3 c4 c12"
         data-garden-id="forms.file.delete"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -2285,13 +2285,13 @@ exports[`FileListStory Component renders FileListStory with aria labels for clos
         aria-valuenow="100"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c13"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="100"
         />
@@ -2504,17 +2504,17 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <span>
         Unknown.txt
@@ -2524,19 +2524,19 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -2556,7 +2556,7 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -2582,13 +2582,13 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
         aria-valuenow="0"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c6"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="0"
         />
@@ -2598,19 +2598,19 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -2631,7 +2631,7 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -2657,13 +2657,13 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
         aria-valuenow="16"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c7"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="16"
         />
@@ -2673,19 +2673,19 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -2713,7 +2713,7 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -2739,13 +2739,13 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
         aria-valuenow="32"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c8"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="32"
         />
@@ -2755,19 +2755,19 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -2797,7 +2797,7 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -2823,13 +2823,13 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
         aria-valuenow="48"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c9"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="48"
         />
@@ -2839,19 +2839,19 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -2871,7 +2871,7 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -2897,13 +2897,13 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
         aria-valuenow="64"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c10"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="64"
         />
@@ -2913,19 +2913,19 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -2946,7 +2946,7 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -2972,13 +2972,13 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
         aria-valuenow="80"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c11"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="80"
         />
@@ -2988,19 +2988,19 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -3021,7 +3021,7 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
         aria-label="Press backspace to delete"
         class="c3 c4 c12"
         data-garden-id="forms.file.delete"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -3048,13 +3048,13 @@ exports[`FileListStory Component renders FileListStory with compact styling 1`] 
         aria-valuenow="100"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c13"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="100"
         />
@@ -3209,24 +3209,24 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -3246,7 +3246,7 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -3272,13 +3272,13 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-valuenow="0"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c6"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="0"
         />
@@ -3437,24 +3437,24 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -3475,7 +3475,7 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-label="Press backspace to delete"
         class="c3 c4 c5"
         data-garden-id="forms.file.delete"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -3502,13 +3502,13 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-valuenow="100"
         class="c6"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c7"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="100"
         />
@@ -3721,17 +3721,17 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <span>
         Unknown.txt
@@ -3741,19 +3741,19 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -3773,7 +3773,7 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -3799,13 +3799,13 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-valuenow="0"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c6"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="0"
         />
@@ -3815,19 +3815,19 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -3848,7 +3848,7 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -3874,13 +3874,13 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-valuenow="16"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c7"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="16"
         />
@@ -3890,19 +3890,19 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -3930,7 +3930,7 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -3956,13 +3956,13 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-valuenow="32"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c8"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="32"
         />
@@ -3972,19 +3972,19 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -4014,7 +4014,7 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -4040,13 +4040,13 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-valuenow="48"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c9"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="48"
         />
@@ -4056,19 +4056,19 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -4088,7 +4088,7 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -4114,13 +4114,13 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-valuenow="64"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c10"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="64"
         />
@@ -4130,19 +4130,19 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -4163,7 +4163,7 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -4189,13 +4189,13 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-valuenow="80"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c11"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="80"
         />
@@ -4205,19 +4205,19 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -4238,7 +4238,7 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-label="Press backspace to delete"
         class="c3 c4 c12"
         data-garden-id="forms.file.delete"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -4265,13 +4265,13 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-valuenow="100"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c13"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="100"
         />
@@ -4426,24 +4426,24 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -4464,7 +4464,7 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -4490,13 +4490,13 @@ exports[`FileListStory Component renders FileListStory with compact styling and 
         aria-valuenow="16"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c6"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="16"
         />
@@ -4709,17 +4709,17 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <span>
         Unknown.txt
@@ -4729,19 +4729,19 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -4761,7 +4761,7 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -4787,13 +4787,13 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
         aria-valuenow="0"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c6"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="0"
         />
@@ -4803,19 +4803,19 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -4836,7 +4836,7 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -4862,13 +4862,13 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
         aria-valuenow="16"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c7"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="16"
         />
@@ -4878,19 +4878,19 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -4918,7 +4918,7 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -4944,13 +4944,13 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
         aria-valuenow="32"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c8"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="32"
         />
@@ -4960,19 +4960,19 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -5002,7 +5002,7 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -5028,13 +5028,13 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
         aria-valuenow="48"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c9"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="48"
         />
@@ -5044,19 +5044,19 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -5076,7 +5076,7 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -5102,13 +5102,13 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
         aria-valuenow="64"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c10"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="64"
         />
@@ -5118,19 +5118,19 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -5151,7 +5151,7 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -5177,13 +5177,13 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
         aria-valuenow="80"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c11"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="80"
         />
@@ -5193,19 +5193,19 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -5226,7 +5226,7 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
         aria-label="Press backspace to delete"
         class="c3 c4 c12"
         data-garden-id="forms.file.delete"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -5253,13 +5253,13 @@ exports[`FileListStory Component renders FileListStory with compact styling, ari
         aria-valuenow="100"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c13"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="2"
           value="100"
         />
@@ -5472,17 +5472,17 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <span>
         Unknown.txt
@@ -5492,19 +5492,19 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -5524,7 +5524,7 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -5550,13 +5550,13 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
         aria-valuenow="0"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c6"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="0"
         />
@@ -5566,19 +5566,19 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -5599,7 +5599,7 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -5625,13 +5625,13 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
         aria-valuenow="16"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c7"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="16"
         />
@@ -5641,19 +5641,19 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -5680,7 +5680,7 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -5706,13 +5706,13 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
         aria-valuenow="32"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c8"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="32"
         />
@@ -5722,19 +5722,19 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -5764,7 +5764,7 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -5790,13 +5790,13 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
         aria-valuenow="48"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c9"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="48"
         />
@@ -5806,19 +5806,19 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -5838,7 +5838,7 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -5864,13 +5864,13 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
         aria-valuenow="64"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c10"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="64"
         />
@@ -5880,19 +5880,19 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -5913,7 +5913,7 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -5939,13 +5939,13 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
         aria-valuenow="80"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c11"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="80"
         />
@@ -5955,19 +5955,19 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -5988,7 +5988,7 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
         aria-label="Press backspace to delete"
         class="c3 c4 c12"
         data-garden-id="forms.file.delete"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -6015,13 +6015,13 @@ exports[`FileListStory Component renders FileListStory with multiple items 1`] =
         aria-valuenow="100"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c13"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="100"
         />
@@ -6189,24 +6189,24 @@ exports[`FileListStory Component renders FileListStory with multiple items, one 
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -6226,7 +6226,7 @@ exports[`FileListStory Component renders FileListStory with multiple items, one 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -6252,13 +6252,13 @@ exports[`FileListStory Component renders FileListStory with multiple items, one 
         aria-valuenow="0"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c6"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="0"
         />
@@ -6268,19 +6268,19 @@ exports[`FileListStory Component renders FileListStory with multiple items, one 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -6301,7 +6301,7 @@ exports[`FileListStory Component renders FileListStory with multiple items, one 
         aria-label="Press backspace to delete"
         class="c3 c4 c7"
         data-garden-id="forms.file.delete"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -6328,13 +6328,13 @@ exports[`FileListStory Component renders FileListStory with multiple items, one 
         aria-valuenow="100"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c8"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="100"
         />
@@ -6489,17 +6489,17 @@ exports[`FileListStory Component renders FileListStory with multiple items, one 
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <span>
         Unknown.txt
@@ -6509,19 +6509,19 @@ exports[`FileListStory Component renders FileListStory with multiple items, one 
   <li
     class=""
     data-garden-id="forms.file_list.item"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="forms.file"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       tabindex="0"
     >
       <svg
         aria-hidden="true"
         class=" c2"
         data-garden-id="forms.file.icon"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -6542,7 +6542,7 @@ exports[`FileListStory Component renders FileListStory with multiple items, one 
         aria-label="Press backspace to delete"
         class="c3 c4"
         data-garden-id="forms.file.close"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         tabindex="-1"
         type="button"
       >
@@ -6568,13 +6568,13 @@ exports[`FileListStory Component renders FileListStory with multiple items, one 
         aria-valuenow="16"
         class="c5"
         data-garden-id="loaders.progress_background"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         role="progressbar"
       >
         <div
           class="c6"
           data-garden-id="loaders.progress_indicator"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           height="6"
           value="16"
         />
@@ -6594,6 +6594,6 @@ exports[`FileListStory Component renders default FileListStory with no items 1`]
 <ul
   class="c0"
   data-garden-id="forms.file_list"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;

--- a/packages/forms/demo/stories/__snapshots__/InputGroupStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/InputGroupStory.spec.tsx.snap
@@ -404,14 +404,14 @@ exports[`InputGroupStory Component renders InputGroupStory with a hint 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r2:--input"
     id=":r2:--label"
   >
@@ -422,7 +422,7 @@ exports[`InputGroupStory Component renders InputGroupStory with a hint 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r2:--hint"
   >
     Enter your username
@@ -430,7 +430,7 @@ exports[`InputGroupStory Component renders InputGroupStory with a hint 1`] = `
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r2:--hint"
@@ -440,14 +440,14 @@ exports[`InputGroupStory Component renders InputGroupStory with a hint 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r2:--input"
       placeholder="Enter text"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -860,14 +860,14 @@ exports[`InputGroupStory Component renders InputGroupStory with a label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r1:--input"
     id=":r1:--label"
   >
@@ -878,7 +878,7 @@ exports[`InputGroupStory Component renders InputGroupStory with a label 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r1:--hint"
   >
     Hint
@@ -886,7 +886,7 @@ exports[`InputGroupStory Component renders InputGroupStory with a label 1`] = `
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r1:--hint"
@@ -896,14 +896,14 @@ exports[`InputGroupStory Component renders InputGroupStory with a label 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r1:--input"
       placeholder="Enter text"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -1316,14 +1316,14 @@ exports[`InputGroupStory Component renders InputGroupStory with a mix of text in
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rn:--input"
     id=":rn:--label"
   >
@@ -1334,7 +1334,7 @@ exports[`InputGroupStory Component renders InputGroupStory with a mix of text in
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--hint"
   >
     Hint
@@ -1342,7 +1342,7 @@ exports[`InputGroupStory Component renders InputGroupStory with a mix of text in
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rn:--hint"
@@ -1352,14 +1352,14 @@ exports[`InputGroupStory Component renders InputGroupStory with a mix of text in
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rn:--input"
       placeholder="First input"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -1372,7 +1372,7 @@ exports[`InputGroupStory Component renders InputGroupStory with a mix of text in
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rn:--input"
       placeholder="Second input"
     />
@@ -1568,14 +1568,14 @@ exports[`InputGroupStory Component renders InputGroupStory with a single button 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":re:--input"
     id=":re:--label"
   >
@@ -1586,7 +1586,7 @@ exports[`InputGroupStory Component renders InputGroupStory with a single button 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":re:--hint"
   >
     Hint
@@ -1594,12 +1594,12 @@ exports[`InputGroupStory Component renders InputGroupStory with a single button 
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <button
       class="c4"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -1911,14 +1911,14 @@ exports[`InputGroupStory Component renders InputGroupStory with a single text in
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rd:--input"
     id=":rd:--label"
   >
@@ -1929,7 +1929,7 @@ exports[`InputGroupStory Component renders InputGroupStory with a single text in
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rd:--hint"
   >
     Hint
@@ -1937,7 +1937,7 @@ exports[`InputGroupStory Component renders InputGroupStory with a single text in
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rd:--hint"
@@ -1947,7 +1947,7 @@ exports[`InputGroupStory Component renders InputGroupStory with a single text in
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rd:--input"
       placeholder="Enter text"
     />
@@ -2359,14 +2359,14 @@ exports[`InputGroupStory Component renders InputGroupStory with a text input and
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rf:--input"
     id=":rf:--label"
   >
@@ -2377,7 +2377,7 @@ exports[`InputGroupStory Component renders InputGroupStory with a text input and
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rf:--hint"
   >
     Hint
@@ -2385,7 +2385,7 @@ exports[`InputGroupStory Component renders InputGroupStory with a text input and
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rf:--hint"
@@ -2395,14 +2395,14 @@ exports[`InputGroupStory Component renders InputGroupStory with a text input and
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rf:--input"
       placeholder="Enter text"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -2815,14 +2815,14 @@ exports[`InputGroupStory Component renders InputGroupStory with bare styling 1`]
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r7:--input"
     id=":r7:--label"
   >
@@ -2833,7 +2833,7 @@ exports[`InputGroupStory Component renders InputGroupStory with bare styling 1`]
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--hint"
   >
     Hint
@@ -2841,7 +2841,7 @@ exports[`InputGroupStory Component renders InputGroupStory with bare styling 1`]
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r7:--hint"
@@ -2851,14 +2851,14 @@ exports[`InputGroupStory Component renders InputGroupStory with bare styling 1`]
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r7:--input"
       placeholder="Enter text"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -3271,14 +3271,14 @@ exports[`InputGroupStory Component renders InputGroupStory with compact styling 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r6:--input"
     id=":r6:--label"
   >
@@ -3289,7 +3289,7 @@ exports[`InputGroupStory Component renders InputGroupStory with compact styling 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r6:--hint"
   >
     Hint
@@ -3297,7 +3297,7 @@ exports[`InputGroupStory Component renders InputGroupStory with compact styling 
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r6:--hint"
@@ -3307,14 +3307,14 @@ exports[`InputGroupStory Component renders InputGroupStory with compact styling 
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r6:--input"
       placeholder="Enter text"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -3727,14 +3727,14 @@ exports[`InputGroupStory Component renders InputGroupStory with disabled and mul
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rr:--input"
     id=":rr:--label"
   >
@@ -3745,7 +3745,7 @@ exports[`InputGroupStory Component renders InputGroupStory with disabled and mul
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rr:--hint"
   >
     Hint
@@ -3753,7 +3753,7 @@ exports[`InputGroupStory Component renders InputGroupStory with disabled and mul
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rr:--hint"
@@ -3763,7 +3763,7 @@ exports[`InputGroupStory Component renders InputGroupStory with disabled and mul
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       disabled=""
       id=":rr:--input"
       placeholder="First input"
@@ -3771,7 +3771,7 @@ exports[`InputGroupStory Component renders InputGroupStory with disabled and mul
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       disabled=""
       type="button"
     >
@@ -4185,14 +4185,14 @@ exports[`InputGroupStory Component renders InputGroupStory with disabled input g
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r8:--input"
     id=":r8:--label"
   >
@@ -4203,7 +4203,7 @@ exports[`InputGroupStory Component renders InputGroupStory with disabled input g
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--hint"
   >
     Hint
@@ -4211,7 +4211,7 @@ exports[`InputGroupStory Component renders InputGroupStory with disabled input g
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r8:--hint"
@@ -4221,7 +4221,7 @@ exports[`InputGroupStory Component renders InputGroupStory with disabled input g
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       disabled=""
       id=":r8:--input"
       placeholder="Enter text"
@@ -4229,7 +4229,7 @@ exports[`InputGroupStory Component renders InputGroupStory with disabled input g
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       disabled=""
       type="button"
     >
@@ -4542,14 +4542,14 @@ exports[`InputGroupStory Component renders InputGroupStory with disabled input g
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rj:--input"
     id=":rj:--label"
   >
@@ -4560,7 +4560,7 @@ exports[`InputGroupStory Component renders InputGroupStory with disabled input g
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rj:--hint"
   >
     Hint
@@ -4568,7 +4568,7 @@ exports[`InputGroupStory Component renders InputGroupStory with disabled input g
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rj:--hint"
@@ -4578,7 +4578,7 @@ exports[`InputGroupStory Component renders InputGroupStory with disabled input g
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       disabled=""
       id=":rj:--input"
       placeholder="Enter text"
@@ -4991,14 +4991,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isDanger 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rc:--input"
     id=":rc:--label"
   >
@@ -5009,7 +5009,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isDanger 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rc:--hint"
   >
     Hint
@@ -5017,7 +5017,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isDanger 1`] = `
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rc:--hint"
@@ -5027,14 +5027,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isDanger 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rc:--input"
       placeholder="Enter text"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -5447,14 +5447,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isDanger and mul
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rq:--input"
     id=":rq:--label"
   >
@@ -5465,7 +5465,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isDanger and mul
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rq:--hint"
   >
     Hint
@@ -5473,7 +5473,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isDanger and mul
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rq:--hint"
@@ -5483,14 +5483,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isDanger and mul
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rq:--input"
       placeholder="First input"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -5802,14 +5802,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isDanger styling
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ri:--input"
     id=":ri:--label"
   >
@@ -5820,7 +5820,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isDanger styling
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ri:--hint"
   >
     Hint
@@ -5828,7 +5828,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isDanger styling
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":ri:--hint"
@@ -5838,7 +5838,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isDanger styling
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":ri:--input"
       placeholder="Enter text"
     />
@@ -6249,14 +6249,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isNeutral 1`] = 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ra:--input"
     id=":ra:--label"
   >
@@ -6267,7 +6267,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isNeutral 1`] = 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--hint"
   >
     Hint
@@ -6275,7 +6275,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isNeutral 1`] = 
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":ra:--hint"
@@ -6285,14 +6285,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isNeutral 1`] = 
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":ra:--input"
       placeholder="Enter text"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -6704,14 +6704,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isNeutral and mu
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ro:--input"
     id=":ro:--label"
   >
@@ -6722,7 +6722,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isNeutral and mu
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ro:--hint"
   >
     Hint
@@ -6730,7 +6730,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isNeutral and mu
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":ro:--hint"
@@ -6740,14 +6740,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isNeutral and mu
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":ro:--input"
       placeholder="First input"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -7059,14 +7059,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isNeutral stylin
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rg:--input"
     id=":rg:--label"
   >
@@ -7077,7 +7077,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isNeutral stylin
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rg:--hint"
   >
     Hint
@@ -7085,7 +7085,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isNeutral stylin
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rg:--hint"
@@ -7095,7 +7095,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isNeutral stylin
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rg:--input"
       placeholder="Enter text"
     />
@@ -7501,14 +7501,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isPrimary 1`] = 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rb:--input"
     id=":rb:--label"
   >
@@ -7519,7 +7519,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isPrimary 1`] = 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--hint"
   >
     Hint
@@ -7527,7 +7527,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isPrimary 1`] = 
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rb:--hint"
@@ -7537,14 +7537,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isPrimary 1`] = 
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rb:--input"
       placeholder="Enter text"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -7951,14 +7951,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isPrimary and mu
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rp:--input"
     id=":rp:--label"
   >
@@ -7969,7 +7969,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isPrimary and mu
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rp:--hint"
   >
     Hint
@@ -7977,7 +7977,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isPrimary and mu
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rp:--hint"
@@ -7987,14 +7987,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isPrimary and mu
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rp:--input"
       placeholder="First input"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -8306,14 +8306,14 @@ exports[`InputGroupStory Component renders InputGroupStory with isPrimary stylin
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rh:--input"
     id=":rh:--label"
   >
@@ -8324,7 +8324,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isPrimary stylin
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rh:--hint"
   >
     Hint
@@ -8332,7 +8332,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isPrimary stylin
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rh:--hint"
@@ -8342,7 +8342,7 @@ exports[`InputGroupStory Component renders InputGroupStory with isPrimary stylin
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rh:--input"
       placeholder="Enter text"
     />
@@ -8538,14 +8538,14 @@ exports[`InputGroupStory Component renders InputGroupStory with multiple buttons
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rl:--input"
     id=":rl:--label"
   >
@@ -8556,7 +8556,7 @@ exports[`InputGroupStory Component renders InputGroupStory with multiple buttons
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rl:--hint"
   >
     Hint
@@ -8564,12 +8564,12 @@ exports[`InputGroupStory Component renders InputGroupStory with multiple buttons
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <button
       class="c4"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Button 1
@@ -8577,7 +8577,7 @@ exports[`InputGroupStory Component renders InputGroupStory with multiple buttons
     <button
       class="c4"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Button 2
@@ -8889,14 +8889,14 @@ exports[`InputGroupStory Component renders InputGroupStory with multiple text in
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rm:--input"
     id=":rm:--label"
   >
@@ -8907,7 +8907,7 @@ exports[`InputGroupStory Component renders InputGroupStory with multiple text in
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rm:--hint"
   >
     Hint
@@ -8915,7 +8915,7 @@ exports[`InputGroupStory Component renders InputGroupStory with multiple text in
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rm:--hint"
@@ -8925,7 +8925,7 @@ exports[`InputGroupStory Component renders InputGroupStory with multiple text in
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rm:--input"
       placeholder="First input"
     />
@@ -8937,7 +8937,7 @@ exports[`InputGroupStory Component renders InputGroupStory with multiple text in
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rm:--input"
       placeholder="Second input"
     />
@@ -9349,14 +9349,14 @@ exports[`InputGroupStory Component renders InputGroupStory with readOnly and mul
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rs:--input"
     id=":rs:--label"
   >
@@ -9367,7 +9367,7 @@ exports[`InputGroupStory Component renders InputGroupStory with readOnly and mul
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rs:--hint"
   >
     Hint
@@ -9375,7 +9375,7 @@ exports[`InputGroupStory Component renders InputGroupStory with readOnly and mul
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rs:--hint"
@@ -9385,7 +9385,7 @@ exports[`InputGroupStory Component renders InputGroupStory with readOnly and mul
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rs:--input"
       placeholder="First input"
       readonly=""
@@ -9393,7 +9393,7 @@ exports[`InputGroupStory Component renders InputGroupStory with readOnly and mul
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -9806,14 +9806,14 @@ exports[`InputGroupStory Component renders InputGroupStory with readOnly input g
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r9:--input"
     id=":r9:--label"
   >
@@ -9824,7 +9824,7 @@ exports[`InputGroupStory Component renders InputGroupStory with readOnly input g
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--hint"
   >
     Hint
@@ -9832,7 +9832,7 @@ exports[`InputGroupStory Component renders InputGroupStory with readOnly input g
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r9:--hint"
@@ -9842,7 +9842,7 @@ exports[`InputGroupStory Component renders InputGroupStory with readOnly input g
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r9:--input"
       placeholder="Enter text"
       readonly=""
@@ -9850,7 +9850,7 @@ exports[`InputGroupStory Component renders InputGroupStory with readOnly input g
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -10162,14 +10162,14 @@ exports[`InputGroupStory Component renders InputGroupStory with readOnly input g
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rk:--input"
     id=":rk:--label"
   >
@@ -10180,7 +10180,7 @@ exports[`InputGroupStory Component renders InputGroupStory with readOnly input g
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rk:--hint"
   >
     Hint
@@ -10188,7 +10188,7 @@ exports[`InputGroupStory Component renders InputGroupStory with readOnly input g
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rk:--hint"
@@ -10198,7 +10198,7 @@ exports[`InputGroupStory Component renders InputGroupStory with readOnly input g
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rk:--input"
       placeholder="Enter text"
       readonly=""
@@ -10611,14 +10611,14 @@ exports[`InputGroupStory Component renders InputGroupStory with validation error
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r4:--input"
     id=":r4:--label"
   >
@@ -10629,7 +10629,7 @@ exports[`InputGroupStory Component renders InputGroupStory with validation error
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r4:--hint"
   >
     Hint
@@ -10637,7 +10637,7 @@ exports[`InputGroupStory Component renders InputGroupStory with validation error
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r4:--hint"
@@ -10647,14 +10647,14 @@ exports[`InputGroupStory Component renders InputGroupStory with validation error
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r4:--input"
       placeholder="Enter text"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -11067,14 +11067,14 @@ exports[`InputGroupStory Component renders InputGroupStory with validation succe
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r3:--input"
     id=":r3:--label"
   >
@@ -11085,7 +11085,7 @@ exports[`InputGroupStory Component renders InputGroupStory with validation succe
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r3:--hint"
   >
     Hint
@@ -11093,7 +11093,7 @@ exports[`InputGroupStory Component renders InputGroupStory with validation succe
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r3:--hint"
@@ -11103,14 +11103,14 @@ exports[`InputGroupStory Component renders InputGroupStory with validation succe
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r3:--input"
       placeholder="Enter text"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -11523,14 +11523,14 @@ exports[`InputGroupStory Component renders InputGroupStory with validation warni
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r5:--input"
     id=":r5:--label"
   >
@@ -11541,7 +11541,7 @@ exports[`InputGroupStory Component renders InputGroupStory with validation warni
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--hint"
   >
     Hint
@@ -11549,7 +11549,7 @@ exports[`InputGroupStory Component renders InputGroupStory with validation warni
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r5:--hint"
@@ -11559,14 +11559,14 @@ exports[`InputGroupStory Component renders InputGroupStory with validation warni
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r5:--input"
       placeholder="Enter text"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit
@@ -11979,14 +11979,14 @@ exports[`InputGroupStory Component renders default InputGroupStory 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r0:--input"
     id=":r0:--label"
   >
@@ -11997,7 +11997,7 @@ exports[`InputGroupStory Component renders default InputGroupStory 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r0:--hint"
   >
     Hint
@@ -12005,7 +12005,7 @@ exports[`InputGroupStory Component renders default InputGroupStory 1`] = `
   <div
     class="c3"
     data-garden-id="forms.input_group"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r0:--hint"
@@ -12015,14 +12015,14 @@ exports[`InputGroupStory Component renders default InputGroupStory 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r0:--input"
       placeholder="Enter text"
     />
     <button
       class="c6"
       data-garden-id="buttons.button"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       type="button"
     >
       Submit

--- a/packages/forms/demo/stories/__snapshots__/InputGroupStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/InputGroupStory.spec.tsx.snap
@@ -1,0 +1,12032 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InputGroupStory Component renders InputGroupStory with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r2:--input"
+    id=":r2:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r2:--hint"
+  >
+    Enter your username
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r2:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r2:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r2:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r1:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r1:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r1:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r1:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with a mix of text inputs and buttons 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rn:--input"
+    id=":rn:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rn:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rn:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rn:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rn:--input"
+      placeholder="First input"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+    <input
+      aria-describedby=":rn:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rn:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rn:--input"
+      placeholder="Second input"
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with a single button 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c4::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c4:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c4:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":re:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <button
+      class="c4"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with a single text input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    id=":rd:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rd:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rd:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rd:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rd:--input"
+      placeholder="Enter text"
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with a text input and a button 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rf:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rf:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rf:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rf:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with bare styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r7:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r7:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r7:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r7:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 11px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 32px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r6:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r6:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r6:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r6:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with disabled and multiple items 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rr:--input"
+    id=":rr:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rr:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rr:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rr:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      disabled=""
+      id=":rr:--input"
+      placeholder="First input"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      disabled=""
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with disabled input group 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    id=":r8:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r8:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r8:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      disabled=""
+      id=":r8:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      disabled=""
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with disabled input group 2`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rj:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rj:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rj:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      disabled=""
+      id=":rj:--input"
+      placeholder="Enter text"
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isDanger 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rc:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rc:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rc:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rc:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isDanger and multiple items 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rq:--input"
+    id=":rq:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rq:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rq:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rq:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rq:--input"
+      placeholder="First input"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isDanger styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":ri:--hint"
+      aria-invalid="false"
+      aria-labelledby=":ri:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":ri:--input"
+      placeholder="Enter text"
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isNeutral 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    id=":ra:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":ra:--hint"
+      aria-invalid="false"
+      aria-labelledby=":ra:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":ra:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isNeutral and multiple items 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ro:--input"
+    id=":ro:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ro:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":ro:--hint"
+      aria-invalid="false"
+      aria-labelledby=":ro:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":ro:--input"
+      placeholder="First input"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isNeutral styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rg:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rg:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rg:--input"
+      placeholder="Enter text"
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isPrimary 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  background-color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 0px solid transparent;
+  outline-offset: 2px;
+  box-shadow: inset 0 0 0 2px #fff, inset 0 0 0 2px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  background-color: #0f3655;
+}
+
+.c6:disabled {
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rb:--input"
+    id=":rb:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rb:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rb:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rb:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isPrimary and multiple items 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  background-color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 0px solid transparent;
+  outline-offset: 2px;
+  box-shadow: inset 0 0 0 2px #fff, inset 0 0 0 2px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  background-color: #0f3655;
+}
+
+.c6:disabled {
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rp:--input"
+    id=":rp:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rp:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rp:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rp:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rp:--input"
+      placeholder="First input"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isPrimary styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rh:--input"
+    id=":rh:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rh:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rh:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rh:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rh:--input"
+      placeholder="Enter text"
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with multiple buttons 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c4::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c4:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c4:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    id=":rl:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <button
+      class="c4"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Button 1
+    </button>
+    <button
+      class="c4"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Button 2
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with multiple text inputs 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rm:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rm:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rm:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rm:--input"
+      placeholder="First input"
+    />
+    <input
+      aria-describedby=":rm:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rm:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rm:--input"
+      placeholder="Second input"
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with readOnly and multiple items 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rs:--input"
+    id=":rs:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rs:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rs:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rs:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rs:--input"
+      placeholder="First input"
+      readonly=""
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with readOnly input group 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r9:--input"
+    id=":r9:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r9:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r9:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r9:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r9:--input"
+      placeholder="Enter text"
+      readonly=""
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with readOnly input group 2`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rk:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rk:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rk:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rk:--input"
+      placeholder="Enter text"
+      readonly=""
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r4:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r4:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r4:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r4:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    id=":r3:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r3:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r3:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r3:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r5:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r5:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r5:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r5:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders default InputGroupStory 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r0:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r0:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r0:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r0:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/InputStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/InputStory.spec.tsx.snap
@@ -1,0 +1,7130 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InputStory Component renders InputStory with a disabled input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":re:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":re:--hint"
+    aria-invalid="false"
+    aria-labelledby=":re:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":re:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a hidden label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c3 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2[readonly],
+.c2[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    hidden=""
+    id=":r3:--label"
+  >
+    Username
+  </label>
+  <input
+    aria-describedby=":r3:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r3:--label"
+    class="c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r3:--input"
+  />
+  <div
+    class="c3"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r4:--hint"
+  >
+    Enter your username
+  </div>
+  <input
+    aria-describedby=":r4:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r4:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r4:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r1:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":r1:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r1:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r1:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a label, hidden label, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c3 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2[readonly],
+.c2[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    hidden=""
+    id=":r8:--label"
+  >
+    Username
+  </label>
+  <input
+    aria-describedby=":r8:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r8:--label"
+    class="c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r8:--input"
+  />
+  <div
+    class="c3"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a label, hidden label, hint, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c3 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2[readonly],
+.c2[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    hidden=""
+    id=":ra:--label"
+  >
+    Username
+  </label>
+  <input
+    aria-describedby=":ra:--hint"
+    aria-invalid="false"
+    aria-labelledby=":ra:--label"
+    class="c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":ra:--input"
+  />
+  <div
+    class="c3"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    Enter your username
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c6 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c6 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c6 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c6 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r7:--hint"
+  >
+    Enter your username
+  </div>
+  <input
+    aria-describedby=":r7:--hint :r7:--message"
+    aria-invalid="false"
+    aria-labelledby=":r7:--label"
+    class="c5"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r7:--input"
+  />
+  <div
+    class="c6 c7"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r7:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a label, regular label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c6 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c6 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c6 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c6 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r9:--input"
+    id=":r9:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r9:--hint"
+  >
+    Enter your username
+  </div>
+  <input
+    aria-describedby=":r9:--hint :r9:--message"
+    aria-invalid="false"
+    aria-labelledby=":r9:--label"
+    class="c5"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r9:--input"
+  />
+  <div
+    class="c6 c7"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r9:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a label, regular label, hint, message, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c6 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c6 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c6 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c6 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rb:--input"
+    id=":rb:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    Enter your username
+  </div>
+  <input
+    aria-describedby=":rb:--hint :rb:--message"
+    aria-invalid="false"
+    aria-labelledby=":rb:--label"
+    class="c5"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rb:--input"
+  />
+  <div
+    class="c6 c7"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rb:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c6 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c6 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c6 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c6 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r5:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":r5:--hint :r5:--message"
+    aria-invalid="false"
+    aria-labelledby=":r5:--label"
+    class="c5"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r5:--input"
+  />
+  <div
+    class="c6 c7"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r5:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a placeholder 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rc:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rc:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rc:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rc:--input"
+    placeholder="Enter your username"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a read-only input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":ri:--hint"
+    aria-invalid="false"
+    aria-labelledby=":ri:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":ri:--input"
+    readonly=""
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a regular label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r2:--input"
+    id=":r2:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r2:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":r2:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r2:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r2:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a required input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rj:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rj:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rj:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rj:--input"
+    required=""
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r6:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":r6:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r6:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r6:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a value 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    id=":rd:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rd:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rd:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rd:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rd:--input"
+    value="JohnDoe"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with bare styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rg:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rg:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rg:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 11px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 32px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rf:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rf:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rf:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rf:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with label, hidden label, validation label, and bare input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c3 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ro:--input"
+    hidden=""
+    id=":ro:--label"
+  >
+    Username
+  </label>
+  <input
+    aria-describedby=":ro:--hint"
+    aria-invalid="false"
+    aria-labelledby=":ro:--label"
+    class="c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":ro:--input"
+  />
+  <div
+    class="c3"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ro:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with label, hint, message, and compact input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c6 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c6 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 11px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 32px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c6 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c6 {
+  margin-top: 4px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rn:--input"
+    id=":rn:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rn:--hint"
+  >
+    Enter your username
+  </div>
+  <input
+    aria-describedby=":rn:--hint :rn:--message"
+    aria-invalid="false"
+    aria-labelledby=":rn:--label"
+    class="c5"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rn:--input"
+  />
+  <div
+    class="c6 c7"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rn:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with label, regular label, hint, message, validation label, and disabled input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c6 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c6 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c6 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c6 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rp:--input"
+    id=":rp:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rp:--hint"
+  >
+    Enter your username
+  </div>
+  <input
+    aria-describedby=":rp:--hint :rp:--message"
+    aria-invalid="false"
+    aria-labelledby=":rp:--label"
+    class="c5"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":rp:--input"
+  />
+  <div
+    class="c6 c7"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rp:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with type password 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rh:--input"
+    id=":rh:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rh:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rh:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rh:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rh:--input"
+    type="password"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #cd3642;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    id=":rl:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rl:--hint"
+    aria-invalid="true"
+    aria-labelledby=":rl:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rl:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #037f52;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #037f52;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rk:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rk:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rk:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rk:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #ac5918;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #ac5918;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rm:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rm:--hint"
+    aria-invalid="true"
+    aria-labelledby=":rm:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rm:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders default InputStory 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r0:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":r0:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r0:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r0:--input"
+  />
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/InputStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/InputStory.spec.tsx.snap
@@ -229,14 +229,14 @@ exports[`InputStory Component renders InputStory with a disabled input 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":re:--input"
     id=":re:--label"
   >
@@ -247,7 +247,7 @@ exports[`InputStory Component renders InputStory with a disabled input 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":re:--hint"
   >
     Hint
@@ -260,7 +260,7 @@ exports[`InputStory Component renders InputStory with a disabled input 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     disabled=""
     id=":re:--input"
   />
@@ -496,14 +496,14 @@ exports[`InputStory Component renders InputStory with a hidden label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r3:--input"
     hidden=""
     id=":r3:--label"
@@ -518,7 +518,7 @@ exports[`InputStory Component renders InputStory with a hidden label 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r3:--input"
   />
   <div
@@ -526,7 +526,7 @@ exports[`InputStory Component renders InputStory with a hidden label 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r3:--hint"
   >
     Hint
@@ -763,14 +763,14 @@ exports[`InputStory Component renders InputStory with a hint 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r4:--input"
     id=":r4:--label"
   >
@@ -781,7 +781,7 @@ exports[`InputStory Component renders InputStory with a hint 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r4:--hint"
   >
     Enter your username
@@ -794,7 +794,7 @@ exports[`InputStory Component renders InputStory with a hint 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r4:--input"
   />
 </div>
@@ -1029,14 +1029,14 @@ exports[`InputStory Component renders InputStory with a label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r1:--input"
     id=":r1:--label"
   >
@@ -1047,7 +1047,7 @@ exports[`InputStory Component renders InputStory with a label 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r1:--hint"
   >
     Hint
@@ -1060,7 +1060,7 @@ exports[`InputStory Component renders InputStory with a label 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r1:--input"
   />
 </div>
@@ -1295,14 +1295,14 @@ exports[`InputStory Component renders InputStory with a label, hidden label, and
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r8:--input"
     hidden=""
     id=":r8:--label"
@@ -1317,7 +1317,7 @@ exports[`InputStory Component renders InputStory with a label, hidden label, and
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--input"
   />
   <div
@@ -1325,7 +1325,7 @@ exports[`InputStory Component renders InputStory with a label, hidden label, and
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--hint"
   >
     Hint
@@ -1562,14 +1562,14 @@ exports[`InputStory Component renders InputStory with a label, hidden label, hin
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ra:--input"
     hidden=""
     id=":ra:--label"
@@ -1584,7 +1584,7 @@ exports[`InputStory Component renders InputStory with a label, hidden label, hin
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--input"
   />
   <div
@@ -1592,7 +1592,7 @@ exports[`InputStory Component renders InputStory with a label, hidden label, hin
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--hint"
   >
     Enter your username
@@ -1854,14 +1854,14 @@ exports[`InputStory Component renders InputStory with a label, hint, and message
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r7:--input"
     id=":r7:--label"
   >
@@ -1872,7 +1872,7 @@ exports[`InputStory Component renders InputStory with a label, hint, and message
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--hint"
   >
     Enter your username
@@ -1885,7 +1885,7 @@ exports[`InputStory Component renders InputStory with a label, hint, and message
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--input"
   />
   <div
@@ -1893,7 +1893,7 @@ exports[`InputStory Component renders InputStory with a label, hint, and message
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--message"
     role="alert"
   >
@@ -2156,14 +2156,14 @@ exports[`InputStory Component renders InputStory with a label, regular label, hi
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r9:--input"
     id=":r9:--label"
   >
@@ -2174,7 +2174,7 @@ exports[`InputStory Component renders InputStory with a label, regular label, hi
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--hint"
   >
     Enter your username
@@ -2187,7 +2187,7 @@ exports[`InputStory Component renders InputStory with a label, regular label, hi
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--input"
   />
   <div
@@ -2195,7 +2195,7 @@ exports[`InputStory Component renders InputStory with a label, regular label, hi
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--message"
     role="alert"
   >
@@ -2458,14 +2458,14 @@ exports[`InputStory Component renders InputStory with a label, regular label, hi
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rb:--input"
     id=":rb:--label"
   >
@@ -2476,7 +2476,7 @@ exports[`InputStory Component renders InputStory with a label, regular label, hi
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--hint"
   >
     Enter your username
@@ -2489,7 +2489,7 @@ exports[`InputStory Component renders InputStory with a label, regular label, hi
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--input"
   />
   <div
@@ -2497,7 +2497,7 @@ exports[`InputStory Component renders InputStory with a label, regular label, hi
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--message"
     role="alert"
   >
@@ -2760,14 +2760,14 @@ exports[`InputStory Component renders InputStory with a message 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r5:--input"
     id=":r5:--label"
   >
@@ -2778,7 +2778,7 @@ exports[`InputStory Component renders InputStory with a message 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--hint"
   >
     Hint
@@ -2791,7 +2791,7 @@ exports[`InputStory Component renders InputStory with a message 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--input"
   />
   <div
@@ -2799,7 +2799,7 @@ exports[`InputStory Component renders InputStory with a message 1`] = `
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--message"
     role="alert"
   >
@@ -3037,14 +3037,14 @@ exports[`InputStory Component renders InputStory with a placeholder 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rc:--input"
     id=":rc:--label"
   >
@@ -3055,7 +3055,7 @@ exports[`InputStory Component renders InputStory with a placeholder 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rc:--hint"
   >
     Hint
@@ -3068,7 +3068,7 @@ exports[`InputStory Component renders InputStory with a placeholder 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rc:--input"
     placeholder="Enter your username"
   />
@@ -3304,14 +3304,14 @@ exports[`InputStory Component renders InputStory with a read-only input 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ri:--input"
     id=":ri:--label"
   >
@@ -3322,7 +3322,7 @@ exports[`InputStory Component renders InputStory with a read-only input 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ri:--hint"
   >
     Hint
@@ -3335,7 +3335,7 @@ exports[`InputStory Component renders InputStory with a read-only input 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ri:--input"
     readonly=""
   />
@@ -3571,14 +3571,14 @@ exports[`InputStory Component renders InputStory with a regular label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r2:--input"
     id=":r2:--label"
   >
@@ -3589,7 +3589,7 @@ exports[`InputStory Component renders InputStory with a regular label 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r2:--hint"
   >
     Hint
@@ -3602,7 +3602,7 @@ exports[`InputStory Component renders InputStory with a regular label 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r2:--input"
   />
 </div>
@@ -3837,14 +3837,14 @@ exports[`InputStory Component renders InputStory with a required input 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rj:--input"
     id=":rj:--label"
   >
@@ -3855,7 +3855,7 @@ exports[`InputStory Component renders InputStory with a required input 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rj:--hint"
   >
     Hint
@@ -3868,7 +3868,7 @@ exports[`InputStory Component renders InputStory with a required input 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rj:--input"
     required=""
   />
@@ -4104,14 +4104,14 @@ exports[`InputStory Component renders InputStory with a validation label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r6:--input"
     id=":r6:--label"
   >
@@ -4122,7 +4122,7 @@ exports[`InputStory Component renders InputStory with a validation label 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r6:--hint"
   >
     Hint
@@ -4135,7 +4135,7 @@ exports[`InputStory Component renders InputStory with a validation label 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r6:--input"
   />
 </div>
@@ -4370,14 +4370,14 @@ exports[`InputStory Component renders InputStory with a value 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rd:--input"
     id=":rd:--label"
   >
@@ -4388,7 +4388,7 @@ exports[`InputStory Component renders InputStory with a value 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rd:--hint"
   >
     Hint
@@ -4401,7 +4401,7 @@ exports[`InputStory Component renders InputStory with a value 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rd:--input"
     value="JohnDoe"
   />
@@ -4630,14 +4630,14 @@ exports[`InputStory Component renders InputStory with bare styling 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rg:--input"
     id=":rg:--label"
   >
@@ -4648,7 +4648,7 @@ exports[`InputStory Component renders InputStory with bare styling 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rg:--hint"
   >
     Hint
@@ -4661,7 +4661,7 @@ exports[`InputStory Component renders InputStory with bare styling 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rg:--input"
   />
 </div>
@@ -4896,14 +4896,14 @@ exports[`InputStory Component renders InputStory with compact styling 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rf:--input"
     id=":rf:--label"
   >
@@ -4914,7 +4914,7 @@ exports[`InputStory Component renders InputStory with compact styling 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rf:--hint"
   >
     Hint
@@ -4927,7 +4927,7 @@ exports[`InputStory Component renders InputStory with compact styling 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rf:--input"
   />
 </div>
@@ -5155,14 +5155,14 @@ exports[`InputStory Component renders InputStory with label, hidden label, valid
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ro:--input"
     hidden=""
     id=":ro:--label"
@@ -5177,7 +5177,7 @@ exports[`InputStory Component renders InputStory with label, hidden label, valid
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ro:--input"
   />
   <div
@@ -5185,7 +5185,7 @@ exports[`InputStory Component renders InputStory with label, hidden label, valid
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ro:--hint"
   >
     Hint
@@ -5447,14 +5447,14 @@ exports[`InputStory Component renders InputStory with label, hint, message, and 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rn:--input"
     id=":rn:--label"
   >
@@ -5465,7 +5465,7 @@ exports[`InputStory Component renders InputStory with label, hint, message, and 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--hint"
   >
     Enter your username
@@ -5478,7 +5478,7 @@ exports[`InputStory Component renders InputStory with label, hint, message, and 
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--input"
   />
   <div
@@ -5486,7 +5486,7 @@ exports[`InputStory Component renders InputStory with label, hint, message, and 
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--message"
     role="alert"
   >
@@ -5749,14 +5749,14 @@ exports[`InputStory Component renders InputStory with label, regular label, hint
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rp:--input"
     id=":rp:--label"
   >
@@ -5767,7 +5767,7 @@ exports[`InputStory Component renders InputStory with label, regular label, hint
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rp:--hint"
   >
     Enter your username
@@ -5780,7 +5780,7 @@ exports[`InputStory Component renders InputStory with label, regular label, hint
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     disabled=""
     id=":rp:--input"
   />
@@ -5789,7 +5789,7 @@ exports[`InputStory Component renders InputStory with label, regular label, hint
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rp:--message"
     role="alert"
   >
@@ -6027,14 +6027,14 @@ exports[`InputStory Component renders InputStory with type password 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rh:--input"
     id=":rh:--label"
   >
@@ -6045,7 +6045,7 @@ exports[`InputStory Component renders InputStory with type password 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rh:--hint"
   >
     Hint
@@ -6058,7 +6058,7 @@ exports[`InputStory Component renders InputStory with type password 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rh:--input"
     type="password"
   />
@@ -6294,14 +6294,14 @@ exports[`InputStory Component renders InputStory with validation error 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rl:--input"
     id=":rl:--label"
   >
@@ -6312,7 +6312,7 @@ exports[`InputStory Component renders InputStory with validation error 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rl:--hint"
   >
     Hint
@@ -6325,7 +6325,7 @@ exports[`InputStory Component renders InputStory with validation error 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rl:--input"
   />
 </div>
@@ -6560,14 +6560,14 @@ exports[`InputStory Component renders InputStory with validation success 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rk:--input"
     id=":rk:--label"
   >
@@ -6578,7 +6578,7 @@ exports[`InputStory Component renders InputStory with validation success 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rk:--hint"
   >
     Hint
@@ -6591,7 +6591,7 @@ exports[`InputStory Component renders InputStory with validation success 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rk:--input"
   />
 </div>
@@ -6826,14 +6826,14 @@ exports[`InputStory Component renders InputStory with validation warning 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rm:--input"
     id=":rm:--label"
   >
@@ -6844,7 +6844,7 @@ exports[`InputStory Component renders InputStory with validation warning 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rm:--hint"
   >
     Hint
@@ -6857,7 +6857,7 @@ exports[`InputStory Component renders InputStory with validation warning 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rm:--input"
   />
 </div>
@@ -7092,14 +7092,14 @@ exports[`InputStory Component renders default InputStory 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r0:--input"
     id=":r0:--label"
   >
@@ -7110,7 +7110,7 @@ exports[`InputStory Component renders default InputStory 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r0:--hint"
   >
     Hint
@@ -7123,7 +7123,7 @@ exports[`InputStory Component renders default InputStory 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r0:--input"
   />
 </div>

--- a/packages/forms/demo/stories/__snapshots__/MediaInputStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/MediaInputStory.spec.tsx.snap
@@ -443,14 +443,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a disabled input
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rf:--input"
     id=":rf:--label"
   >
@@ -461,7 +461,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a disabled input
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rf:--hint"
   >
     Hint
@@ -471,7 +471,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a disabled input
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rf:--hint"
@@ -481,7 +481,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a disabled input
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       disabled=""
       id=":rf:--input"
     />
@@ -932,14 +932,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a hidden label 1
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r3:--input"
     hidden=""
     id=":r3:--label"
@@ -950,7 +950,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a hidden label 1
     aria-invalid="false"
     class="c2 c3 c4"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r3:--hint"
@@ -960,7 +960,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a hidden label 1
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r3:--input"
     />
   </div>
@@ -969,7 +969,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a hidden label 1
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r3:--hint"
   >
     Hint
@@ -1420,14 +1420,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a hint 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r4:--input"
     id=":r4:--label"
   >
@@ -1438,7 +1438,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a hint 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r4:--hint"
   >
     Enter a search term
@@ -1447,7 +1447,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a hint 1`] = `
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r4:--hint"
@@ -1457,7 +1457,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a hint 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r4:--input"
     />
   </div>
@@ -1907,14 +1907,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r1:--input"
     id=":r1:--label"
   >
@@ -1925,7 +1925,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r1:--hint"
   >
     Hint
@@ -1934,7 +1934,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label 1`] = `
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r1:--hint"
@@ -1944,7 +1944,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r1:--input"
     />
   </div>
@@ -2394,14 +2394,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, hidden 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rb:--input"
     hidden=""
     id=":rb:--label"
@@ -2412,7 +2412,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, hidden 
     aria-invalid="false"
     class="c2 c3 c4"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rb:--hint"
@@ -2422,7 +2422,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, hidden 
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rb:--input"
     />
   </div>
@@ -2431,7 +2431,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, hidden 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--hint"
   >
     Hint
@@ -2882,14 +2882,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, hidden 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rd:--input"
     hidden=""
     id=":rd:--label"
@@ -2900,7 +2900,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, hidden 
     aria-invalid="false"
     class="c2 c3 c4"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rd:--hint"
@@ -2910,7 +2910,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, hidden 
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rd:--input"
     />
   </div>
@@ -2919,7 +2919,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, hidden 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rd:--hint"
   >
     Enter a search term
@@ -3403,14 +3403,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, hint, a
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ra:--input"
     id=":ra:--label"
   >
@@ -3421,7 +3421,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, hint, a
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--hint"
   >
     Enter a search term
@@ -3430,7 +3430,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, hint, a
     aria-invalid="false"
     class="c5 c6 c7"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":ra:--hint :ra:--message"
@@ -3440,7 +3440,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, hint, a
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":ra:--input"
     />
   </div>
@@ -3449,7 +3449,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, hint, a
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--message"
     role="alert"
   >
@@ -3934,14 +3934,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, regular
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rc:--input"
     id=":rc:--label"
   >
@@ -3952,7 +3952,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, regular
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rc:--hint"
   >
     Enter a search term
@@ -3961,7 +3961,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, regular
     aria-invalid="false"
     class="c5 c6 c7"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rc:--hint :rc:--message"
@@ -3971,7 +3971,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, regular
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rc:--input"
     />
   </div>
@@ -3980,7 +3980,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, regular
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rc:--message"
     role="alert"
   >
@@ -4465,14 +4465,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, regular
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":re:--input"
     id=":re:--label"
   >
@@ -4483,7 +4483,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, regular
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":re:--hint"
   >
     Enter a search term
@@ -4492,7 +4492,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, regular
     aria-invalid="false"
     class="c5 c6 c7"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":re:--hint :re:--message"
@@ -4502,7 +4502,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, regular
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":re:--input"
     />
   </div>
@@ -4511,7 +4511,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a label, regular
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":re:--message"
     role="alert"
   >
@@ -4996,14 +4996,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a message 1`] = 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r5:--input"
     id=":r5:--label"
   >
@@ -5014,7 +5014,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a message 1`] = 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--hint"
   >
     Hint
@@ -5023,7 +5023,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a message 1`] = 
     aria-invalid="false"
     class="c5 c6 c7"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r5:--hint :r5:--message"
@@ -5033,7 +5033,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a message 1`] = 
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r5:--input"
     />
   </div>
@@ -5042,7 +5042,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a message 1`] = 
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--message"
     role="alert"
   >
@@ -5494,14 +5494,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a read-only inpu
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ri:--input"
     id=":ri:--label"
   >
@@ -5512,7 +5512,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a read-only inpu
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ri:--hint"
   >
     Hint
@@ -5522,7 +5522,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a read-only inpu
     aria-readonly="true"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":ri:--hint"
@@ -5532,7 +5532,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a read-only inpu
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":ri:--input"
       readonly=""
     />
@@ -5983,14 +5983,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a regular label 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r2:--input"
     id=":r2:--label"
   >
@@ -6001,7 +6001,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a regular label 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r2:--hint"
   >
     Hint
@@ -6010,7 +6010,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a regular label 
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r2:--hint"
@@ -6020,7 +6020,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a regular label 
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r2:--input"
     />
   </div>
@@ -6470,14 +6470,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a required input
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rj:--input"
     id=":rj:--label"
   >
@@ -6488,7 +6488,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a required input
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rj:--hint"
   >
     Hint
@@ -6497,7 +6497,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a required input
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rj:--hint"
@@ -6507,7 +6507,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a required input
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rj:--input"
       required=""
     />
@@ -6974,14 +6974,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a start icon 1`]
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r7:--input"
     id=":r7:--label"
   >
@@ -6992,7 +6992,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a start icon 1`]
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--hint"
   >
     Hint
@@ -7001,12 +7001,12 @@ exports[`MediaInputStory Component renders MediaInputStory with a start icon 1`]
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       class="c6  c7"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       xmlns="http://www.w3.org/2000/svg"
     />
     <input
@@ -7017,7 +7017,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a start icon 1`]
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r7:--input"
     />
   </div>
@@ -7467,14 +7467,14 @@ exports[`MediaInputStory Component renders MediaInputStory with a validation lab
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r6:--input"
     id=":r6:--label"
   >
@@ -7485,7 +7485,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a validation lab
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r6:--hint"
   >
     Hint
@@ -7494,7 +7494,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a validation lab
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r6:--hint"
@@ -7504,7 +7504,7 @@ exports[`MediaInputStory Component renders MediaInputStory with a validation lab
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r6:--input"
     />
   </div>
@@ -7970,14 +7970,14 @@ exports[`MediaInputStory Component renders MediaInputStory with an end icon 1`] 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r8:--input"
     id=":r8:--label"
   >
@@ -7988,7 +7988,7 @@ exports[`MediaInputStory Component renders MediaInputStory with an end icon 1`] 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--hint"
   >
     Hint
@@ -7997,7 +7997,7 @@ exports[`MediaInputStory Component renders MediaInputStory with an end icon 1`] 
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r8:--hint"
@@ -8007,13 +8007,13 @@ exports[`MediaInputStory Component renders MediaInputStory with an end icon 1`] 
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r8:--input"
     />
     <svg
       class="c8  c9"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       xmlns="http://www.w3.org/2000/svg"
     />
   </div>
@@ -8276,14 +8276,14 @@ exports[`MediaInputStory Component renders MediaInputStory with bare styling 1`]
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rh:--input"
     id=":rh:--label"
   >
@@ -8294,7 +8294,7 @@ exports[`MediaInputStory Component renders MediaInputStory with bare styling 1`]
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rh:--hint"
   >
     Hint
@@ -8303,7 +8303,7 @@ exports[`MediaInputStory Component renders MediaInputStory with bare styling 1`]
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rh:--hint"
@@ -8313,7 +8313,7 @@ exports[`MediaInputStory Component renders MediaInputStory with bare styling 1`]
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rh:--input"
     />
   </div>
@@ -8789,14 +8789,14 @@ exports[`MediaInputStory Component renders MediaInputStory with both start and e
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r9:--input"
     id=":r9:--label"
   >
@@ -8807,7 +8807,7 @@ exports[`MediaInputStory Component renders MediaInputStory with both start and e
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--hint"
   >
     Hint
@@ -8816,12 +8816,12 @@ exports[`MediaInputStory Component renders MediaInputStory with both start and e
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <svg
       class="c6  c7"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       xmlns="http://www.w3.org/2000/svg"
     />
     <input
@@ -8832,13 +8832,13 @@ exports[`MediaInputStory Component renders MediaInputStory with both start and e
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r9:--input"
     />
     <svg
       class="c6  c10"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       xmlns="http://www.w3.org/2000/svg"
     />
   </div>
@@ -9288,14 +9288,14 @@ exports[`MediaInputStory Component renders MediaInputStory with compact styling 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rg:--input"
     id=":rg:--label"
   >
@@ -9306,7 +9306,7 @@ exports[`MediaInputStory Component renders MediaInputStory with compact styling 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rg:--hint"
   >
     Hint
@@ -9315,7 +9315,7 @@ exports[`MediaInputStory Component renders MediaInputStory with compact styling 
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rg:--hint"
@@ -9325,7 +9325,7 @@ exports[`MediaInputStory Component renders MediaInputStory with compact styling 
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rg:--input"
     />
   </div>
@@ -9588,14 +9588,14 @@ exports[`MediaInputStory Component renders MediaInputStory with label, hidden la
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ro:--input"
     hidden=""
     id=":ro:--label"
@@ -9606,7 +9606,7 @@ exports[`MediaInputStory Component renders MediaInputStory with label, hidden la
     aria-invalid="false"
     class="c2 c3 c4"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":ro:--hint"
@@ -9616,7 +9616,7 @@ exports[`MediaInputStory Component renders MediaInputStory with label, hidden la
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":ro:--input"
     />
   </div>
@@ -9625,7 +9625,7 @@ exports[`MediaInputStory Component renders MediaInputStory with label, hidden la
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ro:--hint"
   >
     Hint
@@ -10109,14 +10109,14 @@ exports[`MediaInputStory Component renders MediaInputStory with label, hint, mes
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rn:--input"
     id=":rn:--label"
   >
@@ -10127,7 +10127,7 @@ exports[`MediaInputStory Component renders MediaInputStory with label, hint, mes
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--hint"
   >
     Enter a search term
@@ -10136,7 +10136,7 @@ exports[`MediaInputStory Component renders MediaInputStory with label, hint, mes
     aria-invalid="false"
     class="c5 c6 c7"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rn:--hint :rn:--message"
@@ -10146,7 +10146,7 @@ exports[`MediaInputStory Component renders MediaInputStory with label, hint, mes
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rn:--input"
     />
   </div>
@@ -10155,7 +10155,7 @@ exports[`MediaInputStory Component renders MediaInputStory with label, hint, mes
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--message"
     role="alert"
   >
@@ -10640,14 +10640,14 @@ exports[`MediaInputStory Component renders MediaInputStory with label, regular l
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rp:--input"
     id=":rp:--label"
   >
@@ -10658,7 +10658,7 @@ exports[`MediaInputStory Component renders MediaInputStory with label, regular l
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rp:--hint"
   >
     Enter a search term
@@ -10668,7 +10668,7 @@ exports[`MediaInputStory Component renders MediaInputStory with label, regular l
     aria-invalid="false"
     class="c5 c6 c7"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rp:--hint :rp:--message"
@@ -10678,7 +10678,7 @@ exports[`MediaInputStory Component renders MediaInputStory with label, regular l
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       disabled=""
       id=":rp:--input"
     />
@@ -10688,7 +10688,7 @@ exports[`MediaInputStory Component renders MediaInputStory with label, regular l
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rp:--message"
     role="alert"
   >
@@ -11140,14 +11140,14 @@ exports[`MediaInputStory Component renders MediaInputStory with validation error
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rl:--input"
     id=":rl:--label"
   >
@@ -11158,7 +11158,7 @@ exports[`MediaInputStory Component renders MediaInputStory with validation error
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rl:--hint"
   >
     Hint
@@ -11167,7 +11167,7 @@ exports[`MediaInputStory Component renders MediaInputStory with validation error
     aria-invalid="true"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rl:--hint"
@@ -11177,7 +11177,7 @@ exports[`MediaInputStory Component renders MediaInputStory with validation error
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rl:--input"
     />
   </div>
@@ -11627,14 +11627,14 @@ exports[`MediaInputStory Component renders MediaInputStory with validation succe
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rk:--input"
     id=":rk:--label"
   >
@@ -11645,7 +11645,7 @@ exports[`MediaInputStory Component renders MediaInputStory with validation succe
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rk:--hint"
   >
     Hint
@@ -11654,7 +11654,7 @@ exports[`MediaInputStory Component renders MediaInputStory with validation succe
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rk:--hint"
@@ -11664,7 +11664,7 @@ exports[`MediaInputStory Component renders MediaInputStory with validation succe
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rk:--input"
     />
   </div>
@@ -12114,14 +12114,14 @@ exports[`MediaInputStory Component renders MediaInputStory with validation warni
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rm:--input"
     id=":rm:--label"
   >
@@ -12132,7 +12132,7 @@ exports[`MediaInputStory Component renders MediaInputStory with validation warni
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rm:--hint"
   >
     Hint
@@ -12141,7 +12141,7 @@ exports[`MediaInputStory Component renders MediaInputStory with validation warni
     aria-invalid="true"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":rm:--hint"
@@ -12151,7 +12151,7 @@ exports[`MediaInputStory Component renders MediaInputStory with validation warni
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rm:--input"
     />
   </div>
@@ -12601,14 +12601,14 @@ exports[`MediaInputStory Component renders default MediaInputStory 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r0:--input"
     id=":r0:--label"
   >
@@ -12619,7 +12619,7 @@ exports[`MediaInputStory Component renders default MediaInputStory 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r0:--hint"
   >
     Hint
@@ -12628,7 +12628,7 @@ exports[`MediaInputStory Component renders default MediaInputStory 1`] = `
     aria-invalid="false"
     class="c3 c4 c5"
     data-garden-id="forms.faux_input"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <input
       aria-describedby=":r0:--hint"
@@ -12638,7 +12638,7 @@ exports[`MediaInputStory Component renders default MediaInputStory 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.media_input"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r0:--input"
     />
   </div>

--- a/packages/forms/demo/stories/__snapshots__/MediaInputStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/MediaInputStory.spec.tsx.snap
@@ -1,0 +1,12646 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MediaInputStory Component renders MediaInputStory with a disabled input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rf:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-disabled="true"
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rf:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rf:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      disabled=""
+      id=":rf:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a hidden label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c6 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    hidden=""
+    id=":r3:--label"
+  >
+    Search
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r3:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r3:--label"
+      class="c2 c5 c6"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r3:--input"
+    />
+  </div>
+  <div
+    class="c7"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r4:--hint"
+  >
+    Enter a search term
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r4:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r4:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r4:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r1:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r1:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r1:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r1:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a label, hidden label, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c6 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rb:--input"
+    hidden=""
+    id=":rb:--label"
+  >
+    Search
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rb:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rb:--label"
+      class="c2 c5 c6"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rb:--input"
+    />
+  </div>
+  <div
+    class="c7"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a label, hidden label, hint, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c6 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    hidden=""
+    id=":rd:--label"
+  >
+    Search
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rd:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rd:--label"
+      class="c2 c5 c6"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rd:--input"
+    />
+  </div>
+  <div
+    class="c7"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rd:--hint"
+  >
+    Enter a search term
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c11 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c10 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c10 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c10 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c8.c8,
+.c3 + .c8.c8,
+.c10 + .c8.c8,
+.c8.c8 + .c3,
+.c8.c8 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    id=":ra:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    Enter a search term
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":ra:--hint :ra:--message"
+      aria-invalid="false"
+      aria-labelledby=":ra:--label"
+      class="c5 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":ra:--input"
+    />
+  </div>
+  <div
+    class="c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":ra:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a label, regular label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c11 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c10 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c10 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c10 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c8.c8,
+.c3 + .c8.c8,
+.c10 + .c8.c8,
+.c8.c8 + .c3,
+.c8.c8 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rc:--hint"
+  >
+    Enter a search term
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rc:--hint :rc:--message"
+      aria-invalid="false"
+      aria-labelledby=":rc:--label"
+      class="c5 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rc:--input"
+    />
+  </div>
+  <div
+    class="c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rc:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a label, regular label, hint, message, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c11 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c10 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c10 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c10 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c8.c8,
+.c3 + .c8.c8,
+.c10 + .c8.c8,
+.c8.c8 + .c3,
+.c8.c8 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":re:--hint"
+  >
+    Enter a search term
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":re:--hint :re:--message"
+      aria-invalid="false"
+      aria-labelledby=":re:--label"
+      class="c5 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":re:--input"
+    />
+  </div>
+  <div
+    class="c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":re:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c11 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c10 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c10 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c10 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c8.c8,
+.c3 + .c8.c8,
+.c10 + .c8.c8,
+.c8.c8 + .c3,
+.c8.c8 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r5:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r5:--hint :r5:--message"
+      aria-invalid="false"
+      aria-labelledby=":r5:--label"
+      class="c5 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r5:--input"
+    />
+  </div>
+  <div
+    class="c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r5:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a read-only input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    aria-readonly="true"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":ri:--hint"
+      aria-invalid="false"
+      aria-labelledby=":ri:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":ri:--input"
+      readonly=""
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a regular label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r2:--input"
+    id=":r2:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r2:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r2:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r2:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r2:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a required input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rj:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rj:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rj:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rj:--input"
+      required=""
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a start icon 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c5 > .c6 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r7:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      class="c6  c7"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+    <input
+      aria-describedby=":r7:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r7:--label"
+      class="c3 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r7:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r6:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r6:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r6:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r6:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with an end icon 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c5 > .c8 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    id=":r8:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r8:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r8:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r8:--input"
+    />
+    <svg
+      class="c8  c9"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with bare styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c6 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rh:--input"
+    id=":rh:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rh:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rh:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rh:--label"
+      class="c3 c4 c6"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rh:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with both start and end icons 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c5 > .c6 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r9:--input"
+    id=":r9:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r9:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      class="c6  c7"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+    <input
+      aria-describedby=":r9:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r9:--label"
+      class="c3 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r9:--input"
+    />
+    <svg
+      class="c6  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 11px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 32px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rg:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rg:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rg:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with label, hidden label, validation label, and bare input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c6 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c5 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ro:--input"
+    hidden=""
+    id=":ro:--label"
+  >
+    Search
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":ro:--hint"
+      aria-invalid="false"
+      aria-labelledby=":ro:--label"
+      class="c2 c3 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":ro:--input"
+    />
+  </div>
+  <div
+    class="c6"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ro:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with label, hint, message, and compact input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c11 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c10 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c10 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 11px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 32px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c10 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c10 {
+  margin-top: 4px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c8.c8,
+.c3 + .c8.c8,
+.c10 + .c8.c8,
+.c8.c8 + .c3,
+.c8.c8 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rn:--input"
+    id=":rn:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rn:--hint"
+  >
+    Enter a search term
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rn:--hint :rn:--message"
+      aria-invalid="false"
+      aria-labelledby=":rn:--label"
+      class="c5 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rn:--input"
+    />
+  </div>
+  <div
+    class="c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rn:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with label, regular label, hint, message, validation label, and disabled input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c11 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c10 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c10 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c10 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c8.c8,
+.c3 + .c8.c8,
+.c10 + .c8.c8,
+.c8.c8 + .c3,
+.c8.c8 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rp:--input"
+    id=":rp:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rp:--hint"
+  >
+    Enter a search term
+  </div>
+  <div
+    aria-disabled="true"
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rp:--hint :rp:--message"
+      aria-invalid="false"
+      aria-labelledby=":rp:--label"
+      class="c5 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      disabled=""
+      id=":rp:--input"
+    />
+  </div>
+  <div
+    class="c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rp:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #cd3642;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    id=":rl:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="true"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rl:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rl:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rl:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #037f52;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #037f52;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rk:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rk:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rk:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rk:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #ac5918;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #ac5918;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rm:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="true"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rm:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rm:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rm:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders default MediaInputStory 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r0:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r0:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r0:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r0:--input"
+    />
+  </div>
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/RadioStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/RadioStory.spec.tsx.snap
@@ -1,0 +1,2692 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RadioStory Component renders RadioStory with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c5[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c9 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c3::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c3 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c3::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c3 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c3::before {
+  outline: none;
+}
+
+.c2 ~ .c3:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c3::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c3 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c3:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c3::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c3:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c3::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c3:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c3:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c3::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c3 {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c3 > .c6 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r3:--hint"
+    aria-labelledby=":r3:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r3:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    id=":r3:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c6 c7"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c5 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c5[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c3::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c3 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c3::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c3 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c3::before {
+  outline: none;
+}
+
+.c2 ~ .c3:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c3::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c3 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c3:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c3::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c3:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c3::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c3:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c3:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c3::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c3 {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c3 > .c6 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r1:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r1:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c6 c7"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c5 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c5[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c3::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c3 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c3::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c3 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c3::before {
+  outline: none;
+}
+
+.c2 ~ .c3:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c3::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c3 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c3:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c3::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c3:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c3::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c3:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c3:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c3::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c3 {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c3 > .c6 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r9:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r9:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r9:--input"
+    id=":r9:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c6 c7"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label and hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c5[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c9 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c3::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c3 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c3::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c3 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c3::before {
+  outline: none;
+}
+
+.c2 ~ .c3:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c3::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c3 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c3:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c3::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c3:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c3::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c3:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c3:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c3::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c3 {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c3 > .c6 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r5:--hint"
+    aria-labelledby=":r5:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r5:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c6 c7"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_hint"
+    data-garden-version="9.0.0"
+    id=":r5:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c10 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c3:not([hidden]) + .c9 {
+  margin-top: 4px;
+}
+
+.c3:not([hidden]) + .c9 {
+  display: block;
+}
+
+.c6 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c6[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c4 ~ .c9 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c11 {
+  padding-left: 24px;
+}
+
+.c8 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c4 > .c7 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r6:--message"
+    aria-labelledby=":r6:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r6:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5 c6"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c7 c8"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c9 c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_message"
+    data-garden-version="9.0.0"
+    id=":r6:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label, hint, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c5[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c9 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c3::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c3 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c3::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c3 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c3::before {
+  outline: none;
+}
+
+.c2 ~ .c3:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c3::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c3 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c3:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c3::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c3:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c3::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c3:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c3:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c3::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c3 {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c3 > .c6 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":ra:--hint"
+    aria-labelledby=":ra:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":ra:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    id=":ra:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c6 c7"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c9 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c12 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c3:not([hidden]) + .c11 {
+  margin-top: 4px;
+}
+
+.c3:not([hidden]) + .c11 {
+  display: block;
+}
+
+.c6 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c6[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c10 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c4 ~ .c11 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c13 {
+  padding-left: 24px;
+}
+
+.c8 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c4 > .c7 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r7:--hint :r7:--message"
+    aria-labelledby=":r7:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r7:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5 c6"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c7 c8"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c9 c10"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_hint"
+    data-garden-version="9.0.0"
+    id=":r7:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c11 c12 c13"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_message"
+    data-garden-version="9.0.0"
+    id=":r7:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label, hint, message, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c9 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c12 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c3:not([hidden]) + .c11 {
+  margin-top: 4px;
+}
+
+.c3:not([hidden]) + .c11 {
+  display: block;
+}
+
+.c6 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c6[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c10 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c4 ~ .c11 {
+  margin-top: 4px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c13 {
+  padding-left: 24px;
+}
+
+.c8 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c4 > .c7 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rc:--hint :rc:--message"
+    aria-labelledby=":rc:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":rc:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5 c6"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c7 c8"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c9 c10"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_hint"
+    data-garden-version="9.0.0"
+    id=":rc:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c11 c12 c13"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_message"
+    data-garden-version="9.0.0"
+    id=":rc:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label, message, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c10 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c3:not([hidden]) + .c9 {
+  margin-top: 4px;
+}
+
+.c3:not([hidden]) + .c9 {
+  display: block;
+}
+
+.c6 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c6[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c4 ~ .c9 {
+  margin-top: 4px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c11 {
+  padding-left: 24px;
+}
+
+.c8 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c4 > .c7 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rb:--message"
+    aria-labelledby=":rb:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":rb:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5 c6"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":rb:--input"
+    id=":rb:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c7 c8"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c9 c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_message"
+    data-garden-version="9.0.0"
+    id=":rb:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c10 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c3:not([hidden]) + .c9 {
+  margin-top: 4px;
+}
+
+.c3:not([hidden]) + .c9 {
+  display: block;
+}
+
+.c6 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c6[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c4 ~ .c9 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c11 {
+  padding-left: 24px;
+}
+
+.c8 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c4 > .c7 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r4:--message"
+    aria-labelledby=":r4:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r4:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5 c6"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c7 c8"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c9 c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_message"
+    data-garden-version="9.0.0"
+    id=":r4:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c5 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c5[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c3::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c3 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c3::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c3 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c3::before {
+  outline: none;
+}
+
+.c2 ~ .c3:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c3::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c3 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c3:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c3::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c3:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c3::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c3:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c3:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c3::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c3 {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c3 > .c6 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r8:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r8:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    id=":r8:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c6 c7"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory without a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r2:--label"
+    class="c1"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r2:--input"
+    type="radio"
+  />
+</div>
+`;
+
+exports[`RadioStory Component renders default RadioStory 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c5 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c5[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c3::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c3 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c3::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c3 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c3::before {
+  outline: none;
+}
+
+.c2 ~ .c3:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c3::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c3 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c3:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c3::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c3:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c3::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c3:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c3:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c3::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c3 {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c3 > .c6 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r0:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r0:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c6 c7"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/RadioStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/RadioStory.spec.tsx.snap
@@ -165,7 +165,7 @@ exports[`RadioStory Component renders RadioStory with a hint 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":r3:--hint"
@@ -174,7 +174,7 @@ exports[`RadioStory Component renders RadioStory with a hint 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r3:--input"
     type="radio"
   />
@@ -183,7 +183,7 @@ exports[`RadioStory Component renders RadioStory with a hint 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r3:--input"
     id=":r3:--label"
   >
@@ -191,7 +191,7 @@ exports[`RadioStory Component renders RadioStory with a hint 1`] = `
       aria-hidden="true"
       class="c6 c7"
       data-garden-id="forms.radio_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -211,7 +211,7 @@ exports[`RadioStory Component renders RadioStory with a hint 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r3:--hint"
   >
     This is a hint
@@ -372,7 +372,7 @@ exports[`RadioStory Component renders RadioStory with a label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r1:--label"
@@ -380,7 +380,7 @@ exports[`RadioStory Component renders RadioStory with a label 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r1:--input"
     type="radio"
   />
@@ -389,7 +389,7 @@ exports[`RadioStory Component renders RadioStory with a label 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r1:--input"
     id=":r1:--label"
   >
@@ -397,7 +397,7 @@ exports[`RadioStory Component renders RadioStory with a label 1`] = `
       aria-hidden="true"
       class="c6 c7"
       data-garden-id="forms.radio_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -568,7 +568,7 @@ exports[`RadioStory Component renders RadioStory with a label and compact stylin
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r9:--label"
@@ -576,7 +576,7 @@ exports[`RadioStory Component renders RadioStory with a label and compact stylin
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--input"
     type="radio"
   />
@@ -585,7 +585,7 @@ exports[`RadioStory Component renders RadioStory with a label and compact stylin
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r9:--input"
     id=":r9:--label"
   >
@@ -593,7 +593,7 @@ exports[`RadioStory Component renders RadioStory with a label and compact stylin
       aria-hidden="true"
       class="c6 c7"
       data-garden-id="forms.radio_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -776,7 +776,7 @@ exports[`RadioStory Component renders RadioStory with a label and hint 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":r5:--hint"
@@ -785,7 +785,7 @@ exports[`RadioStory Component renders RadioStory with a label and hint 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--input"
     type="radio"
   />
@@ -794,7 +794,7 @@ exports[`RadioStory Component renders RadioStory with a label and hint 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r5:--input"
     id=":r5:--label"
   >
@@ -802,7 +802,7 @@ exports[`RadioStory Component renders RadioStory with a label and hint 1`] = `
       aria-hidden="true"
       class="c6 c7"
       data-garden-id="forms.radio_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -822,7 +822,7 @@ exports[`RadioStory Component renders RadioStory with a label and hint 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--hint"
   >
     This is a hint
@@ -1008,7 +1008,7 @@ exports[`RadioStory Component renders RadioStory with a label and message 1`] = 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":r6:--message"
@@ -1017,7 +1017,7 @@ exports[`RadioStory Component renders RadioStory with a label and message 1`] = 
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r6:--input"
     type="radio"
   />
@@ -1026,7 +1026,7 @@ exports[`RadioStory Component renders RadioStory with a label and message 1`] = 
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r6:--input"
     id=":r6:--label"
   >
@@ -1034,7 +1034,7 @@ exports[`RadioStory Component renders RadioStory with a label and message 1`] = 
       aria-hidden="true"
       class="c7 c8"
       data-garden-id="forms.radio_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -1054,7 +1054,7 @@ exports[`RadioStory Component renders RadioStory with a label and message 1`] = 
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r6:--message"
     role="alert"
   >
@@ -1228,7 +1228,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, and compact
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":ra:--hint"
@@ -1237,7 +1237,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, and compact
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--input"
     type="radio"
   />
@@ -1246,7 +1246,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, and compact
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ra:--input"
     id=":ra:--label"
   >
@@ -1254,7 +1254,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, and compact
       aria-hidden="true"
       class="c6 c7"
       data-garden-id="forms.radio_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -1274,7 +1274,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, and compact
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--hint"
   >
     This is a hint
@@ -1472,7 +1472,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, and message
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":r7:--hint :r7:--message"
@@ -1481,7 +1481,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, and message
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--input"
     type="radio"
   />
@@ -1490,7 +1490,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, and message
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r7:--input"
     id=":r7:--label"
   >
@@ -1498,7 +1498,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, and message
       aria-hidden="true"
       class="c7 c8"
       data-garden-id="forms.radio_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -1518,7 +1518,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, and message
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--hint"
   >
     This is a hint
@@ -1528,7 +1528,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, and message
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--message"
     role="alert"
   >
@@ -1727,7 +1727,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, message, an
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":rc:--hint :rc:--message"
@@ -1736,7 +1736,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, message, an
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rc:--input"
     type="radio"
   />
@@ -1745,7 +1745,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, message, an
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rc:--input"
     id=":rc:--label"
   >
@@ -1753,7 +1753,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, message, an
       aria-hidden="true"
       class="c7 c8"
       data-garden-id="forms.radio_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -1773,7 +1773,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, message, an
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rc:--hint"
   >
     This is a hint
@@ -1783,7 +1783,7 @@ exports[`RadioStory Component renders RadioStory with a label, hint, message, an
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rc:--message"
     role="alert"
   >
@@ -1970,7 +1970,7 @@ exports[`RadioStory Component renders RadioStory with a label, message, and comp
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":rb:--message"
@@ -1979,7 +1979,7 @@ exports[`RadioStory Component renders RadioStory with a label, message, and comp
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--input"
     type="radio"
   />
@@ -1988,7 +1988,7 @@ exports[`RadioStory Component renders RadioStory with a label, message, and comp
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rb:--input"
     id=":rb:--label"
   >
@@ -1996,7 +1996,7 @@ exports[`RadioStory Component renders RadioStory with a label, message, and comp
       aria-hidden="true"
       class="c7 c8"
       data-garden-id="forms.radio_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -2016,7 +2016,7 @@ exports[`RadioStory Component renders RadioStory with a label, message, and comp
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--message"
     role="alert"
   >
@@ -2203,7 +2203,7 @@ exports[`RadioStory Component renders RadioStory with a message 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":r4:--message"
@@ -2212,7 +2212,7 @@ exports[`RadioStory Component renders RadioStory with a message 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r4:--input"
     type="radio"
   />
@@ -2221,7 +2221,7 @@ exports[`RadioStory Component renders RadioStory with a message 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r4:--input"
     id=":r4:--label"
   >
@@ -2229,7 +2229,7 @@ exports[`RadioStory Component renders RadioStory with a message 1`] = `
       aria-hidden="true"
       class="c7 c8"
       data-garden-id="forms.radio_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -2249,7 +2249,7 @@ exports[`RadioStory Component renders RadioStory with a message 1`] = `
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r4:--message"
     role="alert"
   >
@@ -2411,7 +2411,7 @@ exports[`RadioStory Component renders RadioStory with compact styling 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r8:--label"
@@ -2419,7 +2419,7 @@ exports[`RadioStory Component renders RadioStory with compact styling 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--input"
     type="radio"
   />
@@ -2428,7 +2428,7 @@ exports[`RadioStory Component renders RadioStory with compact styling 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r8:--input"
     id=":r8:--label"
   >
@@ -2436,7 +2436,7 @@ exports[`RadioStory Component renders RadioStory with compact styling 1`] = `
       aria-hidden="true"
       class="c6 c7"
       data-garden-id="forms.radio_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"
@@ -2480,7 +2480,7 @@ exports[`RadioStory Component renders RadioStory without a label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r2:--label"
@@ -2488,7 +2488,7 @@ exports[`RadioStory Component renders RadioStory without a label 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r2:--input"
     type="radio"
   />
@@ -2648,7 +2648,7 @@ exports[`RadioStory Component renders default RadioStory 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r0:--label"
@@ -2656,7 +2656,7 @@ exports[`RadioStory Component renders default RadioStory 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r0:--input"
     type="radio"
   />
@@ -2665,7 +2665,7 @@ exports[`RadioStory Component renders default RadioStory 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.radio_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r0:--input"
     id=":r0:--label"
   >
@@ -2673,7 +2673,7 @@ exports[`RadioStory Component renders default RadioStory 1`] = `
       aria-hidden="true"
       class="c6 c7"
       data-garden-id="forms.radio_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="12"
       viewBox="0 0 12 12"

--- a/packages/forms/demo/stories/__snapshots__/SelectStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/SelectStory.spec.tsx.snap
@@ -323,14 +323,14 @@ exports[`SelectStory Component renders SelectStory with a disabled select 1`] = 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rc:--input"
     id=":rc:--label"
   >
@@ -341,7 +341,7 @@ exports[`SelectStory Component renders SelectStory with a disabled select 1`] = 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rc:--hint"
   >
     Hint
@@ -351,7 +351,7 @@ exports[`SelectStory Component renders SelectStory with a disabled select 1`] = 
     aria-invalid="false"
     class="c3 c4 c5 c6"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":rc:--hint"
@@ -361,7 +361,7 @@ exports[`SelectStory Component renders SelectStory with a disabled select 1`] = 
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       disabled=""
       id=":rc:--input"
     >
@@ -380,7 +380,7 @@ exports[`SelectStory Component renders SelectStory with a disabled select 1`] = 
       aria-hidden="true"
       class="c9  c10"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -719,14 +719,14 @@ exports[`SelectStory Component renders SelectStory with a hidden label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r3:--input"
     hidden=""
     id=":r3:--label"
@@ -737,7 +737,7 @@ exports[`SelectStory Component renders SelectStory with a hidden label 1`] = `
     aria-invalid="false"
     class="c2 c3 c4 c5"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":r3:--hint"
@@ -747,7 +747,7 @@ exports[`SelectStory Component renders SelectStory with a hidden label 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r3:--input"
     >
       <option
@@ -765,7 +765,7 @@ exports[`SelectStory Component renders SelectStory with a hidden label 1`] = `
       aria-hidden="true"
       class="c8  c9"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -783,7 +783,7 @@ exports[`SelectStory Component renders SelectStory with a hidden label 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r3:--hint"
   >
     Hint
@@ -1114,14 +1114,14 @@ exports[`SelectStory Component renders SelectStory with a hint 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r4:--input"
     id=":r4:--label"
   >
@@ -1132,7 +1132,7 @@ exports[`SelectStory Component renders SelectStory with a hint 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r4:--hint"
   >
     Choose wisely
@@ -1141,7 +1141,7 @@ exports[`SelectStory Component renders SelectStory with a hint 1`] = `
     aria-invalid="false"
     class="c3 c4 c5 c6"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":r4:--hint"
@@ -1151,7 +1151,7 @@ exports[`SelectStory Component renders SelectStory with a hint 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r4:--input"
     >
       <option
@@ -1169,7 +1169,7 @@ exports[`SelectStory Component renders SelectStory with a hint 1`] = `
       aria-hidden="true"
       class="c9  c10"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -1508,14 +1508,14 @@ exports[`SelectStory Component renders SelectStory with a label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r1:--input"
     id=":r1:--label"
   >
@@ -1526,7 +1526,7 @@ exports[`SelectStory Component renders SelectStory with a label 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r1:--hint"
   >
     Hint
@@ -1535,7 +1535,7 @@ exports[`SelectStory Component renders SelectStory with a label 1`] = `
     aria-invalid="false"
     class="c3 c4 c5 c6"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":r1:--hint"
@@ -1545,7 +1545,7 @@ exports[`SelectStory Component renders SelectStory with a label 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r1:--input"
     >
       <option
@@ -1563,7 +1563,7 @@ exports[`SelectStory Component renders SelectStory with a label 1`] = `
       aria-hidden="true"
       class="c9  c10"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -1902,14 +1902,14 @@ exports[`SelectStory Component renders SelectStory with a label, hidden label, a
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r8:--input"
     hidden=""
     id=":r8:--label"
@@ -1920,7 +1920,7 @@ exports[`SelectStory Component renders SelectStory with a label, hidden label, a
     aria-invalid="false"
     class="c2 c3 c4 c5"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":r8:--hint"
@@ -1930,7 +1930,7 @@ exports[`SelectStory Component renders SelectStory with a label, hidden label, a
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r8:--input"
     >
       <option
@@ -1948,7 +1948,7 @@ exports[`SelectStory Component renders SelectStory with a label, hidden label, a
       aria-hidden="true"
       class="c8  c9"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -1966,7 +1966,7 @@ exports[`SelectStory Component renders SelectStory with a label, hidden label, a
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--hint"
   >
     Hint
@@ -2297,14 +2297,14 @@ exports[`SelectStory Component renders SelectStory with a label, hidden label, h
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ra:--input"
     hidden=""
     id=":ra:--label"
@@ -2315,7 +2315,7 @@ exports[`SelectStory Component renders SelectStory with a label, hidden label, h
     aria-invalid="false"
     class="c2 c3 c4 c5"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":ra:--hint"
@@ -2325,7 +2325,7 @@ exports[`SelectStory Component renders SelectStory with a label, hidden label, h
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":ra:--input"
     >
       <option
@@ -2343,7 +2343,7 @@ exports[`SelectStory Component renders SelectStory with a label, hidden label, h
       aria-hidden="true"
       class="c8  c9"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -2361,7 +2361,7 @@ exports[`SelectStory Component renders SelectStory with a label, hidden label, h
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--hint"
   >
     Choose wisely
@@ -2717,14 +2717,14 @@ exports[`SelectStory Component renders SelectStory with a label, hint, and messa
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r7:--input"
     id=":r7:--label"
   >
@@ -2735,7 +2735,7 @@ exports[`SelectStory Component renders SelectStory with a label, hint, and messa
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--hint"
   >
     Choose wisely
@@ -2744,7 +2744,7 @@ exports[`SelectStory Component renders SelectStory with a label, hint, and messa
     aria-invalid="false"
     class="c5 c6 c7 c8"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":r7:--hint :r7:--message"
@@ -2754,7 +2754,7 @@ exports[`SelectStory Component renders SelectStory with a label, hint, and messa
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r7:--input"
     >
       <option
@@ -2772,7 +2772,7 @@ exports[`SelectStory Component renders SelectStory with a label, hint, and messa
       aria-hidden="true"
       class="c11  c12"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -2790,7 +2790,7 @@ exports[`SelectStory Component renders SelectStory with a label, hint, and messa
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--message"
     role="alert"
   >
@@ -3147,14 +3147,14 @@ exports[`SelectStory Component renders SelectStory with a label, regular label, 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r9:--input"
     id=":r9:--label"
   >
@@ -3165,7 +3165,7 @@ exports[`SelectStory Component renders SelectStory with a label, regular label, 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--hint"
   >
     Choose wisely
@@ -3174,7 +3174,7 @@ exports[`SelectStory Component renders SelectStory with a label, regular label, 
     aria-invalid="false"
     class="c5 c6 c7 c8"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":r9:--hint :r9:--message"
@@ -3184,7 +3184,7 @@ exports[`SelectStory Component renders SelectStory with a label, regular label, 
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r9:--input"
     >
       <option
@@ -3202,7 +3202,7 @@ exports[`SelectStory Component renders SelectStory with a label, regular label, 
       aria-hidden="true"
       class="c11  c12"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -3220,7 +3220,7 @@ exports[`SelectStory Component renders SelectStory with a label, regular label, 
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--message"
     role="alert"
   >
@@ -3577,14 +3577,14 @@ exports[`SelectStory Component renders SelectStory with a label, regular label, 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rb:--input"
     id=":rb:--label"
   >
@@ -3595,7 +3595,7 @@ exports[`SelectStory Component renders SelectStory with a label, regular label, 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--hint"
   >
     Choose wisely
@@ -3604,7 +3604,7 @@ exports[`SelectStory Component renders SelectStory with a label, regular label, 
     aria-invalid="false"
     class="c5 c6 c7 c8"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":rb:--hint :rb:--message"
@@ -3614,7 +3614,7 @@ exports[`SelectStory Component renders SelectStory with a label, regular label, 
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rb:--input"
     >
       <option
@@ -3632,7 +3632,7 @@ exports[`SelectStory Component renders SelectStory with a label, regular label, 
       aria-hidden="true"
       class="c11  c12"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -3650,7 +3650,7 @@ exports[`SelectStory Component renders SelectStory with a label, regular label, 
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--message"
     role="alert"
   >
@@ -4007,14 +4007,14 @@ exports[`SelectStory Component renders SelectStory with a message 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r5:--input"
     id=":r5:--label"
   >
@@ -4025,7 +4025,7 @@ exports[`SelectStory Component renders SelectStory with a message 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--hint"
   >
     Hint
@@ -4034,7 +4034,7 @@ exports[`SelectStory Component renders SelectStory with a message 1`] = `
     aria-invalid="false"
     class="c5 c6 c7 c8"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":r5:--hint :r5:--message"
@@ -4044,7 +4044,7 @@ exports[`SelectStory Component renders SelectStory with a message 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r5:--input"
     >
       <option
@@ -4062,7 +4062,7 @@ exports[`SelectStory Component renders SelectStory with a message 1`] = `
       aria-hidden="true"
       class="c11  c12"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -4080,7 +4080,7 @@ exports[`SelectStory Component renders SelectStory with a message 1`] = `
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--message"
     role="alert"
   >
@@ -4412,14 +4412,14 @@ exports[`SelectStory Component renders SelectStory with a regular label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r2:--input"
     id=":r2:--label"
   >
@@ -4430,7 +4430,7 @@ exports[`SelectStory Component renders SelectStory with a regular label 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r2:--hint"
   >
     Hint
@@ -4439,7 +4439,7 @@ exports[`SelectStory Component renders SelectStory with a regular label 1`] = `
     aria-invalid="false"
     class="c3 c4 c5 c6"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":r2:--hint"
@@ -4449,7 +4449,7 @@ exports[`SelectStory Component renders SelectStory with a regular label 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r2:--input"
     >
       <option
@@ -4467,7 +4467,7 @@ exports[`SelectStory Component renders SelectStory with a regular label 1`] = `
       aria-hidden="true"
       class="c9  c10"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -4806,14 +4806,14 @@ exports[`SelectStory Component renders SelectStory with a validation label 1`] =
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r6:--input"
     id=":r6:--label"
   >
@@ -4824,7 +4824,7 @@ exports[`SelectStory Component renders SelectStory with a validation label 1`] =
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r6:--hint"
   >
     Hint
@@ -4833,7 +4833,7 @@ exports[`SelectStory Component renders SelectStory with a validation label 1`] =
     aria-invalid="false"
     class="c3 c4 c5 c6"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":r6:--hint"
@@ -4843,7 +4843,7 @@ exports[`SelectStory Component renders SelectStory with a validation label 1`] =
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r6:--input"
     >
       <option
@@ -4861,7 +4861,7 @@ exports[`SelectStory Component renders SelectStory with a validation label 1`] =
       aria-hidden="true"
       class="c9  c10"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -5161,14 +5161,14 @@ exports[`SelectStory Component renders SelectStory with bare styling 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":re:--input"
     id=":re:--label"
   >
@@ -5179,7 +5179,7 @@ exports[`SelectStory Component renders SelectStory with bare styling 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":re:--hint"
   >
     Hint
@@ -5188,7 +5188,7 @@ exports[`SelectStory Component renders SelectStory with bare styling 1`] = `
     aria-invalid="false"
     class="c3 c4 c5 c6"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":re:--hint"
@@ -5198,7 +5198,7 @@ exports[`SelectStory Component renders SelectStory with bare styling 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":re:--input"
     >
       <option
@@ -5539,14 +5539,14 @@ exports[`SelectStory Component renders SelectStory with compact styling 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rd:--input"
     id=":rd:--label"
   >
@@ -5557,7 +5557,7 @@ exports[`SelectStory Component renders SelectStory with compact styling 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rd:--hint"
   >
     Hint
@@ -5566,7 +5566,7 @@ exports[`SelectStory Component renders SelectStory with compact styling 1`] = `
     aria-invalid="false"
     class="c3 c4 c5 c6"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":rd:--hint"
@@ -5576,7 +5576,7 @@ exports[`SelectStory Component renders SelectStory with compact styling 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rd:--input"
     >
       <option
@@ -5594,7 +5594,7 @@ exports[`SelectStory Component renders SelectStory with compact styling 1`] = `
       aria-hidden="true"
       class="c9  c10"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -5933,14 +5933,14 @@ exports[`SelectStory Component renders SelectStory with focus inset 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rg:--input"
     id=":rg:--label"
   >
@@ -5951,7 +5951,7 @@ exports[`SelectStory Component renders SelectStory with focus inset 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rg:--hint"
   >
     Hint
@@ -5960,7 +5960,7 @@ exports[`SelectStory Component renders SelectStory with focus inset 1`] = `
     aria-invalid="false"
     class="c3 c4 c5 c6"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":rg:--hint"
@@ -5970,7 +5970,7 @@ exports[`SelectStory Component renders SelectStory with focus inset 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rg:--input"
     >
       <option
@@ -5988,7 +5988,7 @@ exports[`SelectStory Component renders SelectStory with focus inset 1`] = `
       aria-hidden="true"
       class="c9  c10"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -6288,14 +6288,14 @@ exports[`SelectStory Component renders SelectStory with label, hidden label, val
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rl:--input"
     hidden=""
     id=":rl:--label"
@@ -6306,7 +6306,7 @@ exports[`SelectStory Component renders SelectStory with label, hidden label, val
     aria-invalid="false"
     class="c2 c3 c4 c5"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":rl:--hint"
@@ -6316,7 +6316,7 @@ exports[`SelectStory Component renders SelectStory with label, hidden label, val
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rl:--input"
     >
       <option
@@ -6336,7 +6336,7 @@ exports[`SelectStory Component renders SelectStory with label, hidden label, val
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rl:--hint"
   >
     Hint
@@ -6692,14 +6692,14 @@ exports[`SelectStory Component renders SelectStory with label, hint, message, an
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rk:--input"
     id=":rk:--label"
   >
@@ -6710,7 +6710,7 @@ exports[`SelectStory Component renders SelectStory with label, hint, message, an
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rk:--hint"
   >
     Choose wisely
@@ -6719,7 +6719,7 @@ exports[`SelectStory Component renders SelectStory with label, hint, message, an
     aria-invalid="false"
     class="c5 c6 c7 c8"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":rk:--hint :rk:--message"
@@ -6729,7 +6729,7 @@ exports[`SelectStory Component renders SelectStory with label, hint, message, an
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rk:--input"
     >
       <option
@@ -6747,7 +6747,7 @@ exports[`SelectStory Component renders SelectStory with label, hint, message, an
       aria-hidden="true"
       class="c11  c12"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -6765,7 +6765,7 @@ exports[`SelectStory Component renders SelectStory with label, hint, message, an
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rk:--message"
     role="alert"
   >
@@ -7122,14 +7122,14 @@ exports[`SelectStory Component renders SelectStory with label, regular label, hi
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rm:--input"
     id=":rm:--label"
   >
@@ -7140,7 +7140,7 @@ exports[`SelectStory Component renders SelectStory with label, regular label, hi
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rm:--hint"
   >
     Choose wisely
@@ -7150,7 +7150,7 @@ exports[`SelectStory Component renders SelectStory with label, regular label, hi
     aria-invalid="false"
     class="c5 c6 c7 c8"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":rm:--hint :rm:--message"
@@ -7160,7 +7160,7 @@ exports[`SelectStory Component renders SelectStory with label, regular label, hi
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       disabled=""
       id=":rm:--input"
     >
@@ -7179,7 +7179,7 @@ exports[`SelectStory Component renders SelectStory with label, regular label, hi
       aria-hidden="true"
       class="c11  c12"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -7197,7 +7197,7 @@ exports[`SelectStory Component renders SelectStory with label, regular label, hi
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rm:--message"
     role="alert"
   >
@@ -7529,14 +7529,14 @@ exports[`SelectStory Component renders SelectStory with the select open 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rf:--input"
     id=":rf:--label"
   >
@@ -7547,7 +7547,7 @@ exports[`SelectStory Component renders SelectStory with the select open 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rf:--hint"
   >
     Hint
@@ -7556,7 +7556,7 @@ exports[`SelectStory Component renders SelectStory with the select open 1`] = `
     aria-invalid="false"
     class="c3 c4 c5 c6"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":rf:--hint"
@@ -7566,7 +7566,7 @@ exports[`SelectStory Component renders SelectStory with the select open 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rf:--input"
     >
       <option
@@ -7584,7 +7584,7 @@ exports[`SelectStory Component renders SelectStory with the select open 1`] = `
       aria-hidden="true"
       class="c9  c10"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -7923,14 +7923,14 @@ exports[`SelectStory Component renders SelectStory with validation error 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ri:--input"
     id=":ri:--label"
   >
@@ -7941,7 +7941,7 @@ exports[`SelectStory Component renders SelectStory with validation error 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ri:--hint"
   >
     Hint
@@ -7950,7 +7950,7 @@ exports[`SelectStory Component renders SelectStory with validation error 1`] = `
     aria-invalid="true"
     class="c3 c4 c5 c6"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":ri:--hint"
@@ -7960,7 +7960,7 @@ exports[`SelectStory Component renders SelectStory with validation error 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":ri:--input"
     >
       <option
@@ -7978,7 +7978,7 @@ exports[`SelectStory Component renders SelectStory with validation error 1`] = `
       aria-hidden="true"
       class="c9  c10"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -8317,14 +8317,14 @@ exports[`SelectStory Component renders SelectStory with validation success 1`] =
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rh:--input"
     id=":rh:--label"
   >
@@ -8335,7 +8335,7 @@ exports[`SelectStory Component renders SelectStory with validation success 1`] =
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rh:--hint"
   >
     Hint
@@ -8344,7 +8344,7 @@ exports[`SelectStory Component renders SelectStory with validation success 1`] =
     aria-invalid="false"
     class="c3 c4 c5 c6"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":rh:--hint"
@@ -8354,7 +8354,7 @@ exports[`SelectStory Component renders SelectStory with validation success 1`] =
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rh:--input"
     >
       <option
@@ -8372,7 +8372,7 @@ exports[`SelectStory Component renders SelectStory with validation success 1`] =
       aria-hidden="true"
       class="c9  c10"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -8711,14 +8711,14 @@ exports[`SelectStory Component renders SelectStory with validation warning 1`] =
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rj:--input"
     id=":rj:--label"
   >
@@ -8729,7 +8729,7 @@ exports[`SelectStory Component renders SelectStory with validation warning 1`] =
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rj:--hint"
   >
     Hint
@@ -8738,7 +8738,7 @@ exports[`SelectStory Component renders SelectStory with validation warning 1`] =
     aria-invalid="true"
     class="c3 c4 c5 c6"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":rj:--hint"
@@ -8748,7 +8748,7 @@ exports[`SelectStory Component renders SelectStory with validation warning 1`] =
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":rj:--input"
     >
       <option
@@ -8766,7 +8766,7 @@ exports[`SelectStory Component renders SelectStory with validation warning 1`] =
       aria-hidden="true"
       class="c9  c10"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -9105,14 +9105,14 @@ exports[`SelectStory Component renders default SelectStory 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r0:--input"
     id=":r0:--label"
   >
@@ -9123,7 +9123,7 @@ exports[`SelectStory Component renders default SelectStory 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r0:--hint"
   >
     Hint
@@ -9132,7 +9132,7 @@ exports[`SelectStory Component renders default SelectStory 1`] = `
     aria-invalid="false"
     class="c3 c4 c5 c6"
     data-garden-id="forms.select_wrapper"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <select
       aria-describedby=":r0:--hint"
@@ -9142,7 +9142,7 @@ exports[`SelectStory Component renders default SelectStory 1`] = `
       data-garden-container-id="containers.field.input"
       data-garden-container-version="3.0.19"
       data-garden-id="forms.select"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       id=":r0:--input"
     >
       <option
@@ -9165,7 +9165,7 @@ exports[`SelectStory Component renders default SelectStory 1`] = `
       aria-hidden="true"
       class="c9  c10"
       data-garden-id="forms.media_figure"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"

--- a/packages/forms/demo/stories/__snapshots__/SelectStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/SelectStory.spec.tsx.snap
@@ -1,0 +1,9182 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SelectStory Component renders SelectStory with a disabled select 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #848f99;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rc:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-disabled="true"
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rc:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rc:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      disabled=""
+      id=":rc:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a hidden label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c10 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c7 + .c8 {
+  top: 11px;
+  right: 12px;
+}
+
+.c7:hover + .c8,
+.c7:focus + .c8,
+.c7:focus-visible + .c8 {
+  color: #39434b;
+}
+
+.c7:disabled + .c8 {
+  color: #848f99;
+}
+
+.c7::-ms-expand {
+  display: none;
+}
+
+.c7::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c7:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c7 + .c8 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c5 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c5 > .c6 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c5 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    hidden=""
+    id=":r3:--label"
+  >
+    Select an option
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4 c5"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r3:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r3:--label"
+      class="c2 c6 c3 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r3:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c8  c9"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c10"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r4:--hint"
+  >
+    Choose wisely
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r4:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r4:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r4:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r1:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r1:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r1:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r1:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a label, hidden label, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c10 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c7 + .c8 {
+  top: 11px;
+  right: 12px;
+}
+
+.c7:hover + .c8,
+.c7:focus + .c8,
+.c7:focus-visible + .c8 {
+  color: #39434b;
+}
+
+.c7:disabled + .c8 {
+  color: #848f99;
+}
+
+.c7::-ms-expand {
+  display: none;
+}
+
+.c7::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c7:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c7 + .c8 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c5 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c5 > .c6 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c5 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    hidden=""
+    id=":r8:--label"
+  >
+    Select an option
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4 c5"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r8:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r8:--label"
+      class="c2 c6 c3 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r8:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c8  c9"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c10"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a label, hidden label, hint, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c10 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c7 + .c8 {
+  top: 11px;
+  right: 12px;
+}
+
+.c7:hover + .c8,
+.c7:focus + .c8,
+.c7:focus-visible + .c8 {
+  color: #39434b;
+}
+
+.c7:disabled + .c8 {
+  color: #848f99;
+}
+
+.c7::-ms-expand {
+  display: none;
+}
+
+.c7::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c7:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c7 + .c8 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c5 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c5 > .c6 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c5 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    hidden=""
+    id=":ra:--label"
+  >
+    Select an option
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4 c5"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":ra:--hint"
+      aria-invalid="false"
+      aria-labelledby=":ra:--label"
+      class="c2 c6 c3 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":ra:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c8  c9"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c10"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    Choose wisely
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c13 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c10 + .c11 {
+  top: 11px;
+  right: 12px;
+}
+
+.c10:hover + .c11,
+.c10:focus + .c11,
+.c10:focus-visible + .c11 {
+  color: #39434b;
+}
+
+.c10:disabled + .c11 {
+  color: #848f99;
+}
+
+.c10::-ms-expand {
+  display: none;
+}
+
+.c10::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c10:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c10 + .c11 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c8 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c8 > .c9 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c8 > .c9:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r7:--hint"
+  >
+    Choose wisely
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7 c8"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r7:--hint :r7:--message"
+      aria-invalid="false"
+      aria-labelledby=":r7:--label"
+      class="c5 c9 c6 c10"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r7:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c11  c12"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r7:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a label, regular label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c13 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c10 + .c11 {
+  top: 11px;
+  right: 12px;
+}
+
+.c10:hover + .c11,
+.c10:focus + .c11,
+.c10:focus-visible + .c11 {
+  color: #39434b;
+}
+
+.c10:disabled + .c11 {
+  color: #848f99;
+}
+
+.c10::-ms-expand {
+  display: none;
+}
+
+.c10::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c10:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c10 + .c11 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c8 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c8 > .c9 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c8 > .c9:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r9:--input"
+    id=":r9:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r9:--hint"
+  >
+    Choose wisely
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7 c8"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r9:--hint :r9:--message"
+      aria-invalid="false"
+      aria-labelledby=":r9:--label"
+      class="c5 c9 c6 c10"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r9:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c11  c12"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r9:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a label, regular label, hint, message, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c13 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c10 + .c11 {
+  top: 11px;
+  right: 12px;
+}
+
+.c10:hover + .c11,
+.c10:focus + .c11,
+.c10:focus-visible + .c11 {
+  color: #39434b;
+}
+
+.c10:disabled + .c11 {
+  color: #848f99;
+}
+
+.c10::-ms-expand {
+  display: none;
+}
+
+.c10::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c10:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c10 + .c11 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c8 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c8 > .c9 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c8 > .c9:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rb:--input"
+    id=":rb:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    Choose wisely
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7 c8"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rb:--hint :rb:--message"
+      aria-invalid="false"
+      aria-labelledby=":rb:--label"
+      class="c5 c9 c6 c10"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rb:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c11  c12"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rb:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c13 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c10 + .c11 {
+  top: 11px;
+  right: 12px;
+}
+
+.c10:hover + .c11,
+.c10:focus + .c11,
+.c10:focus-visible + .c11 {
+  color: #39434b;
+}
+
+.c10:disabled + .c11 {
+  color: #848f99;
+}
+
+.c10::-ms-expand {
+  display: none;
+}
+
+.c10::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c10:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c10 + .c11 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c8 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c8 > .c9 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c8 > .c9:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r5:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7 c8"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r5:--hint :r5:--message"
+      aria-invalid="false"
+      aria-labelledby=":r5:--label"
+      class="c5 c9 c6 c10"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r5:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c11  c12"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r5:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a regular label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r2:--input"
+    id=":r2:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r2:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r2:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r2:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r2:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r6:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r6:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r6:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r6:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with bare styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":re:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":re:--hint"
+      aria-invalid="false"
+      aria-labelledby=":re:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":re:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 11px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 32px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 7px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 32px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    id=":rd:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rd:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rd:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rd:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rd:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with focus inset 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rg:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rg:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rg:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with label, hidden label, validation label, and bare select 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c8 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+}
+
+.c7::-ms-expand {
+  display: none;
+}
+
+.c7::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c7:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c5 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c5 > .c6 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c5 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    hidden=""
+    id=":rl:--label"
+  >
+    Select an option
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4 c5"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rl:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rl:--label"
+      class="c2 c6 c3 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rl:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+  </div>
+  <div
+    class="c8"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with label, hint, message, and compact select 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 11px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 32px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c13 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c13 {
+  margin-top: 4px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c10 + .c11 {
+  top: 7px;
+  right: 12px;
+}
+
+.c10:hover + .c11,
+.c10:focus + .c11,
+.c10:focus-visible + .c11 {
+  color: #39434b;
+}
+
+.c10:disabled + .c11 {
+  color: #848f99;
+}
+
+.c10::-ms-expand {
+  display: none;
+}
+
+.c10::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c10:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c10 + .c11 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c8 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 32px;
+}
+
+.c8 > .c9 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c8 > .c9:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rk:--hint"
+  >
+    Choose wisely
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7 c8"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rk:--hint :rk:--message"
+      aria-invalid="false"
+      aria-labelledby=":rk:--label"
+      class="c5 c9 c6 c10"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rk:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c11  c12"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rk:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with label, regular label, hint, message, validation label, and disabled select 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c13 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #848f99;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c10 + .c11 {
+  top: 11px;
+  right: 12px;
+}
+
+.c10:hover + .c11,
+.c10:focus + .c11,
+.c10:focus-visible + .c11 {
+  color: #39434b;
+}
+
+.c10:disabled + .c11 {
+  color: #848f99;
+}
+
+.c10::-ms-expand {
+  display: none;
+}
+
+.c10::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c10:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c10 + .c11 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c8 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c8 > .c9 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c8 > .c9:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rm:--hint"
+  >
+    Choose wisely
+  </div>
+  <div
+    aria-disabled="true"
+    aria-invalid="false"
+    class="c5 c6 c7 c8"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rm:--hint :rm:--message"
+      aria-invalid="false"
+      aria-labelledby=":rm:--label"
+      class="c5 c9 c6 c10"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      disabled=""
+      id=":rm:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c11  c12"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rm:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with the select open 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rf:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rf:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rf:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rf:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #cd3642;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="true"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":ri:--hint"
+      aria-invalid="true"
+      aria-labelledby=":ri:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":ri:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #037f52;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #037f52;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rh:--input"
+    id=":rh:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rh:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rh:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rh:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rh:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #ac5918;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #ac5918;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rj:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="true"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rj:--hint"
+      aria-invalid="true"
+      aria-labelledby=":rj:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rj:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders default SelectStory 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r0:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r0:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r0:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r0:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+      <option
+        value="2"
+      >
+        Option 3
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/TextareaStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/TextareaStory.spec.tsx.snap
@@ -1,0 +1,7853 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextareaStory Component renders TextareaStory with a disabled textarea 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":re:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":re:--hint"
+    aria-invalid="false"
+    aria-labelledby=":re:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":re:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a hidden label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2[readonly],
+.c2[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c3 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    hidden=""
+    id=":r3:--label"
+  >
+    Description
+  </label>
+  <textarea
+    aria-describedby=":r3:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r3:--label"
+    class="c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r3:--input"
+  />
+  <div
+    class="c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r4:--hint"
+  >
+    Enter a brief description
+  </div>
+  <textarea
+    aria-describedby=":r4:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r4:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r4:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r1:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":r1:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r1:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r1:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a label, hidden label, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2[readonly],
+.c2[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c3 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    hidden=""
+    id=":r8:--label"
+  >
+    Description
+  </label>
+  <textarea
+    aria-describedby=":r8:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r8:--label"
+    class="c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r8:--input"
+  />
+  <div
+    class="c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a label, hidden label, hint, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2[readonly],
+.c2[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c3 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    hidden=""
+    id=":ra:--label"
+  >
+    Description
+  </label>
+  <textarea
+    aria-describedby=":ra:--hint"
+    aria-invalid="false"
+    aria-labelledby=":ra:--label"
+    class="c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":ra:--input"
+  />
+  <div
+    class="c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    Enter a brief description
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c7 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c7 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c7 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c7 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c6 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r7:--hint"
+  >
+    Enter a brief description
+  </div>
+  <textarea
+    aria-describedby=":r7:--hint :r7:--message"
+    aria-invalid="false"
+    aria-labelledby=":r7:--label"
+    class="c5 c6"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r7:--input"
+  />
+  <div
+    class="c7 c8"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r7:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a label, regular label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c7 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c7 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c7 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c7 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c6 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r9:--input"
+    id=":r9:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r9:--hint"
+  >
+    Enter a brief description
+  </div>
+  <textarea
+    aria-describedby=":r9:--hint :r9:--message"
+    aria-invalid="false"
+    aria-labelledby=":r9:--label"
+    class="c5 c6"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r9:--input"
+  />
+  <div
+    class="c7 c8"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r9:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a label, regular label, hint, message, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c7 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c7 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c7 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c7 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c6 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rb:--input"
+    id=":rb:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    Enter a brief description
+  </div>
+  <textarea
+    aria-describedby=":rb:--hint :rb:--message"
+    aria-invalid="false"
+    aria-labelledby=":rb:--label"
+    class="c5 c6"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rb:--input"
+  />
+  <div
+    class="c7 c8"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rb:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a maximum number of rows 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+.c5 {
+  resize: none;
+  overflow: auto;
+  visibility: hidden;
+  position: absolute;
+  overflow: hidden;
+  height: 0;
+  top: 0;
+  left: 0;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ro:--input"
+    id=":ro:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ro:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":ro:--hint"
+    aria-invalid="false"
+    aria-labelledby=":ro:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":ro:--input"
+    style="height: 2px; overflow: hidden;"
+  />
+  <textarea
+    aria-hidden="true"
+    aria-invalid="false"
+    class="c3 c5"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    readonly=""
+    style="width: 100%;"
+    tabindex="-1"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c7 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c7 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c7 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c7 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c6 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r5:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":r5:--hint :r5:--message"
+    aria-invalid="false"
+    aria-labelledby=":r5:--label"
+    class="c5 c6"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r5:--input"
+  />
+  <div
+    class="c7 c8"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r5:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a minimum number of rows 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+.c5 {
+  resize: none;
+  overflow: auto;
+  visibility: hidden;
+  position: absolute;
+  overflow: hidden;
+  height: 0;
+  top: 0;
+  left: 0;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rn:--input"
+    id=":rn:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rn:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rn:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rn:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rn:--input"
+    rows="3"
+    style="height: 2px; overflow: hidden;"
+  />
+  <textarea
+    aria-hidden="true"
+    aria-invalid="false"
+    class="c3 c5"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    readonly=""
+    style="width: 100%;"
+    tabindex="-1"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a placeholder 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rc:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rc:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rc:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rc:--input"
+    placeholder="Enter your description"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a read-only textarea 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rh:--input"
+    id=":rh:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rh:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rh:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rh:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rh:--input"
+    readonly=""
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a regular label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r2:--input"
+    id=":r2:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r2:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":r2:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r2:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r2:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a required textarea 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":ri:--hint"
+    aria-invalid="false"
+    aria-labelledby=":ri:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":ri:--input"
+    required=""
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r6:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":r6:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r6:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r6:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a value 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    id=":rd:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rd:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rd:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rd:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rd:--input"
+  >
+    This is a sample description
+  </textarea>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with bare styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rg:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rg:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rg:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 11px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 32px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rf:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rf:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rf:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rf:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with label, hidden label, validation label, and bare textarea 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c3 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rq:--input"
+    hidden=""
+    id=":rq:--label"
+  >
+    Description
+  </label>
+  <textarea
+    aria-describedby=":rq:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rq:--label"
+    class="c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rq:--input"
+  />
+  <div
+    class="c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rq:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with label, hint, message, and compact textarea 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c7 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c7 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 11px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 32px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c7 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c7 {
+  margin-top: 4px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c6 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rp:--input"
+    id=":rp:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rp:--hint"
+  >
+    Enter a brief description
+  </div>
+  <textarea
+    aria-describedby=":rp:--hint :rp:--message"
+    aria-invalid="false"
+    aria-labelledby=":rp:--label"
+    class="c5 c6"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rp:--input"
+  />
+  <div
+    class="c7 c8"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rp:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with label, regular label, hint, message, validation label, and disabled textarea 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c7 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c7 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c7 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c7 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c6 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rr:--input"
+    id=":rr:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rr:--hint"
+  >
+    Enter a brief description
+  </div>
+  <textarea
+    aria-describedby=":rr:--hint :rr:--message"
+    aria-invalid="false"
+    aria-labelledby=":rr:--label"
+    class="c5 c6"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":rr:--input"
+  />
+  <div
+    class="c7 c8"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rr:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with resizable textarea 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: vertical;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rm:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rm:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rm:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rm:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #cd3642;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rk:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rk:--hint"
+    aria-invalid="true"
+    aria-labelledby=":rk:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rk:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #037f52;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #037f52;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rj:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rj:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rj:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rj:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #ac5918;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #ac5918;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    id=":rl:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rl:--hint"
+    aria-invalid="true"
+    aria-labelledby=":rl:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rl:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders default TextareaStory 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r0:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":r0:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r0:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r0:--input"
+  />
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/TextareaStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/TextareaStory.spec.tsx.snap
@@ -234,14 +234,14 @@ exports[`TextareaStory Component renders TextareaStory with a disabled textarea 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":re:--input"
     id=":re:--label"
   >
@@ -252,7 +252,7 @@ exports[`TextareaStory Component renders TextareaStory with a disabled textarea 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":re:--hint"
   >
     Hint
@@ -265,7 +265,7 @@ exports[`TextareaStory Component renders TextareaStory with a disabled textarea 
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     disabled=""
     id=":re:--input"
   />
@@ -506,14 +506,14 @@ exports[`TextareaStory Component renders TextareaStory with a hidden label 1`] =
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r3:--input"
     hidden=""
     id=":r3:--label"
@@ -528,7 +528,7 @@ exports[`TextareaStory Component renders TextareaStory with a hidden label 1`] =
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r3:--input"
   />
   <div
@@ -536,7 +536,7 @@ exports[`TextareaStory Component renders TextareaStory with a hidden label 1`] =
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r3:--hint"
   >
     Hint
@@ -778,14 +778,14 @@ exports[`TextareaStory Component renders TextareaStory with a hint 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r4:--input"
     id=":r4:--label"
   >
@@ -796,7 +796,7 @@ exports[`TextareaStory Component renders TextareaStory with a hint 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r4:--hint"
   >
     Enter a brief description
@@ -809,7 +809,7 @@ exports[`TextareaStory Component renders TextareaStory with a hint 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r4:--input"
   />
 </div>
@@ -1049,14 +1049,14 @@ exports[`TextareaStory Component renders TextareaStory with a label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r1:--input"
     id=":r1:--label"
   >
@@ -1067,7 +1067,7 @@ exports[`TextareaStory Component renders TextareaStory with a label 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r1:--hint"
   >
     Hint
@@ -1080,7 +1080,7 @@ exports[`TextareaStory Component renders TextareaStory with a label 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r1:--input"
   />
 </div>
@@ -1320,14 +1320,14 @@ exports[`TextareaStory Component renders TextareaStory with a label, hidden labe
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r8:--input"
     hidden=""
     id=":r8:--label"
@@ -1342,7 +1342,7 @@ exports[`TextareaStory Component renders TextareaStory with a label, hidden labe
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--input"
   />
   <div
@@ -1350,7 +1350,7 @@ exports[`TextareaStory Component renders TextareaStory with a label, hidden labe
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--hint"
   >
     Hint
@@ -1592,14 +1592,14 @@ exports[`TextareaStory Component renders TextareaStory with a label, hidden labe
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ra:--input"
     hidden=""
     id=":ra:--label"
@@ -1614,7 +1614,7 @@ exports[`TextareaStory Component renders TextareaStory with a label, hidden labe
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--input"
   />
   <div
@@ -1622,7 +1622,7 @@ exports[`TextareaStory Component renders TextareaStory with a label, hidden labe
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--hint"
   >
     Enter a brief description
@@ -1889,14 +1889,14 @@ exports[`TextareaStory Component renders TextareaStory with a label, hint, and m
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r7:--input"
     id=":r7:--label"
   >
@@ -1907,7 +1907,7 @@ exports[`TextareaStory Component renders TextareaStory with a label, hint, and m
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--hint"
   >
     Enter a brief description
@@ -1920,7 +1920,7 @@ exports[`TextareaStory Component renders TextareaStory with a label, hint, and m
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--input"
   />
   <div
@@ -1928,7 +1928,7 @@ exports[`TextareaStory Component renders TextareaStory with a label, hint, and m
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--message"
     role="alert"
   >
@@ -2196,14 +2196,14 @@ exports[`TextareaStory Component renders TextareaStory with a label, regular lab
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r9:--input"
     id=":r9:--label"
   >
@@ -2214,7 +2214,7 @@ exports[`TextareaStory Component renders TextareaStory with a label, regular lab
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--hint"
   >
     Enter a brief description
@@ -2227,7 +2227,7 @@ exports[`TextareaStory Component renders TextareaStory with a label, regular lab
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--input"
   />
   <div
@@ -2235,7 +2235,7 @@ exports[`TextareaStory Component renders TextareaStory with a label, regular lab
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--message"
     role="alert"
   >
@@ -2503,14 +2503,14 @@ exports[`TextareaStory Component renders TextareaStory with a label, regular lab
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rb:--input"
     id=":rb:--label"
   >
@@ -2521,7 +2521,7 @@ exports[`TextareaStory Component renders TextareaStory with a label, regular lab
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--hint"
   >
     Enter a brief description
@@ -2534,7 +2534,7 @@ exports[`TextareaStory Component renders TextareaStory with a label, regular lab
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--input"
   />
   <div
@@ -2542,7 +2542,7 @@ exports[`TextareaStory Component renders TextareaStory with a label, regular lab
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--message"
     role="alert"
   >
@@ -2799,14 +2799,14 @@ exports[`TextareaStory Component renders TextareaStory with a maximum number of 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ro:--input"
     id=":ro:--label"
   >
@@ -2817,7 +2817,7 @@ exports[`TextareaStory Component renders TextareaStory with a maximum number of 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ro:--hint"
   >
     Hint
@@ -2830,7 +2830,7 @@ exports[`TextareaStory Component renders TextareaStory with a maximum number of 
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ro:--input"
     style="height: 2px; overflow: hidden;"
   />
@@ -2839,7 +2839,7 @@ exports[`TextareaStory Component renders TextareaStory with a maximum number of 
     aria-invalid="false"
     class="c3 c5"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     readonly=""
     style="width: 100%;"
     tabindex="-1"
@@ -3106,14 +3106,14 @@ exports[`TextareaStory Component renders TextareaStory with a message 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r5:--input"
     id=":r5:--label"
   >
@@ -3124,7 +3124,7 @@ exports[`TextareaStory Component renders TextareaStory with a message 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--hint"
   >
     Hint
@@ -3137,7 +3137,7 @@ exports[`TextareaStory Component renders TextareaStory with a message 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--input"
   />
   <div
@@ -3145,7 +3145,7 @@ exports[`TextareaStory Component renders TextareaStory with a message 1`] = `
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--message"
     role="alert"
   >
@@ -3402,14 +3402,14 @@ exports[`TextareaStory Component renders TextareaStory with a minimum number of 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rn:--input"
     id=":rn:--label"
   >
@@ -3420,7 +3420,7 @@ exports[`TextareaStory Component renders TextareaStory with a minimum number of 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--hint"
   >
     Hint
@@ -3433,7 +3433,7 @@ exports[`TextareaStory Component renders TextareaStory with a minimum number of 
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--input"
     rows="3"
     style="height: 2px; overflow: hidden;"
@@ -3443,7 +3443,7 @@ exports[`TextareaStory Component renders TextareaStory with a minimum number of 
     aria-invalid="false"
     class="c3 c5"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     readonly=""
     style="width: 100%;"
     tabindex="-1"
@@ -3685,14 +3685,14 @@ exports[`TextareaStory Component renders TextareaStory with a placeholder 1`] = 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rc:--input"
     id=":rc:--label"
   >
@@ -3703,7 +3703,7 @@ exports[`TextareaStory Component renders TextareaStory with a placeholder 1`] = 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rc:--hint"
   >
     Hint
@@ -3716,7 +3716,7 @@ exports[`TextareaStory Component renders TextareaStory with a placeholder 1`] = 
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rc:--input"
     placeholder="Enter your description"
   />
@@ -3957,14 +3957,14 @@ exports[`TextareaStory Component renders TextareaStory with a read-only textarea
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rh:--input"
     id=":rh:--label"
   >
@@ -3975,7 +3975,7 @@ exports[`TextareaStory Component renders TextareaStory with a read-only textarea
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rh:--hint"
   >
     Hint
@@ -3988,7 +3988,7 @@ exports[`TextareaStory Component renders TextareaStory with a read-only textarea
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rh:--input"
     readonly=""
   />
@@ -4229,14 +4229,14 @@ exports[`TextareaStory Component renders TextareaStory with a regular label 1`] 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r2:--input"
     id=":r2:--label"
   >
@@ -4247,7 +4247,7 @@ exports[`TextareaStory Component renders TextareaStory with a regular label 1`] 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r2:--hint"
   >
     Hint
@@ -4260,7 +4260,7 @@ exports[`TextareaStory Component renders TextareaStory with a regular label 1`] 
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r2:--input"
   />
 </div>
@@ -4500,14 +4500,14 @@ exports[`TextareaStory Component renders TextareaStory with a required textarea 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ri:--input"
     id=":ri:--label"
   >
@@ -4518,7 +4518,7 @@ exports[`TextareaStory Component renders TextareaStory with a required textarea 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ri:--hint"
   >
     Hint
@@ -4531,7 +4531,7 @@ exports[`TextareaStory Component renders TextareaStory with a required textarea 
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ri:--input"
     required=""
   />
@@ -4772,14 +4772,14 @@ exports[`TextareaStory Component renders TextareaStory with a validation label 1
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r6:--input"
     id=":r6:--label"
   >
@@ -4790,7 +4790,7 @@ exports[`TextareaStory Component renders TextareaStory with a validation label 1
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r6:--hint"
   >
     Hint
@@ -4803,7 +4803,7 @@ exports[`TextareaStory Component renders TextareaStory with a validation label 1
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r6:--input"
   />
 </div>
@@ -5043,14 +5043,14 @@ exports[`TextareaStory Component renders TextareaStory with a value 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rd:--input"
     id=":rd:--label"
   >
@@ -5061,7 +5061,7 @@ exports[`TextareaStory Component renders TextareaStory with a value 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rd:--hint"
   >
     Hint
@@ -5074,7 +5074,7 @@ exports[`TextareaStory Component renders TextareaStory with a value 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rd:--input"
   >
     This is a sample description
@@ -5309,14 +5309,14 @@ exports[`TextareaStory Component renders TextareaStory with bare styling 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rg:--input"
     id=":rg:--label"
   >
@@ -5327,7 +5327,7 @@ exports[`TextareaStory Component renders TextareaStory with bare styling 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rg:--hint"
   >
     Hint
@@ -5340,7 +5340,7 @@ exports[`TextareaStory Component renders TextareaStory with bare styling 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rg:--input"
   />
 </div>
@@ -5580,14 +5580,14 @@ exports[`TextareaStory Component renders TextareaStory with compact styling 1`] 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rf:--input"
     id=":rf:--label"
   >
@@ -5598,7 +5598,7 @@ exports[`TextareaStory Component renders TextareaStory with compact styling 1`] 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rf:--hint"
   >
     Hint
@@ -5611,7 +5611,7 @@ exports[`TextareaStory Component renders TextareaStory with compact styling 1`] 
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rf:--input"
   />
 </div>
@@ -5844,14 +5844,14 @@ exports[`TextareaStory Component renders TextareaStory with label, hidden label,
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rq:--input"
     hidden=""
     id=":rq:--label"
@@ -5866,7 +5866,7 @@ exports[`TextareaStory Component renders TextareaStory with label, hidden label,
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rq:--input"
   />
   <div
@@ -5874,7 +5874,7 @@ exports[`TextareaStory Component renders TextareaStory with label, hidden label,
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rq:--hint"
   >
     Hint
@@ -6141,14 +6141,14 @@ exports[`TextareaStory Component renders TextareaStory with label, hint, message
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rp:--input"
     id=":rp:--label"
   >
@@ -6159,7 +6159,7 @@ exports[`TextareaStory Component renders TextareaStory with label, hint, message
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rp:--hint"
   >
     Enter a brief description
@@ -6172,7 +6172,7 @@ exports[`TextareaStory Component renders TextareaStory with label, hint, message
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rp:--input"
   />
   <div
@@ -6180,7 +6180,7 @@ exports[`TextareaStory Component renders TextareaStory with label, hint, message
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rp:--message"
     role="alert"
   >
@@ -6448,14 +6448,14 @@ exports[`TextareaStory Component renders TextareaStory with label, regular label
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1 c2"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rr:--input"
     id=":rr:--label"
   >
@@ -6466,7 +6466,7 @@ exports[`TextareaStory Component renders TextareaStory with label, regular label
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rr:--hint"
   >
     Enter a brief description
@@ -6479,7 +6479,7 @@ exports[`TextareaStory Component renders TextareaStory with label, regular label
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     disabled=""
     id=":rr:--input"
   />
@@ -6488,7 +6488,7 @@ exports[`TextareaStory Component renders TextareaStory with label, regular label
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rr:--message"
     role="alert"
   >
@@ -6731,14 +6731,14 @@ exports[`TextareaStory Component renders TextareaStory with resizable textarea 1
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rm:--input"
     id=":rm:--label"
   >
@@ -6749,7 +6749,7 @@ exports[`TextareaStory Component renders TextareaStory with resizable textarea 1
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rm:--hint"
   >
     Hint
@@ -6762,7 +6762,7 @@ exports[`TextareaStory Component renders TextareaStory with resizable textarea 1
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rm:--input"
   />
 </div>
@@ -7002,14 +7002,14 @@ exports[`TextareaStory Component renders TextareaStory with validation error 1`]
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rk:--input"
     id=":rk:--label"
   >
@@ -7020,7 +7020,7 @@ exports[`TextareaStory Component renders TextareaStory with validation error 1`]
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rk:--hint"
   >
     Hint
@@ -7033,7 +7033,7 @@ exports[`TextareaStory Component renders TextareaStory with validation error 1`]
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rk:--input"
   />
 </div>
@@ -7273,14 +7273,14 @@ exports[`TextareaStory Component renders TextareaStory with validation success 1
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rj:--input"
     id=":rj:--label"
   >
@@ -7291,7 +7291,7 @@ exports[`TextareaStory Component renders TextareaStory with validation success 1
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rj:--hint"
   >
     Hint
@@ -7304,7 +7304,7 @@ exports[`TextareaStory Component renders TextareaStory with validation success 1
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rj:--input"
   />
 </div>
@@ -7544,14 +7544,14 @@ exports[`TextareaStory Component renders TextareaStory with validation warning 1
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rl:--input"
     id=":rl:--label"
   >
@@ -7562,7 +7562,7 @@ exports[`TextareaStory Component renders TextareaStory with validation warning 1
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rl:--hint"
   >
     Hint
@@ -7575,7 +7575,7 @@ exports[`TextareaStory Component renders TextareaStory with validation warning 1
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rl:--input"
   />
 </div>
@@ -7815,14 +7815,14 @@ exports[`TextareaStory Component renders default TextareaStory 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <label
     class="c1"
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r0:--input"
     id=":r0:--label"
   >
@@ -7833,7 +7833,7 @@ exports[`TextareaStory Component renders default TextareaStory 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.input_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r0:--hint"
   >
     Hint
@@ -7846,7 +7846,7 @@ exports[`TextareaStory Component renders default TextareaStory 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.textarea"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r0:--input"
   />
 </div>

--- a/packages/forms/demo/stories/__snapshots__/TilesStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/TilesStory.spec.tsx.snap
@@ -1,0 +1,3065 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TilesStory Component renders TilesStory with a disabled tile 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c7 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <input
+            class="c8"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TilesStory Component renders TilesStory with centered tiles 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c7 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <input
+            class="c8"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TilesStory Component renders TilesStory with centered tiles and a disabled tile 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c7 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <input
+            class="c8"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TilesStory Component renders TilesStory with centered tiles and description 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7 {
+  display: block;
+  text-align: center;
+  margin-top: 4px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c9 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean.
+          </span>
+          <input
+            class="c9"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TilesStory Component renders TilesStory with centered tiles, description, and a disabled tile 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7 {
+  display: block;
+  text-align: center;
+  margin-top: 4px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c9 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean.
+          </span>
+          <input
+            class="c9"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TilesStory Component renders TilesStory with description 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7 {
+  display: block;
+  text-align: center;
+  margin-top: 4px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c9 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean.
+          </span>
+          <input
+            class="c9"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TilesStory Component renders TilesStory with description and a disabled tile 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7 {
+  display: block;
+  text-align: center;
+  margin-top: 4px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c9 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean.
+          </span>
+          <input
+            class="c9"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TilesStory Component renders default TilesStory 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c7 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <input
+            class="c8"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/TilesStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/TilesStory.spec.tsx.snap
@@ -208,29 +208,29 @@ exports[`TilesStory Component renders TilesStory with a disabled tile 1`] = `
   <div
     class="c0"
     data-garden-id="grid.grid"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="grid.row"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -239,7 +239,7 @@ exports[`TilesStory Component renders TilesStory with a disabled tile 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile one"
           >
             Tile one
@@ -254,19 +254,19 @@ exports[`TilesStory Component renders TilesStory with a disabled tile 1`] = `
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -275,7 +275,7 @@ exports[`TilesStory Component renders TilesStory with a disabled tile 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile two"
           >
             Tile two
@@ -290,19 +290,19 @@ exports[`TilesStory Component renders TilesStory with a disabled tile 1`] = `
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="true"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -311,7 +311,7 @@ exports[`TilesStory Component renders TilesStory with a disabled tile 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile three"
           >
             Tile three
@@ -327,19 +327,19 @@ exports[`TilesStory Component renders TilesStory with a disabled tile 1`] = `
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -348,7 +348,7 @@ exports[`TilesStory Component renders TilesStory with a disabled tile 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile four"
           >
             Tile four
@@ -573,29 +573,29 @@ exports[`TilesStory Component renders TilesStory with centered tiles 1`] = `
   <div
     class="c0"
     data-garden-id="grid.grid"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="grid.row"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -604,7 +604,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile one"
           >
             Tile one
@@ -619,19 +619,19 @@ exports[`TilesStory Component renders TilesStory with centered tiles 1`] = `
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -640,7 +640,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile two"
           >
             Tile two
@@ -655,19 +655,19 @@ exports[`TilesStory Component renders TilesStory with centered tiles 1`] = `
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="true"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -676,7 +676,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile three"
           >
             Tile three
@@ -692,19 +692,19 @@ exports[`TilesStory Component renders TilesStory with centered tiles 1`] = `
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -713,7 +713,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile four"
           >
             Tile four
@@ -938,29 +938,29 @@ exports[`TilesStory Component renders TilesStory with centered tiles and a disab
   <div
     class="c0"
     data-garden-id="grid.grid"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="grid.row"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -969,7 +969,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles and a disab
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile one"
           >
             Tile one
@@ -984,19 +984,19 @@ exports[`TilesStory Component renders TilesStory with centered tiles and a disab
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -1005,7 +1005,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles and a disab
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile two"
           >
             Tile two
@@ -1020,19 +1020,19 @@ exports[`TilesStory Component renders TilesStory with centered tiles and a disab
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="true"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -1041,7 +1041,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles and a disab
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile three"
           >
             Tile three
@@ -1057,19 +1057,19 @@ exports[`TilesStory Component renders TilesStory with centered tiles and a disab
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -1078,7 +1078,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles and a disab
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile four"
           >
             Tile four
@@ -1311,29 +1311,29 @@ exports[`TilesStory Component renders TilesStory with centered tiles and descrip
   <div
     class="c0"
     data-garden-id="grid.grid"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="grid.row"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -1342,7 +1342,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles and descrip
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile one"
           >
             Tile one
@@ -1350,7 +1350,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles and descrip
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery.
           </span>
@@ -1364,19 +1364,19 @@ exports[`TilesStory Component renders TilesStory with centered tiles and descrip
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -1385,7 +1385,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles and descrip
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile two"
           >
             Tile two
@@ -1393,7 +1393,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles and descrip
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip.
           </span>
@@ -1407,19 +1407,19 @@ exports[`TilesStory Component renders TilesStory with centered tiles and descrip
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="true"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -1428,7 +1428,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles and descrip
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile three"
           >
             Tile three
@@ -1436,7 +1436,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles and descrip
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean.
           </span>
@@ -1451,19 +1451,19 @@ exports[`TilesStory Component renders TilesStory with centered tiles and descrip
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -1472,7 +1472,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles and descrip
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile four"
           >
             Tile four
@@ -1480,7 +1480,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles and descrip
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon.
           </span>
@@ -1712,29 +1712,29 @@ exports[`TilesStory Component renders TilesStory with centered tiles, descriptio
   <div
     class="c0"
     data-garden-id="grid.grid"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="grid.row"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -1743,7 +1743,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles, descriptio
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile one"
           >
             Tile one
@@ -1751,7 +1751,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles, descriptio
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery.
           </span>
@@ -1765,19 +1765,19 @@ exports[`TilesStory Component renders TilesStory with centered tiles, descriptio
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -1786,7 +1786,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles, descriptio
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile two"
           >
             Tile two
@@ -1794,7 +1794,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles, descriptio
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip.
           </span>
@@ -1808,19 +1808,19 @@ exports[`TilesStory Component renders TilesStory with centered tiles, descriptio
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="true"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -1829,7 +1829,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles, descriptio
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile three"
           >
             Tile three
@@ -1837,7 +1837,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles, descriptio
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean.
           </span>
@@ -1852,19 +1852,19 @@ exports[`TilesStory Component renders TilesStory with centered tiles, descriptio
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -1873,7 +1873,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles, descriptio
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile four"
           >
             Tile four
@@ -1881,7 +1881,7 @@ exports[`TilesStory Component renders TilesStory with centered tiles, descriptio
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon.
           </span>
@@ -2113,29 +2113,29 @@ exports[`TilesStory Component renders TilesStory with description 1`] = `
   <div
     class="c0"
     data-garden-id="grid.grid"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="grid.row"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -2144,7 +2144,7 @@ exports[`TilesStory Component renders TilesStory with description 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile one"
           >
             Tile one
@@ -2152,7 +2152,7 @@ exports[`TilesStory Component renders TilesStory with description 1`] = `
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery.
           </span>
@@ -2166,19 +2166,19 @@ exports[`TilesStory Component renders TilesStory with description 1`] = `
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -2187,7 +2187,7 @@ exports[`TilesStory Component renders TilesStory with description 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile two"
           >
             Tile two
@@ -2195,7 +2195,7 @@ exports[`TilesStory Component renders TilesStory with description 1`] = `
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip.
           </span>
@@ -2209,19 +2209,19 @@ exports[`TilesStory Component renders TilesStory with description 1`] = `
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="true"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -2230,7 +2230,7 @@ exports[`TilesStory Component renders TilesStory with description 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile three"
           >
             Tile three
@@ -2238,7 +2238,7 @@ exports[`TilesStory Component renders TilesStory with description 1`] = `
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean.
           </span>
@@ -2253,19 +2253,19 @@ exports[`TilesStory Component renders TilesStory with description 1`] = `
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -2274,7 +2274,7 @@ exports[`TilesStory Component renders TilesStory with description 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile four"
           >
             Tile four
@@ -2282,7 +2282,7 @@ exports[`TilesStory Component renders TilesStory with description 1`] = `
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon.
           </span>
@@ -2514,29 +2514,29 @@ exports[`TilesStory Component renders TilesStory with description and a disabled
   <div
     class="c0"
     data-garden-id="grid.grid"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="grid.row"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -2545,7 +2545,7 @@ exports[`TilesStory Component renders TilesStory with description and a disabled
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile one"
           >
             Tile one
@@ -2553,7 +2553,7 @@ exports[`TilesStory Component renders TilesStory with description and a disabled
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery.
           </span>
@@ -2567,19 +2567,19 @@ exports[`TilesStory Component renders TilesStory with description and a disabled
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -2588,7 +2588,7 @@ exports[`TilesStory Component renders TilesStory with description and a disabled
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile two"
           >
             Tile two
@@ -2596,7 +2596,7 @@ exports[`TilesStory Component renders TilesStory with description and a disabled
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip.
           </span>
@@ -2610,19 +2610,19 @@ exports[`TilesStory Component renders TilesStory with description and a disabled
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="true"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -2631,7 +2631,7 @@ exports[`TilesStory Component renders TilesStory with description and a disabled
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile three"
           >
             Tile three
@@ -2639,7 +2639,7 @@ exports[`TilesStory Component renders TilesStory with description and a disabled
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean.
           </span>
@@ -2654,19 +2654,19 @@ exports[`TilesStory Component renders TilesStory with description and a disabled
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -2675,7 +2675,7 @@ exports[`TilesStory Component renders TilesStory with description and a disabled
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile four"
           >
             Tile four
@@ -2683,7 +2683,7 @@ exports[`TilesStory Component renders TilesStory with description and a disabled
           <span
             class="c7"
             data-garden-id="forms.tile_description"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon.
           </span>
@@ -2907,29 +2907,29 @@ exports[`TilesStory Component renders default TilesStory 1`] = `
   <div
     class="c0"
     data-garden-id="grid.grid"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
   >
     <div
       class="c1"
       data-garden-id="grid.row"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -2938,7 +2938,7 @@ exports[`TilesStory Component renders default TilesStory 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile one"
           >
             Tile one
@@ -2953,19 +2953,19 @@ exports[`TilesStory Component renders default TilesStory 1`] = `
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -2974,7 +2974,7 @@ exports[`TilesStory Component renders default TilesStory 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile two"
           >
             Tile two
@@ -2989,19 +2989,19 @@ exports[`TilesStory Component renders default TilesStory 1`] = `
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="true"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -3010,7 +3010,7 @@ exports[`TilesStory Component renders default TilesStory 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile three"
           >
             Tile three
@@ -3026,19 +3026,19 @@ exports[`TilesStory Component renders default TilesStory 1`] = `
       <div
         class="c2"
         data-garden-id="grid.col"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
       >
         <label
           aria-disabled="false"
           class="c3 c4"
           data-garden-id="forms.tile"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
           style="margin: 10px;"
         >
           <span
             class="c5"
             data-garden-id="forms.tile_icon"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -3047,7 +3047,7 @@ exports[`TilesStory Component renders default TilesStory 1`] = `
           <span
             class="c6"
             data-garden-id="forms.tile_label"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
             title="Tile four"
           >
             Tile four

--- a/packages/forms/demo/stories/__snapshots__/ToggleStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/ToggleStory.spec.tsx.snap
@@ -222,7 +222,7 @@ exports[`ToggleStory Component renders component with a checked state 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":rf:--label"
@@ -231,7 +231,7 @@ exports[`ToggleStory Component renders component with a checked state 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rf:--input"
     type="checkbox"
   />
@@ -240,7 +240,7 @@ exports[`ToggleStory Component renders component with a checked state 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rf:--input"
     id=":rf:--label"
   >
@@ -248,7 +248,7 @@ exports[`ToggleStory Component renders component with a checked state 1`] = `
       aria-hidden="true"
       class="c10"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -488,7 +488,7 @@ exports[`ToggleStory Component renders component with a disabled state 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":rc:--label"
@@ -496,7 +496,7 @@ exports[`ToggleStory Component renders component with a disabled state 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     disabled=""
     id=":rc:--input"
     type="checkbox"
@@ -506,7 +506,7 @@ exports[`ToggleStory Component renders component with a disabled state 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rc:--input"
     id=":rc:--label"
   >
@@ -514,7 +514,7 @@ exports[`ToggleStory Component renders component with a disabled state 1`] = `
       aria-hidden="true"
       class="c10"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -564,7 +564,7 @@ exports[`ToggleStory Component renders component with a hidden label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r2:--label"
@@ -572,7 +572,7 @@ exports[`ToggleStory Component renders component with a hidden label 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r2:--input"
     label="Accept Terms"
     type="checkbox"
@@ -814,7 +814,7 @@ exports[`ToggleStory Component renders component with a hint 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":r3:--hint"
@@ -823,7 +823,7 @@ exports[`ToggleStory Component renders component with a hint 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r3:--input"
     type="checkbox"
   />
@@ -832,7 +832,7 @@ exports[`ToggleStory Component renders component with a hint 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r3:--input"
     id=":r3:--label"
   >
@@ -840,7 +840,7 @@ exports[`ToggleStory Component renders component with a hint 1`] = `
       aria-hidden="true"
       class="c10"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -860,7 +860,7 @@ exports[`ToggleStory Component renders component with a hint 1`] = `
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r3:--hint"
   >
     This is a hint
@@ -1090,7 +1090,7 @@ exports[`ToggleStory Component renders component with a label 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r1:--label"
@@ -1098,7 +1098,7 @@ exports[`ToggleStory Component renders component with a label 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r1:--input"
     label="Accept Terms"
     type="checkbox"
@@ -1108,7 +1108,7 @@ exports[`ToggleStory Component renders component with a label 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r1:--input"
     id=":r1:--label"
   >
@@ -1116,7 +1116,7 @@ exports[`ToggleStory Component renders component with a label 1`] = `
       aria-hidden="true"
       class="c10"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -1357,7 +1357,7 @@ exports[`ToggleStory Component renders component with a label and compact stylin
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":rk:--label"
@@ -1365,7 +1365,7 @@ exports[`ToggleStory Component renders component with a label and compact stylin
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rk:--input"
     type="checkbox"
   />
@@ -1374,7 +1374,7 @@ exports[`ToggleStory Component renders component with a label and compact stylin
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rk:--input"
     id=":rk:--label"
   >
@@ -1382,7 +1382,7 @@ exports[`ToggleStory Component renders component with a label and compact stylin
       aria-hidden="true"
       class="c10"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -1432,7 +1432,7 @@ exports[`ToggleStory Component renders component with a label, hidden label, and
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r9:--label"
@@ -1440,7 +1440,7 @@ exports[`ToggleStory Component renders component with a label, hidden label, and
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r9:--input"
     label="Accept Terms"
     type="checkbox"
@@ -1492,7 +1492,7 @@ exports[`ToggleStory Component renders component with a label, hidden label, hin
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":rb:--hint"
@@ -1501,7 +1501,7 @@ exports[`ToggleStory Component renders component with a label, hidden label, hin
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--input"
     label="Accept Terms"
     type="checkbox"
@@ -1511,7 +1511,7 @@ exports[`ToggleStory Component renders component with a label, hidden label, hin
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rb:--hint"
   >
     This is a hint
@@ -1753,7 +1753,7 @@ exports[`ToggleStory Component renders component with a label, hint, and compact
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":rl:--hint"
@@ -1762,7 +1762,7 @@ exports[`ToggleStory Component renders component with a label, hint, and compact
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rl:--input"
     type="checkbox"
   />
@@ -1771,7 +1771,7 @@ exports[`ToggleStory Component renders component with a label, hint, and compact
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rl:--input"
     id=":rl:--label"
   >
@@ -1779,7 +1779,7 @@ exports[`ToggleStory Component renders component with a label, hint, and compact
       aria-hidden="true"
       class="c10"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -1799,7 +1799,7 @@ exports[`ToggleStory Component renders component with a label, hint, and compact
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rl:--hint"
   >
     This is a hint
@@ -2066,7 +2066,7 @@ exports[`ToggleStory Component renders component with a label, hint, and message
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":r8:--hint :r8:--message"
@@ -2075,7 +2075,7 @@ exports[`ToggleStory Component renders component with a label, hint, and message
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--input"
     label="Accept Terms"
     type="checkbox"
@@ -2085,7 +2085,7 @@ exports[`ToggleStory Component renders component with a label, hint, and message
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r8:--input"
     id=":r8:--label"
   >
@@ -2093,7 +2093,7 @@ exports[`ToggleStory Component renders component with a label, hint, and message
       aria-hidden="true"
       class="c11"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -2114,7 +2114,7 @@ exports[`ToggleStory Component renders component with a label, hint, and message
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--hint"
   >
     This is a hint
@@ -2124,7 +2124,7 @@ exports[`ToggleStory Component renders component with a label, hint, and message
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r8:--message"
     role="alert"
   >
@@ -2392,7 +2392,7 @@ exports[`ToggleStory Component renders component with a label, hint, message, an
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":rn:--hint :rn:--message"
@@ -2401,7 +2401,7 @@ exports[`ToggleStory Component renders component with a label, hint, message, an
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--input"
     type="checkbox"
   />
@@ -2410,7 +2410,7 @@ exports[`ToggleStory Component renders component with a label, hint, message, an
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rn:--input"
     id=":rn:--label"
   >
@@ -2418,7 +2418,7 @@ exports[`ToggleStory Component renders component with a label, hint, message, an
       aria-hidden="true"
       class="c11"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -2438,7 +2438,7 @@ exports[`ToggleStory Component renders component with a label, hint, message, an
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--hint"
   >
     This is a hint
@@ -2448,7 +2448,7 @@ exports[`ToggleStory Component renders component with a label, hint, message, an
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rn:--message"
     role="alert"
   >
@@ -2732,7 +2732,7 @@ exports[`ToggleStory Component renders component with a label, hint, message, an
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":ra:--hint :ra:--message"
@@ -2741,7 +2741,7 @@ exports[`ToggleStory Component renders component with a label, hint, message, an
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--input"
     label="Accept Terms"
     type="checkbox"
@@ -2751,7 +2751,7 @@ exports[`ToggleStory Component renders component with a label, hint, message, an
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ra:--input"
     id=":ra:--label"
   >
@@ -2759,7 +2759,7 @@ exports[`ToggleStory Component renders component with a label, hint, message, an
       aria-hidden="true"
       class="c11"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -2780,7 +2780,7 @@ exports[`ToggleStory Component renders component with a label, hint, message, an
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--hint"
   >
     This is a hint
@@ -2790,7 +2790,7 @@ exports[`ToggleStory Component renders component with a label, hint, message, an
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ra:--message"
     role="alert"
   >
@@ -2798,7 +2798,7 @@ exports[`ToggleStory Component renders component with a label, hint, message, an
       aria-label="error"
       class="c17  c18"
       data-garden-id="forms.input_message_icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       role="img"
@@ -3079,7 +3079,7 @@ exports[`ToggleStory Component renders component with a label, message, and comp
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":rm:--message"
@@ -3088,7 +3088,7 @@ exports[`ToggleStory Component renders component with a label, message, and comp
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rm:--input"
     type="checkbox"
   />
@@ -3097,7 +3097,7 @@ exports[`ToggleStory Component renders component with a label, message, and comp
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rm:--input"
     id=":rm:--label"
   >
@@ -3105,7 +3105,7 @@ exports[`ToggleStory Component renders component with a label, message, and comp
       aria-hidden="true"
       class="c11"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -3125,7 +3125,7 @@ exports[`ToggleStory Component renders component with a label, message, and comp
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rm:--message"
     role="alert"
   >
@@ -3381,7 +3381,7 @@ exports[`ToggleStory Component renders component with a message 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":r4:--message"
@@ -3390,7 +3390,7 @@ exports[`ToggleStory Component renders component with a message 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r4:--input"
     type="checkbox"
   />
@@ -3399,7 +3399,7 @@ exports[`ToggleStory Component renders component with a message 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r4:--input"
     id=":r4:--label"
   >
@@ -3407,7 +3407,7 @@ exports[`ToggleStory Component renders component with a message 1`] = `
       aria-hidden="true"
       class="c11"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -3427,7 +3427,7 @@ exports[`ToggleStory Component renders component with a message 1`] = `
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r4:--message"
     role="alert"
   >
@@ -3658,7 +3658,7 @@ exports[`ToggleStory Component renders component with a read-only state 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":rd:--label"
@@ -3666,7 +3666,7 @@ exports[`ToggleStory Component renders component with a read-only state 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rd:--input"
     readonly=""
     type="checkbox"
@@ -3676,7 +3676,7 @@ exports[`ToggleStory Component renders component with a read-only state 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rd:--input"
     id=":rd:--label"
   >
@@ -3684,7 +3684,7 @@ exports[`ToggleStory Component renders component with a read-only state 1`] = `
       aria-hidden="true"
       class="c10"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -3924,7 +3924,7 @@ exports[`ToggleStory Component renders component with a required state 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":re:--label"
@@ -3932,7 +3932,7 @@ exports[`ToggleStory Component renders component with a required state 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":re:--input"
     required=""
     type="checkbox"
@@ -3942,7 +3942,7 @@ exports[`ToggleStory Component renders component with a required state 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":re:--input"
     id=":re:--label"
   >
@@ -3950,7 +3950,7 @@ exports[`ToggleStory Component renders component with a required state 1`] = `
       aria-hidden="true"
       class="c10"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -4190,7 +4190,7 @@ exports[`ToggleStory Component renders component with compact styling 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":rj:--label"
@@ -4198,7 +4198,7 @@ exports[`ToggleStory Component renders component with compact styling 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rj:--input"
     type="checkbox"
   />
@@ -4207,7 +4207,7 @@ exports[`ToggleStory Component renders component with compact styling 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rj:--input"
     id=":rj:--label"
   >
@@ -4215,7 +4215,7 @@ exports[`ToggleStory Component renders component with compact styling 1`] = `
       aria-hidden="true"
       class="c10"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -4265,7 +4265,7 @@ exports[`ToggleStory Component renders component with label, hidden label, valid
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":rh:--label"
@@ -4273,7 +4273,7 @@ exports[`ToggleStory Component renders component with label, hidden label, valid
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rh:--input"
     label="Accept Terms"
     readonly=""
@@ -4541,7 +4541,7 @@ exports[`ToggleStory Component renders component with label, hint, message, and 
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":rg:--hint :rg:--message"
@@ -4550,7 +4550,7 @@ exports[`ToggleStory Component renders component with label, hint, message, and 
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     disabled=""
     id=":rg:--input"
     label="Accept Terms"
@@ -4561,7 +4561,7 @@ exports[`ToggleStory Component renders component with label, hint, message, and 
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":rg:--input"
     id=":rg:--label"
   >
@@ -4569,7 +4569,7 @@ exports[`ToggleStory Component renders component with label, hint, message, and 
       aria-hidden="true"
       class="c11"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -4590,7 +4590,7 @@ exports[`ToggleStory Component renders component with label, hint, message, and 
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rg:--hint"
   >
     This is a hint
@@ -4600,7 +4600,7 @@ exports[`ToggleStory Component renders component with label, hint, message, and 
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":rg:--message"
     role="alert"
   >
@@ -4884,7 +4884,7 @@ exports[`ToggleStory Component renders component with label, hint, message, vali
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-describedby=":ri:--hint :ri:--message"
@@ -4893,7 +4893,7 @@ exports[`ToggleStory Component renders component with label, hint, message, vali
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ri:--input"
     label="Accept Terms"
     required=""
@@ -4904,7 +4904,7 @@ exports[`ToggleStory Component renders component with label, hint, message, vali
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":ri:--input"
     id=":ri:--label"
   >
@@ -4912,7 +4912,7 @@ exports[`ToggleStory Component renders component with label, hint, message, vali
       aria-hidden="true"
       class="c11"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -4933,7 +4933,7 @@ exports[`ToggleStory Component renders component with label, hint, message, vali
     data-garden-container-id="containers.field.hint"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_hint"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ri:--hint"
   >
     This is a hint
@@ -4943,7 +4943,7 @@ exports[`ToggleStory Component renders component with label, hint, message, vali
     data-garden-container-id="containers.field.message"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_message"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":ri:--message"
     role="alert"
   >
@@ -4951,7 +4951,7 @@ exports[`ToggleStory Component renders component with label, hint, message, vali
       aria-label="error"
       class="c17  c18"
       data-garden-id="forms.input_message_icon"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       role="img"
@@ -5207,7 +5207,7 @@ exports[`ToggleStory Component renders component with validation error 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r6:--label"
@@ -5215,7 +5215,7 @@ exports[`ToggleStory Component renders component with validation error 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r6:--input"
     type="checkbox"
   />
@@ -5224,7 +5224,7 @@ exports[`ToggleStory Component renders component with validation error 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r6:--input"
     id=":r6:--label"
   >
@@ -5232,7 +5232,7 @@ exports[`ToggleStory Component renders component with validation error 1`] = `
       aria-hidden="true"
       class="c10"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -5472,7 +5472,7 @@ exports[`ToggleStory Component renders component with validation success 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r5:--label"
@@ -5480,7 +5480,7 @@ exports[`ToggleStory Component renders component with validation success 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r5:--input"
     type="checkbox"
   />
@@ -5489,7 +5489,7 @@ exports[`ToggleStory Component renders component with validation success 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r5:--input"
     id=":r5:--label"
   >
@@ -5497,7 +5497,7 @@ exports[`ToggleStory Component renders component with validation success 1`] = `
       aria-hidden="true"
       class="c10"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -5737,7 +5737,7 @@ exports[`ToggleStory Component renders component with validation warning 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r7:--label"
@@ -5745,7 +5745,7 @@ exports[`ToggleStory Component renders component with validation warning 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r7:--input"
     type="checkbox"
   />
@@ -5754,7 +5754,7 @@ exports[`ToggleStory Component renders component with validation warning 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r7:--input"
     id=":r7:--label"
   >
@@ -5762,7 +5762,7 @@ exports[`ToggleStory Component renders component with validation warning 1`] = `
       aria-hidden="true"
       class="c10"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -6002,7 +6002,7 @@ exports[`ToggleStory Component renders default component 1`] = `
 <div
   class="c0"
   data-garden-id="forms.field"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <input
     aria-labelledby=":r0:--label"
@@ -6010,7 +6010,7 @@ exports[`ToggleStory Component renders default component 1`] = `
     data-garden-container-id="containers.field.input"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     id=":r0:--input"
     type="checkbox"
   />
@@ -6019,7 +6019,7 @@ exports[`ToggleStory Component renders default component 1`] = `
     data-garden-container-id="containers.field.label"
     data-garden-container-version="3.0.19"
     data-garden-id="forms.toggle_label"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     for=":r0:--input"
     id=":r0:--label"
   >
@@ -6027,7 +6027,7 @@ exports[`ToggleStory Component renders default component 1`] = `
       aria-hidden="true"
       class="c10"
       data-garden-id="forms.toggle_svg"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"

--- a/packages/forms/demo/stories/__snapshots__/ToggleStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/ToggleStory.spec.tsx.snap
@@ -1,0 +1,6046 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ToggleStory Component renders component with a checked state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rf:--label"
+    checked=""
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rf:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a disabled state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rc:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":rc:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a hidden label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c2 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r2:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r2:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c11 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c12 {
+  padding-left: 48px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r3:--hint"
+    aria-labelledby=":r3:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r3:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    id=":r3:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+  <div
+    class="c11 c12"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r1:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r1:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+    Accept Terms
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rk:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rk:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label, hidden label, and validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c2 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r9:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r9:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label, hidden label, hint, and validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c3 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c4 {
+  padding-left: 48px;
+}
+
+.c2 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rb:--hint"
+    aria-labelledby=":rb:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rb:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label, hint, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c11 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c12 {
+  padding-left: 48px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rl:--hint"
+    aria-labelledby=":rl:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rl:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    id=":rl:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+  <div
+    class="c11 c12"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c8 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c8[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c15 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c14 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c14 {
+  display: block;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c9[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1.c1 ~ .c5 ~ .c14 {
+  margin-top: 8px;
+}
+
+.c1:focus ~ .c5::before {
+  outline: none;
+}
+
+.c1 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c2 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c10 {
+  padding-left: 48px;
+}
+
+.c10[hidden] {
+  padding-left: 40px;
+}
+
+.c13 {
+  padding-left: 48px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c7::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c7 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c7::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c7:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c7:active::before {
+  background-color: #293239;
+}
+
+.c16 {
+  padding-left: 48px;
+}
+
+.c11 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r8:--hint :r8:--message"
+    aria-labelledby=":r8:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r8:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9 c10"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    id=":r8:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c11"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c12 c13"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c14 c15 c16"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_message"
+    data-garden-version="9.0.0"
+    id=":r8:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label, hint, message, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c8 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c8[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c15 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c14 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c14 {
+  display: block;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c9[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1.c1 ~ .c5 ~ .c14 {
+  margin-top: 4px;
+}
+
+.c1:focus ~ .c5::before {
+  outline: none;
+}
+
+.c1 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c2 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c10 {
+  padding-left: 48px;
+}
+
+.c10[hidden] {
+  padding-left: 40px;
+}
+
+.c13 {
+  padding-left: 48px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c7::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c7 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c7::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c7:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c7:active::before {
+  background-color: #293239;
+}
+
+.c16 {
+  padding-left: 48px;
+}
+
+.c11 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rn:--hint :rn:--message"
+    aria-labelledby=":rn:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rn:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9 c10"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rn:--input"
+    id=":rn:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c11"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+  <div
+    class="c12 c13"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":rn:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c14 c15 c16"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_message"
+    data-garden-version="9.0.0"
+    id=":rn:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label, hint, message, and validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c8 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c8[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  width: 16px;
+  height: 16px;
+}
+
+.c15 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 24px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #cd3642;
+}
+
+.c4:not([hidden]) + .c14 {
+  margin-top: 4px;
+}
+
+.c15 .c17 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+}
+
+.c4:not([hidden]) + .c14 {
+  display: block;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c9[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1.c1 ~ .c5 ~ .c14 {
+  margin-top: 8px;
+}
+
+.c1:focus ~ .c5::before {
+  outline: none;
+}
+
+.c1 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c2 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c10 {
+  padding-left: 48px;
+}
+
+.c10[hidden] {
+  padding-left: 40px;
+}
+
+.c13 {
+  padding-left: 48px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c7::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c7 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c7::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c7:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c7:active::before {
+  background-color: #293239;
+}
+
+.c16 {
+  padding-left: 48px;
+}
+
+.c16 .c17 {
+  left: 24px;
+}
+
+.c11 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":ra:--hint :ra:--message"
+    aria-labelledby=":ra:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":ra:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9 c10"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    id=":ra:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c11"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c12 c13"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c14 c15 c16"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_message"
+    data-garden-version="9.0.0"
+    id=":ra:--message"
+    role="alert"
+  >
+    <svg
+      aria-label="error"
+      class="c17  c18"
+      data-garden-id="forms.input_message_icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      role="img"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        stroke="currentColor"
+      >
+        <circle
+          cx="7.5"
+          cy="8.5"
+          r="7"
+        />
+        <path
+          d="M7.5 4.5V9"
+          stroke-linecap="round"
+        />
+      </g>
+      <circle
+        cx="7.5"
+        cy="12"
+        fill="currentColor"
+        r="1"
+      />
+    </svg>
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label, message, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c8 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c8[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c13 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c12 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c12 {
+  display: block;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c9[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1.c1 ~ .c5 ~ .c12 {
+  margin-top: 4px;
+}
+
+.c1:focus ~ .c5::before {
+  outline: none;
+}
+
+.c1 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c2 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c10 {
+  padding-left: 48px;
+}
+
+.c10[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c7::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c7 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c7::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c7:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c7:active::before {
+  background-color: #293239;
+}
+
+.c14 {
+  padding-left: 48px;
+}
+
+.c11 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rm:--message"
+    aria-labelledby=":rm:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rm:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9 c10"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c11"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+  <div
+    class="c12 c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_message"
+    data-garden-version="9.0.0"
+    id=":rm:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c8 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c8[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c13 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c12 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c12 {
+  display: block;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c9[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1.c1 ~ .c5 ~ .c12 {
+  margin-top: 8px;
+}
+
+.c1:focus ~ .c5::before {
+  outline: none;
+}
+
+.c1 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c2 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c10 {
+  padding-left: 48px;
+}
+
+.c10[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c7::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c7 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c7::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c7:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c7:active::before {
+  background-color: #293239;
+}
+
+.c14 {
+  padding-left: 48px;
+}
+
+.c11 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r4:--message"
+    aria-labelledby=":r4:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r4:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9 c10"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c11"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+  <div
+    class="c12 c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_message"
+    data-garden-version="9.0.0"
+    id=":r4:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a read-only state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rd:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rd:--input"
+    readonly=""
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    id=":rd:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a required state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":re:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":re:--input"
+    required=""
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rj:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rj:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with label, hidden label, validation success, and read-only state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c2 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rh:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rh:--input"
+    label="Accept Terms"
+    readonly=""
+    type="checkbox"
+  />
+</div>
+`;
+
+exports[`ToggleStory Component renders component with label, hint, message, and disabled state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c8 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c8[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c15 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c14 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c14 {
+  display: block;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c9[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1.c1 ~ .c5 ~ .c14 {
+  margin-top: 8px;
+}
+
+.c1:focus ~ .c5::before {
+  outline: none;
+}
+
+.c1 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c2 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c10 {
+  padding-left: 48px;
+}
+
+.c10[hidden] {
+  padding-left: 40px;
+}
+
+.c13 {
+  padding-left: 48px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c7::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c7 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c7::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c7:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c7:active::before {
+  background-color: #293239;
+}
+
+.c16 {
+  padding-left: 48px;
+}
+
+.c11 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rg:--hint :rg:--message"
+    aria-labelledby=":rg:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":rg:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9 c10"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c11"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c12 c13"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c14 c15 c16"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_message"
+    data-garden-version="9.0.0"
+    id=":rg:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with label, hint, message, validation error, and required state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c8 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c8[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  width: 16px;
+  height: 16px;
+}
+
+.c15 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 24px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #cd3642;
+}
+
+.c4:not([hidden]) + .c14 {
+  margin-top: 4px;
+}
+
+.c15 .c17 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+}
+
+.c4:not([hidden]) + .c14 {
+  display: block;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c9[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1.c1 ~ .c5 ~ .c14 {
+  margin-top: 8px;
+}
+
+.c1:focus ~ .c5::before {
+  outline: none;
+}
+
+.c1 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c2 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c10 {
+  padding-left: 48px;
+}
+
+.c10[hidden] {
+  padding-left: 40px;
+}
+
+.c13 {
+  padding-left: 48px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c7::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c7 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c7::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c7:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c7:active::before {
+  background-color: #293239;
+}
+
+.c16 {
+  padding-left: 48px;
+}
+
+.c16 .c17 {
+  left: 24px;
+}
+
+.c11 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":ri:--hint :ri:--message"
+    aria-labelledby=":ri:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":ri:--input"
+    label="Accept Terms"
+    required=""
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9 c10"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c11"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c12 c13"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c14 c15 c16"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_message"
+    data-garden-version="9.0.0"
+    id=":ri:--message"
+    role="alert"
+  >
+    <svg
+      aria-label="error"
+      class="c17  c18"
+      data-garden-id="forms.input_message_icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      role="img"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        stroke="currentColor"
+      >
+        <circle
+          cx="7.5"
+          cy="8.5"
+          r="7"
+        />
+        <path
+          d="M7.5 4.5V9"
+          stroke-linecap="round"
+        />
+      </g>
+      <circle
+        cx="7.5"
+        cy="12"
+        fill="currentColor"
+        r="1"
+      />
+    </svg>
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r6:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r6:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r5:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r5:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r7:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r7:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders default component 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r0:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r0:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;

--- a/packages/modals/demo/stories/DrawerStory.spec.tsx
+++ b/packages/modals/demo/stories/DrawerStory.spec.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { DrawerStory } from './DrawerStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<DrawerStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('DrawerStory Component', () => {
+  it('renders default DrawerStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  it('renders DrawerStory with a header', () => {
+    renderAndMatchSnapshot({ hasHeader: true, header: 'Drawer Header' });
+  });
+
+  it('renders DrawerStory with a custom tag for the header', () => {
+    renderAndMatchSnapshot({ hasHeader: true, header: 'Drawer Header', tag: 'h2' });
+  });
+
+  it('renders DrawerStory with a body', () => {
+    renderAndMatchSnapshot({ hasBody: true, body: 'This is the drawer body' });
+  });
+
+  it('renders DrawerStory with a footer', () => {
+    renderAndMatchSnapshot({
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ]
+    });
+  });
+
+  it('renders DrawerStory with a close button', () => {
+    renderAndMatchSnapshot({ hasClose: true, closeAriaLabel: 'Close Drawer' });
+  });
+
+  it('renders DrawerStory with a header, body, and footer', () => {
+    renderAndMatchSnapshot({
+      hasHeader: true,
+      header: 'Drawer Header',
+      hasBody: true,
+      body: 'This is the drawer body',
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ]
+    });
+  });
+
+  it('renders DrawerStory with a header, body, footer, and close button', () => {
+    renderAndMatchSnapshot({
+      hasHeader: true,
+      header: 'Drawer Header',
+      hasBody: true,
+      body: 'This is the drawer body',
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ],
+      hasClose: true,
+      closeAriaLabel: 'Close Drawer'
+    });
+  });
+
+  it('renders DrawerStory with a header and aria-label for the dialog', () => {
+    renderAndMatchSnapshot({
+      hasHeader: true,
+      header: 'Drawer Header',
+      dialogAriaLabel: 'Custom Dialog Label'
+    });
+  });
+
+  it('renders DrawerStory with a body and aria-label for the dialog', () => {
+    renderAndMatchSnapshot({
+      hasBody: true,
+      body: 'This is the drawer body',
+      dialogAriaLabel: 'Custom Dialog Label'
+    });
+  });
+
+  it('renders DrawerStory with a footer and aria-label for the dialog', () => {
+    renderAndMatchSnapshot({
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ],
+      dialogAriaLabel: 'Custom Dialog Label'
+    });
+  });
+
+  it('renders DrawerStory with a header, body, footer, close button, and aria-label for the dialog', () => {
+    renderAndMatchSnapshot({
+      hasHeader: true,
+      header: 'Drawer Header',
+      hasBody: true,
+      body: 'This is the drawer body',
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ],
+      hasClose: true,
+      closeAriaLabel: 'Close Drawer',
+      dialogAriaLabel: 'Custom Dialog Label'
+    });
+  });
+
+  it('renders DrawerStory with a header and custom footer items', () => {
+    renderAndMatchSnapshot({
+      hasHeader: true,
+      header: 'Drawer Header',
+      hasFooter: true,
+      footerItems: [{ text: 'Custom Action', type: 'primary' }]
+    });
+  });
+
+  it('renders DrawerStory with a body and custom footer items', () => {
+    renderAndMatchSnapshot({
+      hasBody: true,
+      body: 'This is the drawer body',
+      hasFooter: true,
+      footerItems: [{ text: 'Custom Action', type: 'primary' }]
+    });
+  });
+
+  it('renders DrawerStory with a header, body, and custom footer items', () => {
+    renderAndMatchSnapshot({
+      hasHeader: true,
+      header: 'Drawer Header',
+      hasBody: true,
+      body: 'This is the drawer body',
+      hasFooter: true,
+      footerItems: [{ text: 'Custom Action', type: 'primary' }]
+    });
+  });
+
+  it('renders DrawerStory with a header, body, footer, and custom close button aria-label', () => {
+    renderAndMatchSnapshot({
+      hasHeader: true,
+      header: 'Drawer Header',
+      hasBody: true,
+      body: 'This is the drawer body',
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ],
+      hasClose: true,
+      closeAriaLabel: 'Custom Close Label'
+    });
+  });
+
+  it('renders DrawerStory with a header, body, footer, and custom dialog aria-label', () => {
+    renderAndMatchSnapshot({
+      hasHeader: true,
+      header: 'Drawer Header',
+      hasBody: true,
+      body: 'This is the drawer body',
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ],
+      dialogAriaLabel: 'Custom Dialog Label'
+    });
+  });
+
+  it('renders DrawerStory with a header, body, footer, close button, and custom dialog aria-label', () => {
+    renderAndMatchSnapshot({
+      hasHeader: true,
+      header: 'Drawer Header',
+      hasBody: true,
+      body: 'This is the drawer body',
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ],
+      hasClose: true,
+      closeAriaLabel: 'Close Drawer',
+      dialogAriaLabel: 'Custom Dialog Label'
+    });
+  });
+});

--- a/packages/modals/demo/stories/ModalStory.spec.tsx
+++ b/packages/modals/demo/stories/ModalStory.spec.tsx
@@ -1,0 +1,240 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { ModalStory } from './ModalStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<ModalStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('ModalStory Component', () => {
+  it('renders default ModalStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  it('renders ModalStory with visible modal', () => {
+    renderAndMatchSnapshot({ isVisible: true });
+  });
+
+  it('renders ModalStory with a header', () => {
+    renderAndMatchSnapshot({ isVisible: true, hasHeader: true, header: 'Modal Header' });
+  });
+
+  it('renders ModalStory with a danger header', () => {
+    renderAndMatchSnapshot({
+      isVisible: true,
+      hasHeader: true,
+      header: 'Danger Header',
+      isDanger: true
+    });
+  });
+
+  it('renders ModalStory with a custom tag in the header', () => {
+    renderAndMatchSnapshot({
+      isVisible: true,
+      hasHeader: true,
+      header: 'Custom Tag Header',
+      tag: 'h3'
+    });
+  });
+
+  it('renders ModalStory with a body', () => {
+    renderAndMatchSnapshot({ isVisible: true, hasBody: true, body: 'This is the modal body' });
+  });
+
+  it('renders ModalStory with a footer', () => {
+    renderAndMatchSnapshot({
+      isVisible: true,
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ]
+    });
+  });
+
+  it('renders ModalStory with a danger footer', () => {
+    renderAndMatchSnapshot({
+      isVisible: true,
+      hasFooter: true,
+      isDanger: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Delete', type: 'primary' }
+      ]
+    });
+  });
+
+  it('renders ModalStory with a close button', () => {
+    renderAndMatchSnapshot({ isVisible: true, hasClose: true, closeAriaLabel: 'Close modal' });
+  });
+
+  it('renders ModalStory with a dialog aria label', () => {
+    renderAndMatchSnapshot({
+      isVisible: true,
+      hasHeader: false,
+      dialogAriaLabel: 'Custom Dialog Label'
+    });
+  });
+
+  it('renders ModalStory with a large button', () => {
+    renderAndMatchSnapshot({ isVisible: true, isLarge: true });
+  });
+
+  it('renders ModalStory with a centered modal', () => {
+    renderAndMatchSnapshot({ isVisible: true, isCentered: true });
+  });
+
+  it('renders ModalStory with an animated modal', () => {
+    renderAndMatchSnapshot({ isVisible: true, isAnimated: true });
+  });
+
+  it('renders ModalStory with focus on mount', () => {
+    renderAndMatchSnapshot({ isVisible: true, focusOnMount: true });
+  });
+
+  it('renders ModalStory with restore focus on close', () => {
+    renderAndMatchSnapshot({ isVisible: true, restoreFocus: true });
+  });
+
+  it('renders ModalStory with a header, body, and footer', () => {
+    renderAndMatchSnapshot({
+      isVisible: true,
+      hasHeader: true,
+      header: 'Modal Header',
+      hasBody: true,
+      body: 'This is the modal body',
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ]
+    });
+  });
+
+  it('renders ModalStory with a header, body, footer, and close button', () => {
+    renderAndMatchSnapshot({
+      isVisible: true,
+      hasHeader: true,
+      header: 'Modal Header',
+      hasBody: true,
+      body: 'This is the modal body',
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ],
+      hasClose: true,
+      closeAriaLabel: 'Close modal'
+    });
+  });
+
+  it('renders ModalStory with a header, body, footer, close button, and danger styling', () => {
+    renderAndMatchSnapshot({
+      isVisible: true,
+      hasHeader: true,
+      header: 'Danger Modal',
+      isDanger: true,
+      hasBody: true,
+      body: 'This is the modal body',
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Delete', type: 'primary' }
+      ],
+      hasClose: true,
+      closeAriaLabel: 'Close modal'
+    });
+  });
+
+  it('renders ModalStory with a header, body, footer, close button, and large button', () => {
+    renderAndMatchSnapshot({
+      isVisible: true,
+      hasHeader: true,
+      header: 'Modal Header',
+      hasBody: true,
+      body: 'This is the modal body',
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ],
+      hasClose: true,
+      closeAriaLabel: 'Close modal',
+      isLarge: true
+    });
+  });
+
+  it('renders ModalStory with a header, body, footer, close button, and centered modal', () => {
+    renderAndMatchSnapshot({
+      isVisible: true,
+      hasHeader: true,
+      header: 'Modal Header',
+      hasBody: true,
+      body: 'This is the modal body',
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ],
+      hasClose: true,
+      closeAriaLabel: 'Close modal',
+      isCentered: true
+    });
+  });
+
+  it('renders ModalStory with a header, body, footer, close button, and animated modal', () => {
+    renderAndMatchSnapshot({
+      isVisible: true,
+      hasHeader: true,
+      header: 'Modal Header',
+      hasBody: true,
+      body: 'This is the modal body',
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ],
+      hasClose: true,
+      closeAriaLabel: 'Close modal',
+      isAnimated: true
+    });
+  });
+
+  it('renders ModalStory with a header, body, footer, close button, and focus on mount', () => {
+    renderAndMatchSnapshot({
+      isVisible: true,
+      hasHeader: true,
+      header: 'Modal Header',
+      hasBody: true,
+      body: 'This is the modal body',
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ],
+      hasClose: true,
+      closeAriaLabel: 'Close modal',
+      focusOnMount: true
+    });
+  });
+
+  it('renders ModalStory with a header, body, footer, close button, and restore focus on close', () => {
+    renderAndMatchSnapshot({
+      isVisible: true,
+      hasHeader: true,
+      header: 'Modal Header',
+      hasBody: true,
+      body: 'This is the modal body',
+      hasFooter: true,
+      footerItems: [
+        { text: 'Cancel', type: 'basic' },
+        { text: 'Submit', type: 'primary' }
+      ],
+      hasClose: true,
+      closeAriaLabel: 'Close modal',
+      restoreFocus: true
+    });
+  });
+});

--- a/packages/modals/demo/stories/TooltipDialogStory.spec.tsx
+++ b/packages/modals/demo/stories/TooltipDialogStory.spec.tsx
@@ -1,0 +1,246 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { TooltipDialogStory } from './TooltipDialogStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<TooltipDialogStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('TooltipDialogStory Component', () => {
+  it('renders default TooltipDialogStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  it('renders TooltipDialogStory with a title', () => {
+    renderAndMatchSnapshot({ hasTitle: true, title: 'Dialog Title' });
+  });
+
+  it('renders TooltipDialogStory with a body', () => {
+    renderAndMatchSnapshot({ hasBody: true, body: 'This is the body content' });
+  });
+
+  it('renders TooltipDialogStory with a footer', () => {
+    renderAndMatchSnapshot({ hasFooter: true });
+  });
+
+  it('renders TooltipDialogStory with a close button', () => {
+    renderAndMatchSnapshot({ hasClose: true, closeAriaLabel: 'Close dialog' });
+  });
+
+  it('renders TooltipDialogStory with a custom tag for the title', () => {
+    renderAndMatchSnapshot({ hasTitle: true, title: 'Dialog Title', tag: 'h2' });
+  });
+
+  it('renders TooltipDialogStory with a custom aria-label for the dialog', () => {
+    renderAndMatchSnapshot({ dialogAriaLabel: 'Custom aria label' });
+  });
+
+  it('renders TooltipDialogStory with a custom placement', () => {
+    renderAndMatchSnapshot({ placement: 'top-end' });
+  });
+
+  it('renders TooltipDialogStory with an arrow', () => {
+    renderAndMatchSnapshot({ hasArrow: true });
+  });
+
+  it('renders TooltipDialogStory with a custom zIndex', () => {
+    renderAndMatchSnapshot({ zIndex: 1000 });
+  });
+
+  it('renders TooltipDialogStory with multiple avatars (count = 3)', () => {
+    renderAndMatchSnapshot({ count: 3 });
+  });
+
+  it('renders TooltipDialogStory with a title, body, and footer', () => {
+    renderAndMatchSnapshot({
+      hasTitle: true,
+      title: 'Dialog Title',
+      hasBody: true,
+      body: 'This is the body content',
+      hasFooter: true
+    });
+  });
+
+  it('renders TooltipDialogStory with a title, body, footer, and close button', () => {
+    renderAndMatchSnapshot({
+      hasTitle: true,
+      title: 'Dialog Title',
+      hasBody: true,
+      body: 'This is the body content',
+      hasFooter: true,
+      hasClose: true,
+      closeAriaLabel: 'Close dialog'
+    });
+  });
+
+  it('renders TooltipDialogStory with a title, body, footer, close button, and custom placement', () => {
+    renderAndMatchSnapshot({
+      hasTitle: true,
+      title: 'Dialog Title',
+      hasBody: true,
+      body: 'This is the body content',
+      hasFooter: true,
+      hasClose: true,
+      closeAriaLabel: 'Close dialog',
+      placement: 'bottom-start'
+    });
+  });
+
+  it('renders TooltipDialogStory with a title, body, footer, close button, and custom zIndex', () => {
+    renderAndMatchSnapshot({
+      hasTitle: true,
+      title: 'Dialog Title',
+      hasBody: true,
+      body: 'This is the body content',
+      hasFooter: true,
+      hasClose: true,
+      closeAriaLabel: 'Close dialog',
+      zIndex: 2000
+    });
+  });
+
+  it('renders TooltipDialogStory with a title, body, footer, close button, and arrow', () => {
+    renderAndMatchSnapshot({
+      hasTitle: true,
+      title: 'Dialog Title',
+      hasBody: true,
+      body: 'This is the body content',
+      hasFooter: true,
+      hasClose: true,
+      closeAriaLabel: 'Close dialog',
+      hasArrow: true
+    });
+  });
+
+  it('renders TooltipDialogStory with a title, body, footer, close button, arrow, and custom placement', () => {
+    renderAndMatchSnapshot({
+      hasTitle: true,
+      title: 'Dialog Title',
+      hasBody: true,
+      body: 'This is the body content',
+      hasFooter: true,
+      hasClose: true,
+      closeAriaLabel: 'Close dialog',
+      hasArrow: true,
+      placement: 'top-end'
+    });
+  });
+
+  it('renders TooltipDialogStory with a title, body, footer, close button, arrow, custom placement, and custom zIndex', () => {
+    renderAndMatchSnapshot({
+      hasTitle: true,
+      title: 'Dialog Title',
+      hasBody: true,
+      body: 'This is the body content',
+      hasFooter: true,
+      hasClose: true,
+      closeAriaLabel: 'Close dialog',
+      hasArrow: true,
+      placement: 'bottom-end',
+      zIndex: 3000
+    });
+  });
+
+  it('renders TooltipDialogStory with multiple avatars and a title', () => {
+    renderAndMatchSnapshot({
+      count: 3,
+      hasTitle: true,
+      title: 'Dialog Title'
+    });
+  });
+
+  it('renders TooltipDialogStory with multiple avatars, a title, and a body', () => {
+    renderAndMatchSnapshot({
+      count: 3,
+      hasTitle: true,
+      title: 'Dialog Title',
+      hasBody: true,
+      body: 'This is the body content'
+    });
+  });
+
+  it('renders TooltipDialogStory with multiple avatars, a title, body, and footer', () => {
+    renderAndMatchSnapshot({
+      count: 3,
+      hasTitle: true,
+      title: 'Dialog Title',
+      hasBody: true,
+      body: 'This is the body content',
+      hasFooter: true
+    });
+  });
+
+  it('renders TooltipDialogStory with multiple avatars, a title, body, footer, and close button', () => {
+    renderAndMatchSnapshot({
+      count: 3,
+      hasTitle: true,
+      title: 'Dialog Title',
+      hasBody: true,
+      body: 'This is the body content',
+      hasFooter: true,
+      hasClose: true,
+      closeAriaLabel: 'Close dialog'
+    });
+  });
+
+  it('renders TooltipDialogStory with multiple avatars, a title, body, footer, close button, and custom placement', () => {
+    renderAndMatchSnapshot({
+      count: 3,
+      hasTitle: true,
+      title: 'Dialog Title',
+      hasBody: true,
+      body: 'This is the body content',
+      hasFooter: true,
+      hasClose: true,
+      closeAriaLabel: 'Close dialog',
+      placement: 'bottom'
+    });
+  });
+
+  it('renders TooltipDialogStory with multiple avatars, a title, body, footer, close button, and custom zIndex', () => {
+    renderAndMatchSnapshot({
+      count: 3,
+      hasTitle: true,
+      title: 'Dialog Title',
+      hasBody: true,
+      body: 'This is the body content',
+      hasFooter: true,
+      hasClose: true,
+      closeAriaLabel: 'Close dialog',
+      zIndex: 1500
+    });
+  });
+
+  it('renders TooltipDialogStory with multiple avatars, a title, body, footer, close button, arrow, and custom placement', () => {
+    renderAndMatchSnapshot({
+      count: 3,
+      hasTitle: true,
+      title: 'Dialog Title',
+      hasBody: true,
+      body: 'This is the body content',
+      hasFooter: true,
+      hasClose: true,
+      closeAriaLabel: 'Close dialog',
+      hasArrow: true,
+      placement: 'top'
+    });
+  });
+
+  it('renders TooltipDialogStory with multiple avatars, a title, body, footer, close button, arrow, custom placement, and custom zIndex', () => {
+    renderAndMatchSnapshot({
+      count: 3,
+      hasTitle: true,
+      title: 'Dialog Title',
+      hasBody: true,
+      body: 'This is the body content',
+      hasFooter: true,
+      hasClose: true,
+      closeAriaLabel: 'Close dialog',
+      hasArrow: true,
+      placement: 'bottom-start',
+      zIndex: 2500
+    });
+  });
+});

--- a/packages/modals/demo/stories/__snapshots__/DrawerStory.spec.tsx.snap
+++ b/packages/modals/demo/stories/__snapshots__/DrawerStory.spec.tsx.snap
@@ -1,0 +1,2431 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DrawerStory Component renders DrawerStory with a body 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a body and aria-label for the dialog 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a body and custom footer items 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a close button 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a custom tag for the header 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a footer 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a footer and aria-label for the dialog 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a header 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a header and aria-label for the dialog 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a header and custom footer items 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a header, body, and custom footer items 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a header, body, and footer 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a header, body, footer, and close button 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a header, body, footer, and custom close button aria-label 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a header, body, footer, and custom dialog aria-label 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a header, body, footer, close button, and aria-label for the dialog 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders DrawerStory with a header, body, footer, close button, and custom dialog aria-label 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`DrawerStory Component renders default DrawerStory 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;

--- a/packages/modals/demo/stories/__snapshots__/DrawerStory.spec.tsx.snap
+++ b/packages/modals/demo/stories/__snapshots__/DrawerStory.spec.tsx.snap
@@ -122,14 +122,14 @@ exports[`DrawerStory Component renders DrawerStory with a body 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -257,14 +257,14 @@ exports[`DrawerStory Component renders DrawerStory with a body and aria-label fo
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -392,14 +392,14 @@ exports[`DrawerStory Component renders DrawerStory with a body and custom footer
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -527,14 +527,14 @@ exports[`DrawerStory Component renders DrawerStory with a close button 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -662,14 +662,14 @@ exports[`DrawerStory Component renders DrawerStory with a custom tag for the hea
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -797,14 +797,14 @@ exports[`DrawerStory Component renders DrawerStory with a footer 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -932,14 +932,14 @@ exports[`DrawerStory Component renders DrawerStory with a footer and aria-label 
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -1067,14 +1067,14 @@ exports[`DrawerStory Component renders DrawerStory with a header 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -1202,14 +1202,14 @@ exports[`DrawerStory Component renders DrawerStory with a header and aria-label 
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -1337,14 +1337,14 @@ exports[`DrawerStory Component renders DrawerStory with a header and custom foot
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -1472,14 +1472,14 @@ exports[`DrawerStory Component renders DrawerStory with a header, body, and cust
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -1607,14 +1607,14 @@ exports[`DrawerStory Component renders DrawerStory with a header, body, and foot
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -1742,14 +1742,14 @@ exports[`DrawerStory Component renders DrawerStory with a header, body, footer, 
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -1877,14 +1877,14 @@ exports[`DrawerStory Component renders DrawerStory with a header, body, footer, 
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2012,14 +2012,14 @@ exports[`DrawerStory Component renders DrawerStory with a header, body, footer, 
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2147,14 +2147,14 @@ exports[`DrawerStory Component renders DrawerStory with a header, body, footer, 
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2282,14 +2282,14 @@ exports[`DrawerStory Component renders DrawerStory with a header, body, footer, 
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2417,14 +2417,14 @@ exports[`DrawerStory Component renders default DrawerStory 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>

--- a/packages/modals/demo/stories/__snapshots__/ModalStory.spec.tsx.snap
+++ b/packages/modals/demo/stories/__snapshots__/ModalStory.spec.tsx.snap
@@ -1,0 +1,3690 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModalStory Component renders ModalStory with a body 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a centered modal 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a close button 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c3:disabled .c1 {
+  color: #848f99;
+}
+
+.c3 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 .c1 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c1 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a custom tag in the header 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a danger footer 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c3:disabled .c1 {
+  color: #848f99;
+}
+
+.c3 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a danger header 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a dialog aria label 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a footer 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c3:disabled .c1 {
+  color: #848f99;
+}
+
+.c3 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a header 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a header, body, and footer 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c3:disabled .c1 {
+  color: #848f99;
+}
+
+.c3 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a header, body, footer, and close button 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c3:disabled .c1 {
+  color: #848f99;
+}
+
+.c3 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c5:disabled .c1 {
+  color: #848f99;
+}
+
+.c5 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c6 .c1 {
+  width: 16px;
+  height: 16px;
+}
+
+.c6 .c1 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a header, body, footer, close button, and animated modal 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c3:disabled .c1 {
+  color: #848f99;
+}
+
+.c3 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c5:disabled .c1 {
+  color: #848f99;
+}
+
+.c5 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c6 .c1 {
+  width: 16px;
+  height: 16px;
+}
+
+.c6 .c1 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a header, body, footer, close button, and centered modal 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c3:disabled .c1 {
+  color: #848f99;
+}
+
+.c3 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c5:disabled .c1 {
+  color: #848f99;
+}
+
+.c5 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c6 .c1 {
+  width: 16px;
+  height: 16px;
+}
+
+.c6 .c1 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a header, body, footer, close button, and danger styling 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c3:disabled .c1 {
+  color: #848f99;
+}
+
+.c3 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c5:disabled .c1 {
+  color: #848f99;
+}
+
+.c5 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c6 .c1 {
+  width: 16px;
+  height: 16px;
+}
+
+.c6 .c1 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a header, body, footer, close button, and focus on mount 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c3:disabled .c1 {
+  color: #848f99;
+}
+
+.c3 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c5:disabled .c1 {
+  color: #848f99;
+}
+
+.c5 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c6 .c1 {
+  width: 16px;
+  height: 16px;
+}
+
+.c6 .c1 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a header, body, footer, close button, and large button 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.3571428571428572em;
+  height: 48px;
+  line-height: 46px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c3:disabled .c1 {
+  color: #848f99;
+}
+
+.c3 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c5:disabled .c1 {
+  color: #848f99;
+}
+
+.c5 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c6 .c1 {
+  width: 16px;
+  height: 16px;
+}
+
+.c6 .c1 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a header, body, footer, close button, and restore focus on close 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c3:disabled .c1 {
+  color: #848f99;
+}
+
+.c3 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c5:disabled .c1 {
+  color: #848f99;
+}
+
+.c5 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c6 .c1 {
+  width: 16px;
+  height: 16px;
+}
+
+.c6 .c1 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with a large button 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.3571428571428572em;
+  height: 48px;
+  line-height: 46px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with an animated modal 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with focus on mount 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with restore focus on close 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders ModalStory with visible modal 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (max-height:399px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),screen and (-ms-high-contrast:none) {
+
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ModalStory Component renders default ModalStory 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Open
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;

--- a/packages/modals/demo/stories/__snapshots__/ModalStory.spec.tsx.snap
+++ b/packages/modals/demo/stories/__snapshots__/ModalStory.spec.tsx.snap
@@ -134,14 +134,14 @@ exports[`ModalStory Component renders ModalStory with a body 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -281,14 +281,14 @@ exports[`ModalStory Component renders ModalStory with a centered modal 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -448,14 +448,14 @@ exports[`ModalStory Component renders ModalStory with a close button 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -595,14 +595,14 @@ exports[`ModalStory Component renders ModalStory with a custom tag in the header
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -758,14 +758,14 @@ exports[`ModalStory Component renders ModalStory with a danger footer 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -905,14 +905,14 @@ exports[`ModalStory Component renders ModalStory with a danger header 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -1052,14 +1052,14 @@ exports[`ModalStory Component renders ModalStory with a dialog aria label 1`] = 
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -1215,14 +1215,14 @@ exports[`ModalStory Component renders ModalStory with a footer 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -1362,14 +1362,14 @@ exports[`ModalStory Component renders ModalStory with a header 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -1525,14 +1525,14 @@ exports[`ModalStory Component renders ModalStory with a header, body, and footer
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -1708,14 +1708,14 @@ exports[`ModalStory Component renders ModalStory with a header, body, footer, an
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -1891,14 +1891,14 @@ exports[`ModalStory Component renders ModalStory with a header, body, footer, cl
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2074,14 +2074,14 @@ exports[`ModalStory Component renders ModalStory with a header, body, footer, cl
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2257,14 +2257,14 @@ exports[`ModalStory Component renders ModalStory with a header, body, footer, cl
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2440,14 +2440,14 @@ exports[`ModalStory Component renders ModalStory with a header, body, footer, cl
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2623,14 +2623,14 @@ exports[`ModalStory Component renders ModalStory with a header, body, footer, cl
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2806,14 +2806,14 @@ exports[`ModalStory Component renders ModalStory with a header, body, footer, cl
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -2953,14 +2953,14 @@ exports[`ModalStory Component renders ModalStory with a large button 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -3100,14 +3100,14 @@ exports[`ModalStory Component renders ModalStory with an animated modal 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -3247,14 +3247,14 @@ exports[`ModalStory Component renders ModalStory with focus on mount 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -3394,14 +3394,14 @@ exports[`ModalStory Component renders ModalStory with restore focus on close 1`]
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -3541,14 +3541,14 @@ exports[`ModalStory Component renders ModalStory with visible modal 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>
@@ -3676,14 +3676,14 @@ exports[`ModalStory Component renders default ModalStory 1`] = `
 <button
   class="c0"
   data-garden-id="buttons.button"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
   type="button"
 >
   Open
   <svg
     class="c1  c2"
     data-garden-id="buttons.icon"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     xmlns="http://www.w3.org/2000/svg"
   />
 </button>

--- a/packages/modals/demo/stories/__snapshots__/TooltipDialogStory.spec.tsx.snap
+++ b/packages/modals/demo/stories/__snapshots__/TooltipDialogStory.spec.tsx.snap
@@ -317,23 +317,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a body 1`]
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -341,12 +341,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a body 1`]
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -674,23 +674,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a close bu
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -698,12 +698,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a close bu
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -1031,23 +1031,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a custom a
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -1055,12 +1055,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a custom a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -1388,23 +1388,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a custom p
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -1412,12 +1412,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a custom p
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -1745,23 +1745,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a custom t
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -1769,12 +1769,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a custom t
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -2102,23 +2102,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a custom z
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -2126,12 +2126,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a custom z
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -2459,23 +2459,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a footer 1
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -2483,12 +2483,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a footer 1
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -2816,23 +2816,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title 1`
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -2840,12 +2840,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title 1`
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -3173,23 +3173,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, b
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -3197,12 +3197,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, b
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -3530,23 +3530,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, b
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -3554,12 +3554,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, b
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -3887,23 +3887,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, b
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -3911,12 +3911,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, b
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -4244,23 +4244,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, b
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -4268,12 +4268,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, b
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -4601,23 +4601,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, b
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -4625,12 +4625,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, b
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -4958,23 +4958,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, b
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -4982,12 +4982,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, b
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -5315,23 +5315,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, b
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -5339,12 +5339,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, b
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -5672,23 +5672,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with an arrow 1
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -5696,12 +5696,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with an arrow 1
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -6029,23 +6029,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -6053,12 +6053,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -6068,12 +6068,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -6081,12 +6081,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             2
           </span>
@@ -6096,12 +6096,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -6109,12 +6109,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             3
           </span>
@@ -6442,23 +6442,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -6466,12 +6466,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -6481,12 +6481,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -6494,12 +6494,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             2
           </span>
@@ -6509,12 +6509,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -6522,12 +6522,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             3
           </span>
@@ -6855,23 +6855,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -6879,12 +6879,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -6894,12 +6894,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -6907,12 +6907,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             2
           </span>
@@ -6922,12 +6922,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -6935,12 +6935,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             3
           </span>
@@ -7268,23 +7268,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -7292,12 +7292,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -7307,12 +7307,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -7320,12 +7320,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             2
           </span>
@@ -7335,12 +7335,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -7348,12 +7348,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             3
           </span>
@@ -7681,23 +7681,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -7705,12 +7705,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -7720,12 +7720,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -7733,12 +7733,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             2
           </span>
@@ -7748,12 +7748,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -7761,12 +7761,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             3
           </span>
@@ -8094,23 +8094,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -8118,12 +8118,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -8133,12 +8133,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -8146,12 +8146,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             2
           </span>
@@ -8161,12 +8161,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -8174,12 +8174,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             3
           </span>
@@ -8507,23 +8507,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -8531,12 +8531,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -8546,12 +8546,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -8559,12 +8559,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             2
           </span>
@@ -8574,12 +8574,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -8587,12 +8587,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             3
           </span>
@@ -8920,23 +8920,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -8944,12 +8944,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -8959,12 +8959,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -8972,12 +8972,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             2
           </span>
@@ -8987,12 +8987,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -9000,12 +9000,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             3
           </span>
@@ -9333,23 +9333,23 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -9357,12 +9357,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>
@@ -9372,12 +9372,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -9385,12 +9385,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             2
           </span>
@@ -9400,12 +9400,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -9413,12 +9413,12 @@ exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple a
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             3
           </span>
@@ -9746,23 +9746,23 @@ exports[`TooltipDialogStory Component renders default TooltipDialogStory 1`] = `
 <div
   class="c0"
   data-garden-id="grid.grid"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   <div
     class="c1"
     data-garden-id="grid.row"
-    data-garden-version="9.0.0"
+    data-garden-version="9.1.0"
     style="height: calc(100vh - 80px);"
   >
     <div
       class="c2"
       data-garden-id="grid.col"
-      data-garden-version="9.0.0"
+      data-garden-version="9.1.0"
     >
       <button
         class="c3 c4"
         data-garden-id="buttons.icon_button"
-        data-garden-version="9.0.0"
+        data-garden-version="9.1.0"
         type="button"
       >
         <figure
@@ -9770,12 +9770,12 @@ exports[`TooltipDialogStory Component renders default TooltipDialogStory 1`] = `
           aria-live="polite"
           class="c5 c6  c7"
           data-garden-id="avatars.avatar"
-          data-garden-version="9.0.0"
+          data-garden-version="9.1.0"
         >
           <span
             class="c8 c9"
             data-garden-id="avatars.text"
-            data-garden-version="9.0.0"
+            data-garden-version="9.1.0"
           >
             1
           </span>

--- a/packages/modals/demo/stories/__snapshots__/TooltipDialogStory.spec.tsx.snap
+++ b/packages/modals/demo/stories/__snapshots__/TooltipDialogStory.spec.tsx.snap
@@ -1,0 +1,9787 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a body 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a close button 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a custom aria-label for the dialog 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a custom placement 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a custom tag for the title 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a custom zIndex 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a footer 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a title 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, body, and footer 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, body, footer, and close button 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, body, footer, close button, and arrow 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, body, footer, close button, and custom placement 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, body, footer, close button, and custom zIndex 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, body, footer, close button, arrow, and custom placement 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with a title, body, footer, close button, arrow, custom placement, and custom zIndex 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with an arrow 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple avatars (count = 3) 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            2
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            3
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple avatars and a title 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            2
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            3
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple avatars, a title, and a body 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            2
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            3
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple avatars, a title, body, and footer 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            2
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            3
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple avatars, a title, body, footer, and close button 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            2
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            3
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple avatars, a title, body, footer, close button, and custom placement 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            2
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            3
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple avatars, a title, body, footer, close button, and custom zIndex 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            2
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            3
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple avatars, a title, body, footer, close button, arrow, and custom placement 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            2
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            3
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders TooltipDialogStory with multiple avatars, a title, body, footer, close button, arrow, custom placement, and custom zIndex 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            2
+          </span>
+        </figure>
+      </button>
+    </div>
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            3
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipDialogStory Component renders default TooltipDialogStory 1`] = `
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c6 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c6 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c4 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c4:hover {
+  color: #39434b;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c4:disabled {
+  background-color: transparent;
+}
+
+.c4 .c6 {
+  width: 16px;
+  height: 16px;
+}
+
+.c4 .c6 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c9 {
+  overflow: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out,color 0.1s ease-in-out;
+  margin: 0;
+  vertical-align: middle;
+  box-sizing: border-box;
+  border-radius: 50%;
+  width: 40px !important;
+  height: 40px !important;
+  box-shadow: 0 0 0 2px transparent;
+  background-color: transparent;
+}
+
+.c5::before {
+  box-shadow: inset 0 0 0 2px;
+}
+
+.c5 > svg {
+  font-size: 16px;
+}
+
+.c5 .c8 {
+  line-height: 40px;
+  font-size: 18px;
+}
+
+.c5.c5 {
+  color: transparent;
+}
+
+.c5 > svg,
+.c5 .c8 {
+  color: #293239;
+}
+
+.c5::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: box-shadow 0.25s ease-in-out;
+  transition: box-shadow 0.25s ease-in-out;
+  content: '';
+}
+
+.c5::before,
+.c5.c5 > img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.c5.c5 > img {
+  box-sizing: inherit;
+  vertical-align: bottom;
+  object-fit: cover;
+}
+
+.c5.c5 > svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 33.33333333333333%;
+    -ms-flex-preferred-size: 33.33333333333333%;
+    flex-basis: 33.33333333333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 33.33333333333333%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <button
+        class="c3 c4"
+        data-garden-id="buttons.icon_button"
+        data-garden-version="9.0.0"
+        type="button"
+      >
+        <figure
+          aria-atomic="true"
+          aria-live="polite"
+          class="c5 c6  c7"
+          data-garden-id="avatars.avatar"
+          data-garden-version="9.0.0"
+        >
+          <span
+            class="c8 c9"
+            data-garden-id="avatars.text"
+            data-garden-version="9.0.0"
+          >
+            1
+          </span>
+        </figure>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/modals/src/elements/Drawer/Drawer.tsx
+++ b/packages/modals/src/elements/Drawer/Drawer.tsx
@@ -161,7 +161,7 @@ const DrawerComponent = forwardRef<HTMLDivElement, IDrawerProps>(
           nodeRef={transitionRef}
         >
           <StyledBackdrop
-            isAnimated
+            $isAnimated
             {...(getBackdropProps(backdropProps) as HTMLAttributes<HTMLDivElement>)}
           >
             <StyledDrawer

--- a/packages/modals/src/elements/Drawer/Header.tsx
+++ b/packages/modals/src/elements/Drawer/Header.tsx
@@ -30,7 +30,7 @@ const HeaderComponent = forwardRef<HTMLDivElement, IDrawerHeaderProps>(({ tag, .
     <StyledDrawerHeader
       {...(getTitleProps(other) as HTMLAttributes<HTMLDivElement>)}
       as={tag}
-      isCloseButtonPresent={isCloseButtonPresent}
+      $isCloseButtonPresent={isCloseButtonPresent}
       ref={ref}
     />
   );

--- a/packages/modals/src/elements/Header.tsx
+++ b/packages/modals/src/elements/Header.tsx
@@ -36,7 +36,7 @@ export const Header = forwardRef<HTMLDivElement, IHeaderProps>(
       <StyledHeader
         {...(getTitleProps(other) as HTMLAttributes<HTMLDivElement>)}
         as={tag}
-        isCloseButtonPresent={isCloseButtonPresent}
+        $isCloseButtonPresent={isCloseButtonPresent}
         ref={ref}
       >
         {!!other.isDanger && <StyledDangerIcon />}

--- a/packages/modals/src/elements/Modal.tsx
+++ b/packages/modals/src/elements/Modal.tsx
@@ -170,14 +170,14 @@ export const ModalComponent = forwardRef<HTMLDivElement, IModalProps>(
     return createPortal(
       <ModalsContext.Provider value={value}>
         <StyledBackdrop
-          isCentered={isCentered}
-          isAnimated={isAnimated}
+          $isCentered={isCentered}
+          $isAnimated={isAnimated}
           {...(getBackdropProps(backdropProps) as HTMLAttributes<HTMLDivElement>)}
         >
           <StyledModal
-            isCentered={isCentered}
-            isAnimated={isAnimated}
-            isLarge={isLarge}
+            $isCentered={isCentered}
+            $isAnimated={isAnimated}
+            $isLarge={isLarge}
             {...modalContainerProps}
             {...ariaProps}
             {...modalProps}

--- a/packages/modals/src/elements/TooltipDialog/TooltipDialog.tsx
+++ b/packages/modals/src/elements/TooltipDialog/TooltipDialog.tsx
@@ -155,15 +155,15 @@ const TooltipDialogComponent = React.forwardRef<HTMLDivElement, ITooltipDialogPr
                 <StyledTooltipWrapper
                   ref={setFloatingElement}
                   style={{ transform }}
-                  placement={placement}
-                  zIndex={zIndex}
-                  isAnimated={isAnimated}
+                  $placement={placement}
+                  $zIndex={zIndex}
+                  $isAnimated={isAnimated}
                 >
                   <StyledTooltipDialog
-                    transitionState={transitionState}
-                    placement={placement}
-                    hasArrow={hasArrow}
-                    isAnimated={isAnimated}
+                    $transitionState={transitionState}
+                    $placement={placement}
+                    $hasArrow={hasArrow}
+                    $isAnimated={isAnimated}
                     {...modalProps}
                     {...ariaProps}
                     {...props}

--- a/packages/modals/src/styled/StyledBackdrop.spec.tsx
+++ b/packages/modals/src/styled/StyledBackdrop.spec.tsx
@@ -29,7 +29,7 @@ describe('StyledBackdrop', () => {
   });
 
   it('renders center styling if provided', () => {
-    const { container } = render(<StyledBackdrop isCentered />);
+    const { container } = render(<StyledBackdrop $isCentered />);
 
     expect(container.firstChild).toHaveStyleRule('align-items', 'center');
     expect(container.firstChild).toHaveStyleRule('justify-content', 'center');
@@ -38,7 +38,7 @@ describe('StyledBackdrop', () => {
   describe('backdrop color', () => {
     it.each([['light'], ['dark']])('gets the correct %s mode color', mode => {
       const renderFn = mode === 'light' ? render : renderDark;
-      const { container } = renderFn(<StyledBackdrop isCentered />);
+      const { container } = renderFn(<StyledBackdrop $isCentered />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',

--- a/packages/modals/src/styled/StyledBackdrop.ts
+++ b/packages/modals/src/styled/StyledBackdrop.ts
@@ -12,8 +12,8 @@ import { retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming'
 const COMPONENT_ID = 'modals.backdrop';
 
 export interface IStyledBackdropProps {
-  isCentered?: boolean;
-  isAnimated?: boolean;
+  $isCentered?: boolean;
+  $isAnimated?: boolean;
 }
 
 const animationName = keyframes`
@@ -27,7 +27,7 @@ const animationName = keyframes`
 `;
 
 const animationStyles = (props: IStyledBackdropProps) => {
-  if (props.isAnimated) {
+  if (props.$isAnimated) {
     return css`
       animation: ${animationName} 0.15s ease-in;
     `;
@@ -46,8 +46,8 @@ export const StyledBackdrop = styled.div.attrs<IStyledBackdropProps>({
   display: flex;
   position: fixed;
   inset: 0;
-  align-items: ${props => props.isCentered && 'center'};
-  justify-content: ${props => props.isCentered && 'center'};
+  align-items: ${props => props.$isCentered && 'center'};
+  justify-content: ${props => props.$isCentered && 'center'};
   z-index: 400;
   background-color: ${({ theme }) =>
     getColor({
@@ -68,6 +68,6 @@ export const StyledBackdrop = styled.div.attrs<IStyledBackdropProps>({
 `;
 
 StyledBackdrop.propTypes = {
-  isCentered: PropTypes.bool,
-  isAnimated: PropTypes.bool
+  $isCentered: PropTypes.bool,
+  $isAnimated: PropTypes.bool
 };

--- a/packages/modals/src/styled/StyledDrawerHeader.spec.tsx
+++ b/packages/modals/src/styled/StyledDrawerHeader.spec.tsx
@@ -24,7 +24,7 @@ describe('StyledDrawerHeader', () => {
 
   it.each([['light'], ['dark']])('gets the correct %s mode danger color', mode => {
     const renderFn = mode === 'light' ? render : renderDark;
-    const { container } = renderFn(<StyledDrawerHeader isDanger />);
+    const { container } = renderFn(<StyledDrawerHeader $isDanger />);
 
     expect(container.firstChild).toHaveStyleRule(
       'color',

--- a/packages/modals/src/styled/StyledDrawerHeader.ts
+++ b/packages/modals/src/styled/StyledDrawerHeader.ts
@@ -22,7 +22,7 @@ export const StyledDrawerHeader = styled(StyledHeader).attrs({
 })`
   padding: ${props => props.theme.space.base * 5}px;
   ${props =>
-    props.isCloseButtonPresent &&
+    props.$isCloseButtonPresent &&
     `padding-${props.theme.rtl ? 'left' : 'right'}: ${
       props.theme.space.base * (BASE_MULTIPLIERS.size + BASE_MULTIPLIERS.side + 2)
     }px;`} /* [1] */

--- a/packages/modals/src/styled/StyledHeader.spec.tsx
+++ b/packages/modals/src/styled/StyledHeader.spec.tsx
@@ -24,7 +24,7 @@ describe('StyledHeader', () => {
 
   it.each([['light'], ['dark']])('gets the correct %s mode danger color', mode => {
     const renderFn = mode === 'light' ? render : renderDark;
-    const { container } = renderFn(<StyledHeader isDanger />);
+    const { container } = renderFn(<StyledHeader $isDanger />);
 
     expect(container.firstChild).toHaveStyleRule(
       'color',

--- a/packages/modals/src/styled/StyledHeader.ts
+++ b/packages/modals/src/styled/StyledHeader.ts
@@ -13,15 +13,15 @@ import { BASE_MULTIPLIERS } from './StyledClose';
 const COMPONENT_ID = 'modals.header';
 
 export interface IStyledHeaderProps {
-  isDanger?: boolean;
-  isCloseButtonPresent?: boolean;
+  $isDanger?: boolean;
+  $isCloseButtonPresent?: boolean;
 }
 
-const colorStyles = ({ isDanger, theme }: IStyledHeaderProps & ThemeProps<DefaultTheme>) => {
+const colorStyles = ({ $isDanger, theme }: IStyledHeaderProps & ThemeProps<DefaultTheme>) => {
   const bottomBorderColor = getColor({ theme, variable: 'border.subtle' });
   const color = getColor({
     theme,
-    variable: isDanger ? 'foreground.danger' : 'foreground.default'
+    variable: $isDanger ? 'foreground.danger' : 'foreground.default'
   });
 
   return css`
@@ -39,12 +39,12 @@ export const StyledHeader = styled.div.attrs<IStyledHeaderProps>({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledHeaderProps>`
   display: block;
-  position: ${props => props.isDanger && 'relative'};
+  position: ${props => props.$isDanger && 'relative'};
   margin: 0;
   border-bottom: ${props => props.theme.borders.sm};
   padding: ${props => `${props.theme.space.base * 5}px ${props.theme.space.base * 10}px`};
   ${props =>
-    props.isCloseButtonPresent &&
+    props.$isCloseButtonPresent &&
     `padding-${props.theme.rtl ? 'left' : 'right'}: ${
       props.theme.space.base * (BASE_MULTIPLIERS.size + BASE_MULTIPLIERS.side + 2)
     }px;`} /* [1] */

--- a/packages/modals/src/styled/StyledModal.spec.tsx
+++ b/packages/modals/src/styled/StyledModal.spec.tsx
@@ -31,7 +31,7 @@ describe('StyledModal', () => {
   });
 
   it('renders large styling if provided', () => {
-    const { container } = render(<StyledModal isLarge />);
+    const { container } = render(<StyledModal $isLarge />);
 
     expect(container.firstChild).toHaveStyleRule('width', DEFAULT_THEME.breakpoints.md, {
       media: `(min-width: ${DEFAULT_THEME.breakpoints.md})`
@@ -39,7 +39,7 @@ describe('StyledModal', () => {
   });
 
   it('renders centered styling if provided', () => {
-    const { container } = render(<StyledModal isCentered />);
+    const { container } = render(<StyledModal $isCentered />);
 
     expect(container.firstChild).toHaveStyleRule('margin', '0');
   });

--- a/packages/modals/src/styled/StyledModal.ts
+++ b/packages/modals/src/styled/StyledModal.ts
@@ -12,9 +12,9 @@ import { mediaQuery, retrieveComponentStyles, getColor } from '@zendeskgarden/re
 const COMPONENT_ID = 'modals.modal';
 
 export interface IStyledModalProps {
-  isLarge?: boolean;
-  isCentered?: boolean;
-  isAnimated?: boolean;
+  $isLarge?: boolean;
+  $isCentered?: boolean;
+  $isAnimated?: boolean;
 }
 
 const animationName = keyframes`
@@ -33,7 +33,7 @@ const animationName = keyframes`
 `;
 
 const animationStyles = (props: IStyledModalProps) => {
-  if (props.isAnimated) {
+  if (props.$isAnimated) {
     return css`
       animation: ${animationName} 0.3s ease-in;
     `;
@@ -60,8 +60,8 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
 
 const sizeStyles = (props: IStyledModalProps & ThemeProps<DefaultTheme>) => {
   return css`
-    ${mediaQuery('up', props.isLarge ? 'md' : 'sm', props.theme)} {
-      width: ${props.isLarge ? props.theme.breakpoints.md : props.theme.breakpoints.sm};
+    ${mediaQuery('up', props.$isLarge ? 'md' : 'sm', props.theme)} {
+      width: ${props.$isLarge ? props.theme.breakpoints.md : props.theme.breakpoints.sm};
     }
   `;
 };
@@ -77,7 +77,7 @@ export const StyledModal = styled.div.attrs<IStyledModalProps>({
   position: fixed;
   flex-direction: column;
   animation-delay: 0.01s;
-  margin: ${props => (props.isCentered ? '0' : `${props.theme.space.base * 12}px`)};
+  margin: ${props => (props.$isCentered ? '0' : `${props.theme.space.base * 12}px`)};
   border: ${props => props.theme.borders.sm};
   border-radius: ${props => props.theme.borderRadii.md};
   min-height: 60px;
@@ -104,15 +104,15 @@ export const StyledModal = styled.div.attrs<IStyledModalProps>({
   }
 
   @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
-    right: ${props => props.isCentered && '50%'}; /* [1] */
-    bottom: ${props => props.isCentered && '50%'}; /* [1] */
-    transform: ${props => props.isCentered && 'translate(50%, 50%)'}; /* [1] */
+    right: ${props => props.$isCentered && '50%'}; /* [1] */
+    bottom: ${props => props.$isCentered && '50%'}; /* [1] */
+    transform: ${props => props.$isCentered && 'translate(50%, 50%)'}; /* [1] */
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledModal.propTypes = {
-  isLarge: PropTypes.bool,
-  isAnimated: PropTypes.bool
+  $isLarge: PropTypes.bool,
+  $isAnimated: PropTypes.bool
 };

--- a/packages/modals/src/styled/StyledTooltipDialog.ts
+++ b/packages/modals/src/styled/StyledTooltipDialog.ts
@@ -14,14 +14,14 @@ import {
 } from '@zendeskgarden/react-theming';
 import { StyledTooltipDialogClose } from '../styled/StyledTooltipDialogClose';
 import { TransitionStatus } from 'react-transition-group';
-import { ITooltipDialogProps } from '../types';
 
 const COMPONENT_ID = 'modals.tooltip_dialog';
 
-export interface IStyledTooltipDialogProps
-  extends Pick<ITooltipDialogProps, 'hasArrow' | 'isAnimated'> {
-  placement: Placement;
-  transitionState?: TransitionStatus;
+export interface IStyledTooltipDialogProps {
+  $hasArrow?: boolean;
+  $isAnimated?: boolean;
+  $placement: Placement;
+  $transitionState?: TransitionStatus;
 }
 
 const sizeStyles = (props: ThemeProps<DefaultTheme>) => `
@@ -36,20 +36,20 @@ const sizeStyles = (props: ThemeProps<DefaultTheme>) => `
 export const StyledTooltipDialog = styled.div.attrs<IStyledTooltipDialogProps>(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: props.isAnimated && 'is-animated'
+  className: props.$isAnimated && 'is-animated'
 }))<IStyledTooltipDialogProps>`
   ${props => {
-    const computedArrowStyles = arrowStyles(getArrowPosition(props.theme, props.placement), {
+    const computedArrowStyles = arrowStyles(getArrowPosition(props.theme, props.$placement), {
       size: `${props.theme.space.base * 2}px`,
       inset: '1px',
       animationModifier: '.is-animated'
     });
 
-    if (props.isAnimated) {
-      return props.hasArrow && props.transitionState === 'entered' && computedArrowStyles;
+    if (props.$isAnimated) {
+      return props.$hasArrow && props.$transitionState === 'entered' && computedArrowStyles;
     }
 
-    return props.hasArrow && computedArrowStyles;
+    return props.$hasArrow && computedArrowStyles;
   }};
 
   ${sizeStyles}

--- a/packages/modals/src/styled/StyledTooltipWrapper.ts
+++ b/packages/modals/src/styled/StyledTooltipWrapper.ts
@@ -8,26 +8,27 @@
 import styled from 'styled-components';
 import { Placement } from '@floating-ui/react-dom';
 import { getMenuPosition, menuStyles } from '@zendeskgarden/react-theming';
-import { ITooltipDialogProps } from '../types';
 
-interface IStyledTooltipWrapperProps extends Pick<ITooltipDialogProps, 'isAnimated' | 'zIndex'> {
-  placement: Placement;
+interface IStyledTooltipWrapperProps {
+  $placement: Placement;
+  $isAnimated?: boolean;
+  $zIndex?: number;
 }
 
 /*
  * 1. Expected to use https://floating-ui.com/docs/misc#subpixel-and-accelerated-positioning
  */
 export const StyledTooltipWrapper = styled.div.attrs<IStyledTooltipWrapperProps>(props => ({
-  className: props.isAnimated && 'is-animated'
+  className: props.$isAnimated && 'is-animated'
 }))<IStyledTooltipWrapperProps>`
   top: 0; /* [1] */
   left: 0; /* [1] */
 
   ${props =>
-    menuStyles(getMenuPosition(props.placement), {
+    menuStyles(getMenuPosition(props.$placement), {
       theme: props.theme,
       hidden: false,
-      zIndex: props.zIndex,
+      zIndex: props.$zIndex,
       animationModifier: '.is-animated'
     })};
 `;

--- a/packages/typography/demo/stories/TypescaleStory.spec.tsx
+++ b/packages/typography/demo/stories/TypescaleStory.spec.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { TypescaleStory } from './TypescaleStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<TypescaleStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('TypescaleStory Component', () => {
+  it('renders default TypescaleStory (medium size)', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  it('renders TypescaleStory with small size', () => {
+    renderAndMatchSnapshot({ size: 'small' });
+  });
+
+  it('renders TypescaleStory with large size', () => {
+    renderAndMatchSnapshot({ size: 'large' });
+  });
+
+  it('renders TypescaleStory with extra-large size', () => {
+    renderAndMatchSnapshot({ size: 'extra-large' });
+  });
+
+  it('renders TypescaleStory with 2x-large size', () => {
+    renderAndMatchSnapshot({ size: '2x-large' });
+  });
+
+  it('renders TypescaleStory with 3x-large size', () => {
+    renderAndMatchSnapshot({ size: '3x-large' });
+  });
+
+  it('renders TypescaleStory with display name', () => {
+    renderAndMatchSnapshot({ hasDisplayName: true });
+  });
+
+  it('renders TypescaleStory with bold text', () => {
+    renderAndMatchSnapshot({ isBold: true });
+  });
+
+  it('renders TypescaleStory with monospace font', () => {
+    renderAndMatchSnapshot({ isMonospace: true });
+  });
+
+  it('renders TypescaleStory with a custom tag', () => {
+    renderAndMatchSnapshot({ tag: 'span' });
+  });
+
+  it('renders TypescaleStory with small size and display name', () => {
+    renderAndMatchSnapshot({ size: 'small', hasDisplayName: true });
+  });
+
+  it('renders TypescaleStory with large size and bold text', () => {
+    renderAndMatchSnapshot({ size: 'large', isBold: true });
+  });
+
+  it('renders TypescaleStory with extra-large size and monospace font', () => {
+    renderAndMatchSnapshot({ size: 'extra-large', isMonospace: true });
+  });
+
+  it('renders TypescaleStory with 2x-large size and custom tag', () => {
+    renderAndMatchSnapshot({ size: '2x-large', tag: 'h1' });
+  });
+
+  it('renders TypescaleStory with 3x-large size, display name, and bold text', () => {
+    renderAndMatchSnapshot({ size: '3x-large', hasDisplayName: true, isBold: true });
+  });
+
+  it('renders TypescaleStory with small size, monospace font, and custom tag', () => {
+    renderAndMatchSnapshot({ size: 'small', isMonospace: true, tag: 'code' });
+  });
+
+  it('renders TypescaleStory with large size, display name, bold text, and monospace font', () => {
+    renderAndMatchSnapshot({
+      size: 'large',
+      hasDisplayName: true,
+      isBold: true,
+      isMonospace: true
+    });
+  });
+
+  it('renders TypescaleStory with extra-large size, display name, bold text, and custom tag', () => {
+    renderAndMatchSnapshot({
+      size: 'extra-large',
+      hasDisplayName: true,
+      isBold: true,
+      tag: 'strong'
+    });
+  });
+
+  it('renders TypescaleStory with 2x-large size, display name, monospace font, and custom tag', () => {
+    renderAndMatchSnapshot({
+      size: '2x-large',
+      hasDisplayName: true,
+      isMonospace: true,
+      tag: 'pre'
+    });
+  });
+
+  it('renders TypescaleStory with 3x-large size, display name, bold text, monospace font, and custom tag', () => {
+    renderAndMatchSnapshot({
+      size: '3x-large',
+      hasDisplayName: true,
+      isBold: true,
+      isMonospace: true,
+      tag: 'h2'
+    });
+  });
+});

--- a/packages/typography/demo/stories/__snapshots__/TypescaleStory.spec.tsx.snap
+++ b/packages/typography/demo/stories/__snapshots__/TypescaleStory.spec.tsx.snap
@@ -1,0 +1,645 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TypescaleStory Component renders TypescaleStory with 2x-large size 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 32px;
+  font-size: 26px;
+  font-weight: 400;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with 2x-large size and custom tag 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 32px;
+  font-size: 26px;
+  font-weight: 400;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<h1
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with 2x-large size, display name, monospace font, and custom tag 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 32px;
+  font-size: 26px;
+  font-weight: 400;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<pre
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+>
+  &lt;XXL&gt;
+  &lt;/XXL&gt;
+</pre>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with 3x-large size 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 44px;
+  font-size: 36px;
+  font-weight: 400;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with 3x-large size, display name, and bold text 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 44px;
+  font-size: 36px;
+  font-weight: 600;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+>
+  &lt;XXXL&gt;
+  &lt;/XXXL&gt;
+</div>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with 3x-large size, display name, bold text, monospace font, and custom tag 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 44px;
+  font-size: 36px;
+  font-weight: 600;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<h2
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+>
+  &lt;XXXL&gt;
+  &lt;/XXXL&gt;
+</h2>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with a custom tag 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 20px;
+  font-size: 14px;
+  font-weight: 400;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<span
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with bold text 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 20px;
+  font-size: 14px;
+  font-weight: 600;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with display name 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 20px;
+  font-size: 14px;
+  font-weight: 400;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+>
+  &lt;MD&gt;
+  &lt;/MD&gt;
+</div>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with extra-large size 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 28px;
+  font-size: 22px;
+  font-weight: 400;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with extra-large size and monospace font 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 28px;
+  font-size: 22px;
+  font-weight: 400;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with extra-large size, display name, bold text, and custom tag 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 28px;
+  font-size: 22px;
+  font-weight: 600;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<strong
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+>
+  &lt;XL&gt;
+  &lt;/XL&gt;
+</strong>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with large size 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 24px;
+  font-size: 18px;
+  font-weight: 400;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with large size and bold text 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 24px;
+  font-size: 18px;
+  font-weight: 600;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with large size, display name, bold text, and monospace font 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 23px;
+  font-family: SFMono-Regular,Consolas,"Liberation Mono",Menlo,Courier,monospace;
+  font-size: 17px;
+  font-weight: 600;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+>
+  &lt;LG&gt;
+  &lt;/LG&gt;
+</div>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with monospace font 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 19px;
+  font-family: SFMono-Regular,Consolas,"Liberation Mono",Menlo,Courier,monospace;
+  font-size: 13px;
+  font-weight: 400;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with small size 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 16px;
+  font-size: 12px;
+  font-weight: 400;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with small size and display name 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 16px;
+  font-size: 12px;
+  font-weight: 400;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+>
+  &lt;SM&gt;
+  &lt;/SM&gt;
+</div>
+`;
+
+exports[`TypescaleStory Component renders TypescaleStory with small size, monospace font, and custom tag 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 15px;
+  font-family: SFMono-Regular,Consolas,"Liberation Mono",Menlo,Courier,monospace;
+  font-size: 11px;
+  font-weight: 400;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<code
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+/>
+`;
+
+exports[`TypescaleStory Component renders default TypescaleStory (medium size) 1`] = `
+.c0 {
+  -webkit-transition: color 0.1s ease-in-out;
+  transition: color 0.1s ease-in-out;
+  line-height: 20px;
+  font-size: 14px;
+  font-weight: 400;
+  direction: ltr;
+}
+
+.c0[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  class="c0"
+  data-garden-id="typography.font"
+  data-garden-version="9.0.0"
+/>
+`;

--- a/packages/typography/demo/stories/__snapshots__/TypescaleStory.spec.tsx.snap
+++ b/packages/typography/demo/stories/__snapshots__/TypescaleStory.spec.tsx.snap
@@ -27,7 +27,7 @@ exports[`TypescaleStory Component renders TypescaleStory with 2x-large size 1`] 
 <div
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -58,7 +58,7 @@ exports[`TypescaleStory Component renders TypescaleStory with 2x-large size and 
 <h1
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -89,7 +89,7 @@ exports[`TypescaleStory Component renders TypescaleStory with 2x-large size, dis
 <pre
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   &lt;XXL&gt;
   &lt;/XXL&gt;
@@ -123,7 +123,7 @@ exports[`TypescaleStory Component renders TypescaleStory with 3x-large size 1`] 
 <div
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -154,7 +154,7 @@ exports[`TypescaleStory Component renders TypescaleStory with 3x-large size, dis
 <div
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   &lt;XXXL&gt;
   &lt;/XXXL&gt;
@@ -188,7 +188,7 @@ exports[`TypescaleStory Component renders TypescaleStory with 3x-large size, dis
 <h2
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   &lt;XXXL&gt;
   &lt;/XXXL&gt;
@@ -222,7 +222,7 @@ exports[`TypescaleStory Component renders TypescaleStory with a custom tag 1`] =
 <span
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -253,7 +253,7 @@ exports[`TypescaleStory Component renders TypescaleStory with bold text 1`] = `
 <div
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -284,7 +284,7 @@ exports[`TypescaleStory Component renders TypescaleStory with display name 1`] =
 <div
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   &lt;MD&gt;
   &lt;/MD&gt;
@@ -318,7 +318,7 @@ exports[`TypescaleStory Component renders TypescaleStory with extra-large size 1
 <div
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -349,7 +349,7 @@ exports[`TypescaleStory Component renders TypescaleStory with extra-large size a
 <div
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -380,7 +380,7 @@ exports[`TypescaleStory Component renders TypescaleStory with extra-large size, 
 <strong
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   &lt;XL&gt;
   &lt;/XL&gt;
@@ -414,7 +414,7 @@ exports[`TypescaleStory Component renders TypescaleStory with large size 1`] = `
 <div
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -445,7 +445,7 @@ exports[`TypescaleStory Component renders TypescaleStory with large size and bol
 <div
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -477,7 +477,7 @@ exports[`TypescaleStory Component renders TypescaleStory with large size, displa
 <div
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   &lt;LG&gt;
   &lt;/LG&gt;
@@ -512,7 +512,7 @@ exports[`TypescaleStory Component renders TypescaleStory with monospace font 1`]
 <div
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -543,7 +543,7 @@ exports[`TypescaleStory Component renders TypescaleStory with small size 1`] = `
 <div
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -574,7 +574,7 @@ exports[`TypescaleStory Component renders TypescaleStory with small size and dis
 <div
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 >
   &lt;SM&gt;
   &lt;/SM&gt;
@@ -609,7 +609,7 @@ exports[`TypescaleStory Component renders TypescaleStory with small size, monosp
 <code
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;
 
@@ -640,6 +640,6 @@ exports[`TypescaleStory Component renders default TypescaleStory (medium size) 1
 <div
   class="c0"
   data-garden-id="typography.font"
-  data-garden-version="9.0.0"
+  data-garden-version="9.1.0"
 />
 `;

--- a/packages/typography/src/elements/Code.tsx
+++ b/packages/typography/src/elements/Code.tsx
@@ -13,8 +13,8 @@ import { StyledCode } from '../styled';
 /**
  * @extends HTMLAttributes<HTMLElement>
  */
-export const Code = forwardRef<HTMLElement, ICodeProps>(({ hue, ...other }, ref) => (
-  <StyledCode ref={ref} hue={hue} {...other} />
+export const Code = forwardRef<HTMLElement, ICodeProps>(({ hue, size, ...other }, ref) => (
+  <StyledCode ref={ref} $hue={hue} $size={size} {...other} />
 ));
 
 Code.displayName = 'Code';

--- a/packages/typography/src/elements/CodeBlock.tsx
+++ b/packages/typography/src/elements/CodeBlock.tsx
@@ -88,11 +88,11 @@ export const CodeBlock = React.forwardRef<HTMLPreElement, ICodeBlockProps>(
                   <StyledCodeBlockLine
                     {...getLineProps({ line })}
                     key={index}
-                    language={language}
-                    isHighlighted={highlightLines?.includes(index + 1)}
-                    isNumbered={isNumbered}
-                    diff={getDiff(line)}
-                    size={size}
+                    $language={language}
+                    $isHighlighted={highlightLines?.includes(index + 1)}
+                    $isNumbered={isNumbered}
+                    $diff={getDiff(line)}
+                    $size={size}
                     style={undefined}
                   >
                     {line.map((token, tokenKey) => (

--- a/packages/typography/src/elements/LG.tsx
+++ b/packages/typography/src/elements/LG.tsx
@@ -13,9 +13,18 @@ import { ITypescaleMonospaceProps } from '../types';
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const LG = forwardRef<HTMLDivElement, ITypescaleMonospaceProps>(({ tag, ...other }, ref) => (
-  <StyledFont as={tag} ref={ref} size="large" {...other} />
-));
+export const LG = forwardRef<HTMLDivElement, ITypescaleMonospaceProps>(
+  ({ isBold, isMonospace, tag, ...other }, ref) => (
+    <StyledFont
+      $isBold={isBold}
+      $isMonospace={isMonospace}
+      $size="large"
+      as={tag}
+      ref={ref}
+      {...other}
+    />
+  )
+);
 
 LG.displayName = 'LG';
 

--- a/packages/typography/src/elements/MD.tsx
+++ b/packages/typography/src/elements/MD.tsx
@@ -13,9 +13,18 @@ import { StyledFont } from '../styled';
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const MD = forwardRef<HTMLDivElement, ITypescaleMonospaceProps>(({ tag, ...other }, ref) => (
-  <StyledFont as={tag} ref={ref} size="medium" {...other} />
-));
+export const MD = forwardRef<HTMLDivElement, ITypescaleMonospaceProps>(
+  ({ isBold, isMonospace, tag, ...other }, ref) => (
+    <StyledFont
+      $isBold={isBold}
+      $isMonospace={isMonospace}
+      $size="medium"
+      as={tag}
+      ref={ref}
+      {...other}
+    />
+  )
+);
 
 MD.displayName = 'MD';
 

--- a/packages/typography/src/elements/SM.tsx
+++ b/packages/typography/src/elements/SM.tsx
@@ -13,9 +13,18 @@ import { StyledFont } from '../styled';
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const SM = forwardRef<HTMLDivElement, ITypescaleMonospaceProps>(({ tag, ...other }, ref) => (
-  <StyledFont as={tag} ref={ref} size="small" {...other} />
-));
+export const SM = forwardRef<HTMLDivElement, ITypescaleMonospaceProps>(
+  ({ isBold, isMonospace, tag, ...other }, ref) => (
+    <StyledFont
+      $isBold={isBold}
+      $isMonospace={isMonospace}
+      as={tag}
+      ref={ref}
+      $size="small"
+      {...other}
+    />
+  )
+);
 
 SM.displayName = 'SM';
 

--- a/packages/typography/src/elements/XL.tsx
+++ b/packages/typography/src/elements/XL.tsx
@@ -13,8 +13,8 @@ import { StyledFont } from '../styled';
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const XL = forwardRef<HTMLDivElement, ITypescaleProps>(({ tag, ...other }, ref) => (
-  <StyledFont as={tag} ref={ref} size="extralarge" {...other} />
+export const XL = forwardRef<HTMLDivElement, ITypescaleProps>(({ isBold, tag, ...other }, ref) => (
+  <StyledFont $size="extralarge" $isBold={isBold} ref={ref} as={tag} {...other} />
 ));
 
 XL.displayName = 'XL';

--- a/packages/typography/src/elements/XXL.tsx
+++ b/packages/typography/src/elements/XXL.tsx
@@ -13,8 +13,8 @@ import { StyledFont } from '../styled';
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const XXL = forwardRef<HTMLDivElement, ITypescaleProps>(({ tag, ...other }, ref) => (
-  <StyledFont as={tag} ref={ref} size="2xlarge" {...other} />
+export const XXL = forwardRef<HTMLDivElement, ITypescaleProps>(({ isBold, tag, ...other }, ref) => (
+  <StyledFont $size="2xlarge" $isBold={isBold} ref={ref} as={tag} {...other} />
 ));
 
 XXL.displayName = 'XXL';

--- a/packages/typography/src/elements/XXXL.tsx
+++ b/packages/typography/src/elements/XXXL.tsx
@@ -13,9 +13,11 @@ import { ITypescaleProps } from '../types';
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const XXXL = forwardRef<HTMLDivElement, ITypescaleProps>(({ tag, ...other }, ref) => (
-  <StyledFont as={tag} ref={ref} size="3xlarge" {...other} />
-));
+export const XXXL = forwardRef<HTMLDivElement, ITypescaleProps>(
+  ({ isBold, tag, ...other }, ref) => (
+    <StyledFont $isBold={isBold} $size="3xlarge" {...other} as={tag} ref={ref} />
+  )
+);
 
 XXXL.displayName = 'XXXL';
 

--- a/packages/typography/src/elements/lists/OrderedList.tsx
+++ b/packages/typography/src/elements/lists/OrderedList.tsx
@@ -18,7 +18,7 @@ const OrderedListComponent = React.forwardRef<HTMLOListElement, IOrderedListProp
 
     return (
       <OrderedListContext.Provider value={value}>
-        <StyledOrderedList ref={ref} listType={type} {...other} />
+        <StyledOrderedList ref={ref} $listType={type} {...other} />
       </OrderedListContext.Provider>
     );
   }

--- a/packages/typography/src/elements/lists/OrderedListItem.tsx
+++ b/packages/typography/src/elements/lists/OrderedListItem.tsx
@@ -12,7 +12,7 @@ import { StyledOrderedListItem } from '../../styled';
 const OrderedListItem = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>((props, ref) => {
   const { size } = useOrderedListContext();
 
-  return <StyledOrderedListItem ref={ref} space={size} {...props} />;
+  return <StyledOrderedListItem ref={ref} $space={size} {...props} />;
 });
 
 OrderedListItem.displayName = 'OrderedList.Item';

--- a/packages/typography/src/elements/lists/UnorderedList.tsx
+++ b/packages/typography/src/elements/lists/UnorderedList.tsx
@@ -18,7 +18,7 @@ const UnorderedListComponent = forwardRef<HTMLUListElement, IUnorderedListProps>
 
     return (
       <UnorderedListContext.Provider value={value}>
-        <StyledUnorderedList ref={ref} listType={type} {...other} />
+        <StyledUnorderedList ref={ref} $listType={type} {...other} />
       </UnorderedListContext.Provider>
     );
   }

--- a/packages/typography/src/elements/lists/UnorderedListItem.tsx
+++ b/packages/typography/src/elements/lists/UnorderedListItem.tsx
@@ -13,7 +13,7 @@ const UnorderedListItem = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIEleme
   (props, ref) => {
     const { size } = useUnorderedListContext();
 
-    return <StyledUnorderedListItem ref={ref} space={size} {...props} />;
+    return <StyledUnorderedListItem ref={ref} $space={size} {...props} />;
   }
 );
 

--- a/packages/typography/src/elements/span/Span.tsx
+++ b/packages/typography/src/elements/span/Span.tsx
@@ -12,9 +12,19 @@ import { StyledFont } from '../../styled';
 import { StartIcon } from './StartIcon';
 import { Icon } from './Icon';
 
-const SpanComponent = forwardRef<HTMLSpanElement, ISpanProps>(({ tag, ...other }, ref) => (
-  <StyledFont as={tag} ref={ref} size="inherit" {...other} />
-));
+const SpanComponent = forwardRef<HTMLSpanElement, ISpanProps>(
+  ({ hue, isBold, isMonospace, tag, ...other }, ref) => (
+    <StyledFont
+      $hue={hue}
+      $isBold={isBold}
+      $isMonospace={isMonospace}
+      $size="inherit"
+      as={tag}
+      ref={ref}
+      {...other}
+    />
+  )
+);
 
 SpanComponent.displayName = 'Span';
 

--- a/packages/typography/src/styled/StyledCode.ts
+++ b/packages/typography/src/styled/StyledCode.ts
@@ -12,7 +12,7 @@ import { ICodeProps } from '../types';
 
 const COMPONENT_ID = 'typography.code';
 
-const colorStyles = ({ hue, theme }: IStyledCodeProps & ThemeProps<DefaultTheme>) => {
+const colorStyles = ({ $hue, theme }: IStyledCodeProps & ThemeProps<DefaultTheme>) => {
   const bgColorArgs: Parameters<typeof getColor>[0] = {
     theme,
     light: { offset: 100 },
@@ -20,7 +20,7 @@ const colorStyles = ({ hue, theme }: IStyledCodeProps & ThemeProps<DefaultTheme>
   };
   const fgColorArgs: Parameters<typeof getColor>[0] = { theme };
 
-  switch (hue) {
+  switch ($hue) {
     case 'green':
       bgColorArgs.variable = 'background.success';
       fgColorArgs.variable = 'foreground.successEmphasis';
@@ -54,15 +54,15 @@ const colorStyles = ({ hue, theme }: IStyledCodeProps & ThemeProps<DefaultTheme>
 };
 
 interface IStyledCodeProps extends Omit<IStyledFontProps, 'size'> {
-  hue?: ICodeProps['hue'];
-  size?: ICodeProps['size'];
+  $hue?: ICodeProps['hue'];
+  $size?: ICodeProps['size'];
 }
 
 export const StyledCode = styled(StyledFont as 'code').attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   as: 'code',
-  isMonospace: true
+  $isMonospace: true
 })<IStyledCodeProps>`
   border-radius: ${props => props.theme.borderRadii.sm};
   padding: 1.5px;
@@ -74,6 +74,6 @@ export const StyledCode = styled(StyledFont as 'code').attrs({
 
 StyledCode.defaultProps = {
   theme: DEFAULT_THEME,
-  hue: 'grey',
-  size: 'inherit'
+  $hue: 'grey',
+  $size: 'inherit'
 };

--- a/packages/typography/src/styled/StyledCodeBlockLine.spec.tsx
+++ b/packages/typography/src/styled/StyledCodeBlockLine.spec.tsx
@@ -26,7 +26,7 @@ describe('StyledCodeBlockLine', () => {
 
   describe('highlights', () => {
     it('renders highlight as expected', () => {
-      const { container } = renderDark(<StyledCodeBlockLine isHighlighted />);
+      const { container } = renderDark(<StyledCodeBlockLine $isHighlighted />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
@@ -35,7 +35,7 @@ describe('StyledCodeBlockLine', () => {
     });
 
     it('renders as expected in light mode', () => {
-      const { container } = render(<StyledCodeBlockLine isHighlighted />);
+      const { container } = render(<StyledCodeBlockLine $isHighlighted />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
@@ -46,7 +46,7 @@ describe('StyledCodeBlockLine', () => {
 
   describe('line numbers', () => {
     it('renders line numbers as expected', () => {
-      const { container } = renderDark(<StyledCodeBlockLine isNumbered />);
+      const { container } = renderDark(<StyledCodeBlockLine $isNumbered />);
 
       expect(container.firstChild).toHaveStyleRule('display', 'table-cell', {
         modifier: '&::before'
@@ -54,7 +54,7 @@ describe('StyledCodeBlockLine', () => {
     });
 
     it('renders as expected in light mode', () => {
-      const { container } = render(<StyledCodeBlockLine isNumbered />);
+      const { container } = render(<StyledCodeBlockLine $isNumbered />);
 
       expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[600], {
         modifier: '&::before'
@@ -64,19 +64,19 @@ describe('StyledCodeBlockLine', () => {
 
   describe('size', () => {
     it('renders small size', () => {
-      const { container } = render(<StyledCodeBlockLine size="small" />);
+      const { container } = render(<StyledCodeBlockLine $size="small" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', '11px');
     });
 
     it('renders medium size', () => {
-      const { container } = render(<StyledCodeBlockLine size="medium" />);
+      const { container } = render(<StyledCodeBlockLine $size="medium" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', '13px');
     });
 
     it('renders large size', () => {
-      const { container } = render(<StyledCodeBlockLine size="large" />);
+      const { container } = render(<StyledCodeBlockLine $size="large" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', '17px');
     });
@@ -84,7 +84,7 @@ describe('StyledCodeBlockLine', () => {
 
   describe('diff', () => {
     it('renders add diff', () => {
-      const { container } = render(<StyledCodeBlockLine diff="add" />);
+      const { container } = render(<StyledCodeBlockLine $diff="add" />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
@@ -93,7 +93,7 @@ describe('StyledCodeBlockLine', () => {
     });
 
     it('renders delete diff', () => {
-      const { container } = render(<StyledCodeBlockLine diff="delete" />);
+      const { container } = render(<StyledCodeBlockLine $diff="delete" />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
@@ -102,7 +102,7 @@ describe('StyledCodeBlockLine', () => {
     });
 
     it('renders change diff', () => {
-      const { container } = render(<StyledCodeBlockLine diff="change" />);
+      const { container } = render(<StyledCodeBlockLine $diff="change" />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
@@ -111,7 +111,7 @@ describe('StyledCodeBlockLine', () => {
     });
 
     it('renders hunk diff', () => {
-      const { container } = render(<StyledCodeBlockLine diff="hunk" />);
+      const { container } = render(<StyledCodeBlockLine $diff="hunk" />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',

--- a/packages/typography/src/styled/StyledCodeBlockLine.ts
+++ b/packages/typography/src/styled/StyledCodeBlockLine.ts
@@ -14,21 +14,21 @@ import { StyledFont, THEME_SIZES } from './StyledFont';
 const COMPONENT_ID = 'typography.codeblock_code';
 
 export interface IStyledCodeBlockLineProps {
-  language?: Language;
-  isHighlighted?: boolean;
-  isNumbered?: boolean;
-  diff?: Diff;
-  size?: Size;
+  $language?: Language;
+  $isHighlighted?: boolean;
+  $isNumbered?: boolean;
+  $diff?: Diff;
+  $size?: Size;
 }
 
 const colorStyles = ({
   theme,
-  diff,
-  isHighlighted
+  $diff,
+  $isHighlighted
 }: IStyledCodeBlockLineProps & ThemeProps<DefaultTheme>) => {
   let backgroundColor;
 
-  if (diff) {
+  if ($diff) {
     const hues = {
       hunk: 'royal',
       add: 'lime',
@@ -38,12 +38,12 @@ const colorStyles = ({
 
     backgroundColor = getColor({
       theme,
-      hue: hues[diff],
+      hue: hues[$diff],
       dark: { shade: 600 },
       light: { shade: 400 },
       transparency: theme.opacity[300]
     });
-  } else if (isHighlighted) {
+  } else if ($isHighlighted) {
     backgroundColor = getColor({
       theme,
       dark: { hue: 'white' },
@@ -59,17 +59,17 @@ const colorStyles = ({
 
 const lineNumberStyles = ({
   theme,
-  language,
-  size
+  $language,
+  $size
 }: IStyledCodeBlockLineProps & ThemeProps<DefaultTheme>) => {
   const color = getColor({ theme, variable: 'foreground.subtle', light: { offset: -100 } });
   let padding;
 
-  if (language && language === 'diff') {
+  if ($language && $language === 'diff') {
     padding = 0;
-  } else if (size === 'small') {
+  } else if ($size === 'small') {
     padding = theme.space.base * 4;
-  } else if (size === 'large') {
+  } else if ($size === 'large') {
     padding = theme.space.base * 7;
   } else {
     padding = theme.space.base * 6;
@@ -96,15 +96,15 @@ export const StyledCodeBlockLine = styled(StyledFont as 'code').attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   as: 'code',
-  isMonospace: true
+  $isMonospace: true
 })<IStyledCodeBlockLineProps>`
   display: table-row;
-  height: ${props => props.theme.lineHeights[THEME_SIZES[props.size!]]}; /* [1] */
+  height: ${props => props.theme.lineHeights[THEME_SIZES[props.$size!]]}; /* [1] */
   direction: ltr;
 
   ${colorStyles};
 
-  ${props => props.isNumbered && lineNumberStyles(props)};
+  ${props => props.$isNumbered && lineNumberStyles(props)};
 
   &::after {
     display: inline-block;

--- a/packages/typography/src/styled/StyledFont.spec.tsx
+++ b/packages/typography/src/styled/StyledFont.spec.tsx
@@ -12,7 +12,7 @@ import { StyledFont } from './StyledFont';
 
 describe('StyledFont', () => {
   it('renders bold if specified', () => {
-    const { container } = render(<StyledFont isBold />);
+    const { container } = render(<StyledFont $isBold />);
 
     expect(container.firstChild).toHaveStyleRule(
       'font-weight',
@@ -21,7 +21,7 @@ describe('StyledFont', () => {
   });
 
   it('renders monospace if specified', () => {
-    const { container } = render(<StyledFont isMonospace />);
+    const { container } = render(<StyledFont $isMonospace />);
 
     expect(container.firstChild).toHaveStyleRule('font-family', /monospace/u);
     expect(container.firstChild).toHaveStyleRule('line-height', 'normal');
@@ -50,55 +50,55 @@ describe('StyledFont', () => {
     });
 
     it('renders small size', () => {
-      const { container } = render(<StyledFont size="small" />);
+      const { container } = render(<StyledFont $size="small" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.sm);
     });
 
     it('renders medium size', () => {
-      const { container } = render(<StyledFont size="medium" />);
+      const { container } = render(<StyledFont $size="medium" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.md);
     });
 
     it('renders large size', () => {
-      const { container } = render(<StyledFont size="large" />);
+      const { container } = render(<StyledFont $size="large" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.lg);
     });
 
     it('renders extra-large size', () => {
-      const { container } = render(<StyledFont size="extralarge" />);
+      const { container } = render(<StyledFont $size="extralarge" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.xl);
     });
 
     it('does not render monospace at extra-large size', () => {
-      const { container } = render(<StyledFont isMonospace size="extralarge" />);
+      const { container } = render(<StyledFont $isMonospace $size="extralarge" />);
 
       expect(container.firstChild).not.toHaveStyleRule('font-family', /monospace/u);
     });
 
     it('renders extra extra-large size', () => {
-      const { container } = render(<StyledFont size="2xlarge" />);
+      const { container } = render(<StyledFont $size="2xlarge" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.xxl);
     });
 
     it('does not render monospace at extra extra-large size', () => {
-      const { container } = render(<StyledFont isMonospace size="2xlarge" />);
+      const { container } = render(<StyledFont $isMonospace $size="2xlarge" />);
 
       expect(container.firstChild).not.toHaveStyleRule('font-family', /monospace/u);
     });
 
     it('renders extra extra extra-large size', () => {
-      const { container } = render(<StyledFont size="3xlarge" />);
+      const { container } = render(<StyledFont $size="3xlarge" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.xxxl);
     });
 
     it('does not render monospace at extra extra extra-large size', () => {
-      const { container } = render(<StyledFont isMonospace size="3xlarge" />);
+      const { container } = render(<StyledFont $isMonospace $size="3xlarge" />);
 
       expect(container.firstChild).not.toHaveStyleRule('font-family', /monospace/u);
     });

--- a/packages/typography/src/styled/StyledFont.tsx
+++ b/packages/typography/src/styled/StyledFont.tsx
@@ -7,7 +7,7 @@
 
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import { hideVisually, math } from 'polished';
-import { DEFAULT_THEME, retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming';
 import { SIZE } from '../types';
 
 const COMPONENT_ID = 'typography.font';
@@ -31,13 +31,13 @@ export const THEME_SIZES: Record<TypographySize, ThemeSize> = {
 };
 
 const fontStyles = ({
-  hue,
-  isBold,
-  isMonospace,
-  size,
+  $hue,
+  $isBold,
+  $isMonospace,
+  $size,
   theme
 }: IStyledFontProps & ThemeProps<DefaultTheme>) => {
-  const monospace = isMonospace && ['inherit', 'small', 'medium', 'large'].indexOf(size!) !== -1;
+  const monospace = $isMonospace && ['inherit', 'small', 'medium', 'large'].indexOf($size!) !== -1;
   const fontFamily = monospace && theme.fonts.mono;
   const direction = theme.rtl ? 'rtl' : 'ltr';
   let fontSize;
@@ -46,30 +46,30 @@ const fontStyles = ({
   let color;
 
   if (monospace) {
-    if (size === 'inherit') {
+    if ($size === 'inherit') {
       fontSize = 'calc(1em - 1px)';
       lineHeight = 'normal';
     } else {
-      const themeSize = THEME_SIZES[size!];
+      const themeSize = THEME_SIZES[$size!];
 
       fontSize = math(`${theme.fontSizes[themeSize]} - 1px`);
       lineHeight = math(`${theme.lineHeights[themeSize]} - 1px`);
     }
-  } else if (size !== 'inherit') {
-    const themeSize = THEME_SIZES[size!];
+  } else if ($size !== 'inherit') {
+    const themeSize = THEME_SIZES[$size!];
 
     fontSize = theme.fontSizes[themeSize];
     lineHeight = theme.lineHeights[themeSize];
   }
 
-  if (isBold === true) {
+  if ($isBold === true) {
     fontWeight = theme.fontWeights.semibold;
-  } else if (isBold === false || size !== 'inherit') {
+  } else if ($isBold === false || $size !== 'inherit') {
     fontWeight = theme.fontWeights.regular;
   }
 
-  if (hue) {
-    const options = hue.includes('.') ? { variable: hue, theme } : { hue, theme };
+  if ($hue) {
+    const options = $hue.includes('.') ? { variable: $hue, theme } : { hue: $hue, theme };
 
     color = getColor(options);
   }
@@ -86,10 +86,10 @@ const fontStyles = ({
 };
 
 export interface IStyledFontProps {
-  isBold?: boolean;
-  isMonospace?: boolean;
-  size?: (typeof FONT_SIZE)[number];
-  hue?: string;
+  $isBold?: boolean;
+  $isMonospace?: boolean;
+  $size?: (typeof FONT_SIZE)[number];
+  $hue?: string;
 }
 
 export const StyledFont = styled.div.attrs({
@@ -107,6 +107,5 @@ export const StyledFont = styled.div.attrs({
 `;
 
 StyledFont.defaultProps = {
-  theme: DEFAULT_THEME,
-  size: 'inherit'
+  $size: 'inherit'
 };

--- a/packages/typography/src/styled/StyledList.spec.tsx
+++ b/packages/typography/src/styled/StyledList.spec.tsx
@@ -24,37 +24,37 @@ describe('StyledOrderedList', () => {
 
   describe('type', () => {
     it('renders a decimal list style', () => {
-      const { container } = render(<StyledOrderedList listType="decimal" />);
+      const { container } = render(<StyledOrderedList $listType="decimal" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'decimal');
     });
 
     it('renders a decimal (leading zero) list style', () => {
-      const { container } = render(<StyledOrderedList listType="decimal-leading-zero" />);
+      const { container } = render(<StyledOrderedList $listType="decimal-leading-zero" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'decimal-leading-zero');
     });
 
     it('renders a lowercase alpha list style', () => {
-      const { container } = render(<StyledOrderedList listType="lower-alpha" />);
+      const { container } = render(<StyledOrderedList $listType="lower-alpha" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'lower-alpha');
     });
 
     it('renders a lowercase roman list style', () => {
-      const { container } = render(<StyledOrderedList listType="lower-roman" />);
+      const { container } = render(<StyledOrderedList $listType="lower-roman" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'lower-roman');
     });
 
     it('renders a uppercase alpha list style', () => {
-      const { container } = render(<StyledOrderedList listType="upper-alpha" />);
+      const { container } = render(<StyledOrderedList $listType="upper-alpha" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'upper-alpha');
     });
 
     it('renders a uppercase roman list style', () => {
-      const { container } = render(<StyledOrderedList listType="upper-roman" />);
+      const { container } = render(<StyledOrderedList $listType="upper-roman" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'upper-roman');
     });
@@ -76,19 +76,19 @@ describe('StyledUnorderedList', () => {
 
   describe('type', () => {
     it('renders a circle list style', () => {
-      const { container } = render(<StyledUnorderedList listType="circle" />);
+      const { container } = render(<StyledUnorderedList $listType="circle" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'circle');
     });
 
     it('renders a disc list style', () => {
-      const { container } = render(<StyledUnorderedList listType="disc" />);
+      const { container } = render(<StyledUnorderedList $listType="disc" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'disc');
     });
 
     it('renders a square list style', () => {
-      const { container } = render(<StyledUnorderedList listType="square" />);
+      const { container } = render(<StyledUnorderedList $listType="square" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'square');
     });

--- a/packages/typography/src/styled/StyledList.ts
+++ b/packages/typography/src/styled/StyledList.ts
@@ -9,7 +9,7 @@ import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
 import { IOrderedListProps, IUnorderedListProps } from '../types';
 
-const listStyles = (props: { listType?: string } & ThemeProps<DefaultTheme>) => {
+const listStyles = (props: { $listType?: string } & ThemeProps<DefaultTheme>) => {
   const rtl = props.theme.rtl;
 
   return css`
@@ -18,14 +18,14 @@ const listStyles = (props: { listType?: string } & ThemeProps<DefaultTheme>) => 
     margin-${rtl ? 'right' : 'left'}: 24px;
     padding: 0;
     list-style-position: outside;
-    list-style-type: ${props.listType};
+    list-style-type: ${props.$listType};
   `;
 };
 
 const ORDERED_ID = 'typography.ordered_list';
 
 interface IStyledListProps {
-  listType?: IOrderedListProps['type'];
+  $listType?: IOrderedListProps['type'];
 }
 
 export const StyledOrderedList = styled.ol.attrs({
@@ -39,7 +39,7 @@ export const StyledOrderedList = styled.ol.attrs({
 const UNORDERED_ID = 'typography.unordered_list';
 
 interface IStyledUnorderedListProps {
-  listType?: IUnorderedListProps['type'];
+  $listType?: IUnorderedListProps['type'];
 }
 
 export const StyledUnorderedList = styled.ul.attrs({

--- a/packages/typography/src/styled/StyledListItem.spec.tsx
+++ b/packages/typography/src/styled/StyledListItem.spec.tsx
@@ -18,19 +18,19 @@ describe('StyledListItem', () => {
 
   describe('StyledListItemContent', () => {
     it('renders small spacing', () => {
-      const { container } = render(<StyledListItem space="small" />);
+      const { container } = render(<StyledListItem $space="small" />);
 
       expect(container.firstChild).not.toHaveStyleRule('padding-top');
     });
 
     it('renders medium spacing', () => {
-      const { container } = render(<StyledListItem space="medium" />);
+      const { container } = render(<StyledListItem $space="medium" />);
 
       expect(container.firstChild).toHaveStyleRule('padding-top', '4px');
     });
 
     it('renders large spacing', () => {
-      const { container } = render(<StyledListItem space="large" />);
+      const { container } = render(<StyledListItem $space="large" />);
 
       expect(container.firstChild).toHaveStyleRule('padding-top', '8px');
     });

--- a/packages/typography/src/styled/StyledListItem.ts
+++ b/packages/typography/src/styled/StyledListItem.ts
@@ -17,12 +17,12 @@ import { StyledOrderedList, StyledUnorderedList } from './StyledList';
 import { StyledFont } from './StyledFont';
 
 interface IStyledListItemProps {
-  space?: Size;
+  $space?: Size;
 }
 
 const listItemPaddingStyles = (props: IStyledListItemProps & ThemeProps<DefaultTheme>) => {
   const base = props.theme.space.base;
-  const paddingTop = props.space === 'large' ? `${base * 2}px` : `${base}px`;
+  const paddingTop = props.$space === 'large' ? `${base * 2}px` : `${base}px`;
 
   /**
    * 1. Prevent padding the very first list item.
@@ -49,7 +49,7 @@ const listItemStyles = (props: IStyledListItemProps & ThemeProps<DefaultTheme>) 
   return css`
     line-height: ${getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
 
-    ${props.space !== 'small' && listItemPaddingStyles(props)};
+    ${props.$space !== 'small' && listItemPaddingStyles(props)};
   `;
 };
 
@@ -71,7 +71,7 @@ export const StyledOrderedListItem = styled(StyledFont as 'li').attrs({
 `;
 
 StyledOrderedListItem.defaultProps = {
-  space: 'medium',
+  $space: 'medium',
   theme: DEFAULT_THEME
 };
 
@@ -88,6 +88,6 @@ export const StyledUnorderedListItem = styled(StyledFont as 'li').attrs({
 `;
 
 StyledUnorderedListItem.defaultProps = {
-  space: 'medium',
+  $space: 'medium',
   theme: DEFAULT_THEME
 };

--- a/utils/test/jest.config.js
+++ b/utils/test/jest.config.js
@@ -20,7 +20,7 @@ module.exports = {
     '!**/node_modules/**',
     '!**/vendor/**'
   ],
-  testMatch: ['<rootDir>/packages/*/src/**/?(*.)+(spec|test).[jt]s?(x)'],
+  testMatch: ['<rootDir>/packages/*/(demo|src)/**/?(*.)+(spec|test).[jt]s?(x)'],
   testPathIgnorePatterns: ['/node_modules/', '<rootDir>/packages/.template'],
   testEnvironment: 'jest-environment-jsdom',
   setupFilesAfterEnv: ['<rootDir>/utils/test/jest.setup.js'],


### PR DESCRIPTION
# ⚠️ DO NOT MERGE! ⚠️

## Description
This PR adds snapshot tests from stories from the following packages:
- `buttons`
- `forms`
- `dropdowns`
- `drodowns.legacy`
- `draggable`
- `modals`
- `typography`

These tests capture the current visual appearance of the stories *before* making changes to transient props.

This helps ensure that the refactoring work in #1963 doesn't accidentally introduce any visual bugs. Identical snapshots taken before and after the changes should give reviewers more confidence that no regressions were introduced.