### PR TITLE
fix(accordions): set `inert` for hidden `Stepper` content

### DIFF
--- a/packages/accordions/src/elements/stepper/components/Content.spec.tsx
+++ b/packages/accordions/src/elements/stepper/components/Content.spec.tsx
@@ -58,8 +58,12 @@ describe('Content', () => {
         </Stepper.Step>
       </Stepper>
     );
+    const visibleElement = queryByText('Blueberry');
+    const hiddenElement = queryByText('Strawberry');
 
-    expect(queryByText('Blueberry')).toHaveAttribute('aria-hidden', 'false');
-    expect(queryByText('Strawberry')).toHaveAttribute('aria-hidden', 'true');
+    expect(visibleElement).toHaveAttribute('aria-hidden', 'false');
+    expect(visibleElement).not.toHaveAttribute('inert');
+    expect(hiddenElement).toHaveAttribute('aria-hidden', 'true');
+    expect(hiddenElement).toHaveAttribute('inert');
   });
 });

--- a/packages/accordions/src/elements/stepper/components/Content.tsx
+++ b/packages/accordions/src/elements/stepper/components/Content.tsx
@@ -16,7 +16,9 @@ const ContentComponent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElemen
 
     return isHorizontal === false ? (
       <StyledContent ref={ref} $isActive={isActive} {...props}>
-        <StyledInnerContent aria-hidden={!isActive}>{props.children}</StyledInnerContent>
+        <StyledInnerContent aria-hidden={!isActive} inert={isActive ? undefined : ''}>
+          {props.children}
+        </StyledInnerContent>
       </StyledContent>
     ) : null;
   }

--- a/packages/accordions/src/styled/stepper/StyledInnerContent.ts
+++ b/packages/accordions/src/styled/stepper/StyledInnerContent.ts
@@ -10,10 +10,14 @@ import { getLineHeight, retrieveComponentStyles, getColor } from '@zendeskgarden
 
 const COMPONENT_ID = 'accordions.step_inner_content';
 
-export const StyledInnerContent = styled.div.attrs<ThemeProps<DefaultTheme>>({
+interface IStyledInnerContentProps extends ThemeProps<DefaultTheme> {
+  inert?: string;
+}
+
+export const StyledInnerContent = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})`
+})<IStyledInnerContentProps>`
   overflow: hidden;
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   color: ${({ theme }) => getColor({ theme, variable: 'foreground.default' })};


### PR DESCRIPTION
## Description

Similar to `Accordion` panel and `Sheet` content, this PR applies the HTML `inert` attribute in order to prevent tab navigation through focusable elements that are rendered within hidden `Stepper` content sections.

## Detail

Compare with https://github.com/zendeskgarden/react-components/pull/1920

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`npm start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :black_circle: ~renders as expected in dark mode~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
