### PR TITLE
fix(theming): nested `ColorSchemeProvider` system color scheme handling

### DIFF
--- a/packages/theming/src/elements/ColorSchemeProvider.tsx
+++ b/packages/theming/src/elements/ColorSchemeProvider.tsx
@@ -20,6 +20,9 @@ import {
   IGardenTheme
 } from '../types';
 
+const mediaQuery =
+  typeof window === 'undefined' ? undefined : window.matchMedia('(prefers-color-scheme: dark)');
+
 const useColorScheme = (initialState?: ColorScheme, colorSchemeKey = 'color-scheme') => {
   /* eslint-disable-next-line n/no-unsupported-features/node-builtins */
   const localStorage = typeof window === 'undefined' ? undefined : window.localStorage;
@@ -29,11 +32,6 @@ const useColorScheme = (initialState?: ColorScheme, colorSchemeKey = 'color-sche
     let colorScheme: IGardenTheme['colors']['base'];
 
     if (isSystem) {
-      const mediaQuery =
-        typeof window === 'undefined'
-          ? undefined
-          : window.matchMedia('(prefers-color-scheme: dark)');
-
       colorScheme = mediaQuery?.matches ? 'dark' : 'light';
     } else {
       colorScheme = _state;
@@ -75,9 +73,6 @@ export const ColorSchemeProvider = ({
 
   useEffect(() => {
     // Listen for changes to the system color scheme
-    const mediaQuery =
-      typeof window === 'undefined' ? undefined : window.matchMedia('(prefers-color-scheme: dark)');
-
     /* istanbul ignore next */
     const eventListener = () => {
       setColorScheme('system');

--- a/packages/theming/src/elements/ColorSchemeProvider.tsx
+++ b/packages/theming/src/elements/ColorSchemeProvider.tsx
@@ -13,6 +13,7 @@ import React, {
   useMemo,
   useState
 } from 'react';
+import PropTypes from 'prop-types';
 import {
   ColorScheme,
   IColorSchemeContext,
@@ -23,7 +24,7 @@ import {
 const mediaQuery =
   typeof window === 'undefined' ? undefined : window.matchMedia('(prefers-color-scheme: dark)');
 
-const useColorScheme = (initialState?: ColorScheme, colorSchemeKey = 'color-scheme') => {
+const useColorScheme = (initialState: ColorScheme, colorSchemeKey: string) => {
   /* eslint-disable-next-line n/no-unsupported-features/node-builtins */
   const localStorage = typeof window === 'undefined' ? undefined : window.localStorage;
 
@@ -59,8 +60,8 @@ export const ColorSchemeContext = createContext<IColorSchemeContext | undefined>
 
 export const ColorSchemeProvider = ({
   children,
-  colorSchemeKey,
-  initialColorScheme
+  colorSchemeKey = 'color-scheme',
+  initialColorScheme = 'system'
 }: PropsWithChildren<IColorSchemeProviderProps>) => {
   const { isSystem, colorScheme, setColorScheme } = useColorScheme(
     initialColorScheme,
@@ -90,4 +91,9 @@ export const ColorSchemeProvider = ({
   }, [isSystem, setColorScheme]);
 
   return <ColorSchemeContext.Provider value={contextValue}>{children}</ColorSchemeContext.Provider>;
+};
+
+ColorSchemeProvider.propTypes = {
+  colorSchemeKey: PropTypes.string,
+  initialColorScheme: PropTypes.oneOf(['light', 'dark', 'system'])
 };

--- a/utils/test/jest.setup.js
+++ b/utils/test/jest.setup.js
@@ -14,3 +14,19 @@ import '@testing-library/jest-dom';
 import { TextEncoder } from 'node:util';
 
 global.TextEncoder = TextEncoder;
+
+// https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  /* eslint-disable no-undef */
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  }))
+});


### PR DESCRIPTION
## Description

I ran into a gnarly error while attempting to retrofit `ColorSchemeProvider` on to the Garden website along with a new component page and embedded example. Due to React's [useEffect cleanup logic](https://react.dev/reference/react/useEffect#my-cleanup-logic-runs-even-though-my-component-didnt-unmount) the placement of the provider's `mediaQuery` listener was being unexpectedly removed from the embedded example. As a result, changing the system color scheme updated the website as expected, but was not cascading to the embedded example.

The solution was to move the `useEffect` out of the hook and into the `ColorSchemeProvider` itself. Doing so ensures mounting/unmounting (and associated listener add/removal) works as expected.
