### PR TITLE
fix(theming): return hex from generated `getColor` values

### DIFF
--- a/packages/theming/demo/stories/GetColorStory.tsx
+++ b/packages/theming/demo/stories/GetColorStory.tsx
@@ -66,22 +66,24 @@ const Color = ({
       </Tag>
     );
 
-    const hues = [...Object.keys(theme.colors), ...Object.keys(theme.palette)].filter(
-      _hue => _hue !== 'base' && _hue !== 'variables'
-    );
-    const selectedHue = (theme.colors.base === 'dark' ? dark?.hue : light?.hue) || hue || '';
+    if (!variable) {
+      const hues = [...Object.keys(theme.colors), ...Object.keys(theme.palette)].filter(
+        _hue => _hue !== 'base' && _hue !== 'variables'
+      );
+      const selectedHue = (theme.colors.base === 'dark' ? dark?.hue : light?.hue) || hue || '';
 
-    if (!(variable || hues.includes(selectedHue))) {
-      generatedHue = [...Array(12).keys()].reduce<Record<number, string>>((retVal, index) => {
-        const _shade = (index + 1) * 100;
+      if (!hues.includes(selectedHue)) {
+        generatedHue = [...Array(12).keys()].reduce<Record<number, string>>((retVal, index) => {
+          const _shade = (index + 1) * 100;
 
-        retVal[_shade] = getColor({ theme, hue: opacify(backgroundColor, 1), shade: _shade });
+          retVal[_shade] = getColor({ theme, hue: opacify(backgroundColor, 1), shade: _shade });
 
-        return retVal;
-      }, {});
+          return retVal;
+        }, {});
 
-      /* eslint-disable-next-line no-console */
-      console.log(generatedHue);
+        /* eslint-disable-next-line no-console */
+        console.log(generatedHue);
+      }
     }
   } catch (error) {
     background = 'transparent';

--- a/packages/theming/demo/stories/GetColorStory.tsx
+++ b/packages/theming/demo/stories/GetColorStory.tsx
@@ -9,9 +9,13 @@ import React from 'react';
 import { StoryFn } from '@storybook/react';
 import styled, { useTheme } from 'styled-components';
 import { opacify } from 'color2k';
-import { IGardenTheme, getCheckeredBackground, getColor } from '@zendeskgarden/react-theming';
-import { Code, LG, MD, Span } from '@zendeskgarden/react-typography';
-import { Anchor } from '@zendeskgarden/react-buttons';
+import {
+  ColorParameters,
+  IGardenTheme,
+  getCheckeredBackground,
+  getColor
+} from '@zendeskgarden/react-theming';
+import { LG, SM } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 import { Tag } from '@zendeskgarden/react-tags';
 
@@ -25,18 +29,16 @@ const StyledDiv = styled.div.attrs<{ $background: string }>(p => ({
   height: 208px;
 `;
 
-interface IColorProps {
-  dark?: object;
-  hue?: string;
-  light?: object;
-  offset?: number;
-  shade?: number;
-  theme: IGardenTheme;
-  transparency?: number;
-  variable?: string;
-}
-
-const Color = ({ dark, hue, light, offset, shade, theme, transparency, variable }: IColorProps) => {
+const Color = ({
+  dark,
+  hue,
+  light,
+  offset,
+  shade,
+  theme,
+  transparency,
+  variable
+}: ColorParameters) => {
   let background;
   let tag;
   let generatedHue;
@@ -63,16 +65,25 @@ const Color = ({ dark, hue, light, offset, shade, theme, transparency, variable 
         {backgroundColor}
       </Tag>
     );
-    generatedHue = [...Array(12).keys()].reduce<Record<number, string>>((retVal, index) => {
-      const _shade = (index + 1) * 100;
 
-      retVal[_shade] = getColor({ theme, hue: opacify(backgroundColor, 1), shade: _shade });
+    const hues = [...Object.keys(theme.colors), ...Object.keys(theme.palette)].filter(
+      _hue => _hue !== 'base' && _hue !== 'variables'
+    );
 
-      return retVal;
-    }, {});
+    const selectedHue = (theme.colors.base === 'dark' ? dark?.hue : light?.hue) || hue || '';
 
-    /* eslint-disable-next-line no-console */
-    console.log(generatedHue);
+    if (!(variable || hues.includes(selectedHue))) {
+      generatedHue = [...Array(12).keys()].reduce<Record<number, string>>((retVal, index) => {
+        const _shade = (index + 1) * 100;
+
+        retVal[_shade] = getColor({ theme, hue: opacify(backgroundColor, 1), shade: _shade });
+
+        return retVal;
+      }, {});
+
+      /* eslint-disable-next-line no-console */
+      console.log(generatedHue);
+    }
   } catch (error) {
     background = 'transparent';
     tag = (
@@ -87,19 +98,11 @@ const Color = ({ dark, hue, light, offset, shade, theme, transparency, variable 
       <StyledDiv $background={background}>{tag}</StyledDiv>
       {!!generatedHue && (
         <>
-          <LG style={{ marginTop: 20 }}>Generated hue</LG>
-          <MD style={{ marginBottom: 12 }}>
-            <Span hue="foreground.subtle">
-              Not used when <Code>hue[shade]</Code> is defined by the theme{' '}
-              <Anchor href="https://garden.zendesk.com/components/theme-object#palette" isExternal>
-                palette
-              </Anchor>
-            </Span>
-          </MD>
+          <LG style={{ margin: '20px 0 12px' }}>Generated hue</LG>
           <Grid gutters={false}>
             <Grid.Row wrap="nowrap">
-              {Object.values(generatedHue).map((backgroundColor, index) => (
-                <Grid.Col key={index}>
+              {Object.entries(generatedHue).map(([_shade, backgroundColor], index) => (
+                <Grid.Col key={index} textAlign="center">
                   <StyledDiv $background={backgroundColor}>
                     <Tag
                       hue={getColor({ theme, variable: 'background.default' })}
@@ -108,6 +111,7 @@ const Color = ({ dark, hue, light, offset, shade, theme, transparency, variable 
                       {backgroundColor}
                     </Tag>
                   </StyledDiv>
+                  <SM>{_shade}</SM>
                 </Grid.Col>
               ))}
             </Grid.Row>
@@ -118,7 +122,7 @@ const Color = ({ dark, hue, light, offset, shade, theme, transparency, variable 
   );
 };
 
-interface IArgs extends Omit<IColorProps, 'theme'> {
+interface IArgs extends Omit<ColorParameters, 'theme'> {
   theme: {
     colors: Omit<IGardenTheme['colors'], 'base'>;
     opacity: IGardenTheme['opacity'];

--- a/packages/theming/demo/stories/GetColorStory.tsx
+++ b/packages/theming/demo/stories/GetColorStory.tsx
@@ -69,7 +69,6 @@ const Color = ({
     const hues = [...Object.keys(theme.colors), ...Object.keys(theme.palette)].filter(
       _hue => _hue !== 'base' && _hue !== 'variables'
     );
-
     const selectedHue = (theme.colors.base === 'dark' ? dark?.hue : light?.hue) || hue || '';
 
     if (!(variable || hues.includes(selectedHue))) {

--- a/packages/theming/demo/stories/GetColorStory.tsx
+++ b/packages/theming/demo/stories/GetColorStory.tsx
@@ -8,15 +8,20 @@
 import React from 'react';
 import { StoryFn } from '@storybook/react';
 import styled, { useTheme } from 'styled-components';
+import { opacify } from 'color2k';
 import { IGardenTheme, getCheckeredBackground, getColor } from '@zendeskgarden/react-theming';
+import { Code, LG, MD, Span } from '@zendeskgarden/react-typography';
+import { Anchor } from '@zendeskgarden/react-buttons';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Tag } from '@zendeskgarden/react-tags';
 
-const StyledDiv = styled.div.attrs<{ background: string }>(p => ({
-  style: { background: p.background }
-}))<{ background: string }>`
+const StyledDiv = styled.div.attrs<{ $background: string }>(p => ({
+  style: { background: p.$background }
+}))`
   display: flex;
   align-items: center;
   justify-content: center;
+  min-width: 32px;
   height: 208px;
 `;
 
@@ -34,6 +39,7 @@ interface IColorProps {
 const Color = ({ dark, hue, light, offset, shade, theme, transparency, variable }: IColorProps) => {
   let background;
   let tag;
+  let generatedHue;
 
   try {
     const backgroundColor = getColor({
@@ -57,16 +63,59 @@ const Color = ({ dark, hue, light, offset, shade, theme, transparency, variable 
         {backgroundColor}
       </Tag>
     );
+    generatedHue = [...Array(12).keys()].reduce<Record<number, string>>((retVal, index) => {
+      const _shade = (index + 1) * 100;
+
+      retVal[_shade] = getColor({ theme, hue: opacify(backgroundColor, 1), shade: _shade });
+
+      return retVal;
+    }, {});
+
+    /* eslint-disable-next-line no-console */
+    console.log(generatedHue);
   } catch (error) {
     background = 'transparent';
     tag = (
-      <Tag hue="red" size="large">
+      <Tag hue="dangerHue" size="large">
         {error instanceof Error ? error.message : String(error)}
       </Tag>
     );
   }
 
-  return <StyledDiv background={background}>{tag}</StyledDiv>;
+  return (
+    <>
+      <StyledDiv $background={background}>{tag}</StyledDiv>
+      {!!generatedHue && (
+        <>
+          <LG style={{ marginTop: 20 }}>Generated hue</LG>
+          <MD style={{ marginBottom: 12 }}>
+            <Span hue="foreground.subtle">
+              Not used when <Code>hue[shade]</Code> is defined by the theme{' '}
+              <Anchor href="https://garden.zendesk.com/components/theme-object#palette" isExternal>
+                palette
+              </Anchor>
+            </Span>
+          </MD>
+          <Grid gutters={false}>
+            <Grid.Row wrap="nowrap">
+              {Object.values(generatedHue).map((backgroundColor, index) => (
+                <Grid.Col key={index}>
+                  <StyledDiv $background={backgroundColor}>
+                    <Tag
+                      hue={getColor({ theme, variable: 'background.default' })}
+                      style={{ position: 'absolute', transform: 'rotate(-90deg)' }}
+                    >
+                      {backgroundColor}
+                    </Tag>
+                  </StyledDiv>
+                </Grid.Col>
+              ))}
+            </Grid.Row>
+          </Grid>
+        </>
+      )}
+    </>
+  );
 };
 
 interface IArgs extends Omit<IColorProps, 'theme'> {

--- a/packages/theming/src/utils/getColor.ts
+++ b/packages/theming/src/utils/getColor.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getScale, parseToRgba } from 'color2k';
+import { getScale, parseToRgba, toHex as _toHex } from 'color2k';
 import { darken, getContrast, lighten, rgba } from 'polished';
 import get from 'lodash.get';
 import memoize from 'lodash.memoize';
@@ -151,7 +151,7 @@ const generateColorScale = memoize((color: string) => {
   const contrastRatios = [];
 
   for (let i = 0; i <= scaleSize; i++) {
-    const _color = scale(i);
+    const _color = _toHex(scale(i));
     colors.push(_color);
     contrastRatios.push(getContrast('#FFF', _color));
   }


### PR DESCRIPTION
## Description

While this PR focuses on a very minor `getColor` fix, the main enhancement is the updated Storybook that shows the potential generated palette `hue` for any non-themed color value resolved by `getColor`.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :black_circle: renders as expected in dark mode
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
