### PR TITLE
chore: set `dist-tag` to `v8`

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -21,7 +21,7 @@
   ],
   "command": {
     "publish": {
-      "preDistTag": "next",
+      "distTag": "v8",
       "registry": "https://registry.npmjs.org/"
     },
     "version": {

--- a/lerna.json
+++ b/lerna.json
@@ -22,6 +22,7 @@
   "command": {
     "publish": {
       "distTag": "v8",
+      "preDistTag": "next",
       "registry": "https://registry.npmjs.org/"
     },
     "version": {


### PR DESCRIPTION
## Description
Explicitly sets the `dist-tag` to `v8` instead of the [default](https://www.npmjs.com/package/@lerna/publish#--dist-tag-tag) `latest`
