### PR TITLE
fix(theming): swap `hasOwn` for `hasOwnProperty` call in `getColor`

### DIFF
--- a/packages/theming/src/utils/getColor.ts
+++ b/packages/theming/src/utils/getColor.ts
@@ -181,8 +181,7 @@ const toColor = (
     colors[hue as keyof typeof colors] /* ex. `hue` = 'primaryHue' */ ||
     hue; /* ex. `hue` = '#fd5a1e' */
 
-  // eslint-disable-next-line n/no-unsupported-features/es-builtins
-  if (Object.hasOwn(palette, _hue)) {
+  if (Object.prototype.hasOwnProperty.call(palette, _hue)) {
     _hue = palette[_hue]; /* ex. `hue` = 'grey' */
   }
 


### PR DESCRIPTION
## Description

Revert in order to broaden legacy browser support.
