### PR TITLE
fix(grid): use `auto` tooltip positioning for `Pane.SplitterButton`

### DIFF
--- a/packages/grid/src/elements/pane/components/SplitterButton.tsx
+++ b/packages/grid/src/elements/pane/components/SplitterButton.tsx
@@ -69,6 +69,7 @@ const SplitterButtonComponent = forwardRef<HTMLButtonElement, ISplitterButtonPro
       >
         <Tooltip
           content={label}
+          placement="auto"
           zIndex={2}
           style={{ cursor: 'default' }}
           onMouseDown={e => e.stopPropagation()}


### PR DESCRIPTION
## Description

This PR addresses an issue where default tooltip positioning can result in cutting off the tooltip when a pane is expanded/contracted to the edge of the visible screen/container.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`npm start`)~
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :black_circle: ~renders as expected in dark mode~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
