### PR TITLE
chore(dropdowns): fix multiselectable combobox tags

### DIFF
--- a/packages/dropdowns/demo/stories/ComboboxStory.tsx
+++ b/packages/dropdowns/demo/stories/ComboboxStory.tsx
@@ -109,7 +109,7 @@ export const ComboboxStory: Story<IArgs> = ({
             <Svg />
           </span>
         </Tag.Avatar>{' '}
-        {option.tagProps?.children || toLabel(option)}
+        <span>{option.tagProps?.children || toLabel(option)}</span>
       </>
     ) : undefined;
 


### PR DESCRIPTION
## Description

The addition of a child element to the story's custom tags ensures truncation behaves like it would in the default case.

## Detail

**Before**

<img width="172" alt="Screenshot 2024-12-04 at 2 57 27 PM" src="https://github.com/user-attachments/assets/01b68f5a-9d5e-45d1-aaa0-ca84b6d5ea8a">

**After**

<img width="166" alt="Screenshot 2024-12-04 at 2 58 55 PM" src="https://github.com/user-attachments/assets/81f29d88-b09c-411d-90d1-fe0e423453d4">


## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :black_circle: ~renders as expected in dark mode~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [ ] :memo: tested in Chrome, Firefox, Safari, and Edge
