### PR TITLE
fix(Combobox): improve screen reader experience for Select-Only combobox w NVDA

### DIFF
--- a/packages/dropdowns/src/elements/combobox/Combobox.spec.tsx
+++ b/packages/dropdowns/src/elements/combobox/Combobox.spec.tsx
@@ -512,6 +512,26 @@ describe('Combobox', () => {
       expect(input).toHaveAttribute('aria-expanded', 'false');
     });
 
+    it('sets the correct aria attributes on `ListBox` when expanded or collapsed', async () => {
+      const { getByTestId } = render(
+        <TestCombobox isAutocomplete>
+          <Option data-test-id="option" value="test" />
+        </TestCombobox>
+      );
+      const combobox = getByTestId('combobox');
+      const trigger = combobox.firstChild as HTMLElement;
+
+      await user.click(trigger);
+
+      const listbox = combobox.querySelector('[role="listbox"]') as HTMLElement;
+
+      expect(listbox).toHaveAttribute('aria-hidden', 'false');
+
+      await user.click(trigger);
+
+      expect(listbox).toHaveAttribute('aria-hidden', 'true');
+    });
+
     it('retains expansion on `OptGroup` click', async () => {
       const { getByTestId } = render(
         <TestCombobox isAutocomplete>

--- a/packages/dropdowns/src/elements/combobox/Listbox.tsx
+++ b/packages/dropdowns/src/elements/combobox/Listbox.tsx
@@ -22,9 +22,6 @@ import { ThemeContext } from 'styled-components';
 import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 
-/**
- * 1. Hide from NVDA when collapsed to avoid incorrect / missing announcements caused by animation
- */
 export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
   (
     {
@@ -136,7 +133,10 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
           $isCompact={isCompact}
           $maxHeight={maxHeight}
           $minHeight={minHeight}
-          aria-hidden={!isExpanded} /* [1] */
+          aria-hidden={
+            // Hide from NVDA when collapsed to prevent incorrect / missing announcements caused by animation
+            !isExpanded
+          }
           onMouseDown={composeEventHandlers(onMouseDown, handleMouseDown)}
           style={{ height }}
           {...props}

--- a/packages/dropdowns/src/elements/combobox/Listbox.tsx
+++ b/packages/dropdowns/src/elements/combobox/Listbox.tsx
@@ -22,6 +22,9 @@ import { ThemeContext } from 'styled-components';
 import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 
+/**
+ * 1. Hide from NVDA when collapsed to avoid incorrect / missing announcements caused by animation
+ */
 export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
   (
     {
@@ -133,6 +136,7 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
           $isCompact={isCompact}
           $maxHeight={maxHeight}
           $minHeight={minHeight}
+          aria-hidden={!isExpanded} /* [1] */
           onMouseDown={composeEventHandlers(onMouseDown, handleMouseDown)}
           style={{ height }}
           {...props}


### PR DESCRIPTION
## Description

This update fixes how our Comboboxes interact with NVDA during animations. Previously, NVDA users might have experienced incomplete or inaccurate announcements of the selected option when the dropdown list was animating. This was due to the way NVDA processes rapid changes in the page, which sometimes led to announcements being out of sync with the visual state.

## Detail

### The problem

When interacting with the Select-Only Combobox, NVDA's announcement of the selected option (e.g., "Label combo box Poppy collapsed opens list") is often interrupted by an incorrect announcement of a now-inactive option previously referenced by `aria-activedescendant` (e.g., "Poppy Lee 4 of 16").

Analysis revealed that the dropdown animation is interfering with NVDA’s event queue, causing it to announce outdated or incorrect information. Disabling the animation did resolve the issue, allowing NVDA to announce the correct selected option without interruption, but another solution was preferred.

https://github.com/user-attachments/assets/ca3aef29-cc0d-47aa-9128-1bb7d7f5fbb9

To further demonstrate the problem, the issue was [reproduced](https://codepen.io/zeFlo/pen/azoZJyK) in a modified version of the _ARIA Authoring Practices Guide_ (APG) Select-Only Combobox [example](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/) by adding a slide animation to the dropdown. The animation caused NVDA to fail in announcing the correct selection.

https://github.com/user-attachments/assets/558b93a0-a654-43db-8291-9e560f461306

### The solution

To address this, we now apply an aria-hidden="true" attribute to the Listbox immediately when it is set to `collapsed` and at the start of the animation sequence. This prevents screen readers from processing its contents during the animation.  Now NVDA correctly process and announce the selected option without interruptions.

https://github.com/user-attachments/assets/4a5ed730-00ed-4db0-95dc-9edaaf1029df

## Regression testing

The fix was tested across various screen readers to ensure compatibility and continued functionality:

**JAWS**: Announcements work as expected.

https://github.com/user-attachments/assets/db561d3b-780c-4bcb-8206-c8bf86853513

**VoiceOver**: Announcements work as expected.
[Video coming soon]


## Checklist

- [] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:black_circle: renders as expected in dark mode~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
