### PR TITLE
fix(chrome,loaders): ferry props to view component transient props

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -15,13 +15,13 @@ const DARK = getColor({ theme: DARK_THEME, variable: 'background.default' });
 const LIGHT = getColor({ theme: DEFAULT_THEME, variable: 'background.default' });
 
 export const args = {
-  'colors.dark': DEFAULT_THEME.colors.variables.dark,
-  'colors.light': DEFAULT_THEME.colors.variables.light
+  '$colors.dark': DEFAULT_THEME.colors.variables.dark,
+  '$colors.light': DEFAULT_THEME.colors.variables.light
 };
 
 export const argTypes = {
-  'colors.dark': { table: { category: 'Variables' } },
-  'colors.light': { table: { category: 'Variables' } }
+  '$colors.dark': { name: 'colors.dark', table: { category: 'Variables' } },
+  '$colors.light': { name: 'colors.light', table: { category: 'Variables' } }
 };
 
 export const parameters = {
@@ -76,8 +76,8 @@ const withThemeProvider = (story, context) => {
     primaryHue: context.globals.primaryHue,
     variables: {
       ...DEFAULT_THEME.colors.variables,
-      dark: context.args['colors.dark'],
-      light: context.args['colors.light']
+      dark: context.args['$colors.dark'],
+      light: context.args['$colors.light']
     }
   };
 

--- a/packages/chrome/src/elements/header/HeaderItemWrapper.tsx
+++ b/packages/chrome/src/elements/header/HeaderItemWrapper.tsx
@@ -15,7 +15,9 @@ import { StyledHeaderItemWrapper } from '../../styled';
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const HeaderItemWrapper = React.forwardRef<HTMLDivElement, IHeaderItemWrapperProps>(
-  (props, ref) => <StyledHeaderItemWrapper ref={ref} {...props} />
+  ({ isRound, maxX, maxY, ...other }, ref) => (
+    <StyledHeaderItemWrapper ref={ref} $isRound={isRound} $maxX={maxX} $maxY={maxY} {...other} />
+  )
 );
 
 HeaderItemWrapper.displayName = 'Header.ItemWrapper';

--- a/packages/chrome/src/styled/header/StyledHeaderItemWrapper.ts
+++ b/packages/chrome/src/styled/header/StyledHeaderItemWrapper.ts
@@ -7,7 +7,7 @@
 
 import styled from 'styled-components';
 import { componentStyles } from '@zendeskgarden/react-theming';
-import { StyledBaseHeaderItem } from './StyledBaseHeaderItem';
+import { IStyledBaseHeaderItemProps, StyledBaseHeaderItem } from './StyledBaseHeaderItem';
 
 const COMPONENT_ID = 'chrome.header_item_wrapper';
 
@@ -15,6 +15,6 @@ export const StyledHeaderItemWrapper = styled(StyledBaseHeaderItem as 'div').att
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   as: 'div'
-})`
+})<IStyledBaseHeaderItemProps>`
   ${componentStyles};
 `;

--- a/packages/loaders/demo/dots.stories.mdx
+++ b/packages/loaders/demo/dots.stories.mdx
@@ -13,7 +13,7 @@ import README from '../README.md';
 <Canvas>
   <Story
     name="Dots"
-    argTypes={{ color: { control: 'color' }, size: { control: 'number' } }}
+    argTypes={{ color: { control: 'color' }, size: { control: 'text' } }}
     parameters={{
       design: {
         allowFullscreen: true,

--- a/packages/loaders/src/elements/Dots.tsx
+++ b/packages/loaders/src/elements/Dots.tsx
@@ -56,7 +56,7 @@ export const Dots = forwardRef<SVGSVGElement, IDotsProps>(
     });
 
     if (!delayComplete && delayMS !== 0) {
-      return <StyledLoadingPlaceholder fontSize={size!}>&nbsp;</StyledLoadingPlaceholder>;
+      return <StyledLoadingPlaceholder $fontSize={size!}>&nbsp;</StyledLoadingPlaceholder>;
     }
 
     return (

--- a/packages/loaders/src/elements/Spinner.tsx
+++ b/packages/loaders/src/elements/Spinner.tsx
@@ -66,7 +66,7 @@ export const Spinner = forwardRef<SVGSVGElement, ISpinnerProps>(
 
     if (!delayComplete && delayMS !== 0) {
       return (
-        <StyledLoadingPlaceholder width="1em" height="1em" fontSize={size!}>
+        <StyledLoadingPlaceholder $width="1em" $height="1em" $fontSize={size!}>
           &nbsp;
         </StyledLoadingPlaceholder>
       );

--- a/packages/loaders/src/styled/StyledLoadingPlaceholder.ts
+++ b/packages/loaders/src/styled/StyledLoadingPlaceholder.ts
@@ -5,16 +5,38 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { getValueAndUnit } from 'polished';
 import { componentStyles } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'loaders.loading_placeholder';
 
 interface IStyledLoadingPlaceholderProps {
-  fontSize: string | number;
-  width?: string;
-  height?: string;
+  $fontSize: string | number;
+  $width?: string;
+  $height?: string;
 }
+
+const sizeStyles = ({
+  $width = '1em',
+  $height = '0.9em',
+  $fontSize
+}: IStyledLoadingPlaceholderProps) => {
+  const [value, unit] = getValueAndUnit($fontSize);
+  let fontSize;
+
+  if (unit === undefined) {
+    fontSize = $fontSize;
+  } else {
+    fontSize = `${value}${unit === '' ? 'px' : unit}`;
+  }
+
+  return css`
+    width: ${$width};
+    height: ${$height};
+    font-size: ${fontSize};
+  `;
+};
 
 export const StyledLoadingPlaceholder = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
@@ -22,9 +44,8 @@ export const StyledLoadingPlaceholder = styled.div.attrs({
   role: 'progressbar'
 })<IStyledLoadingPlaceholderProps>`
   display: inline-block;
-  width: ${props => props.width || '1em'};
-  height: ${props => props.height || '0.9em'};
-  font-size: ${props => props.fontSize};
+
+  ${sizeStyles};
 
   ${componentStyles}
 `;

--- a/packages/loaders/src/styled/StyledSVG.ts
+++ b/packages/loaders/src/styled/StyledSVG.ts
@@ -6,6 +6,7 @@
  */
 
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
+import { getValueAndUnit } from 'polished';
 import { getColor, componentStyles } from '@zendeskgarden/react-theming';
 
 interface IStyledSVGProps {
@@ -26,6 +27,27 @@ const colorStyles = ({ theme, $color = 'inherit' }: IStyledSVGProps & ThemeProps
   `;
 };
 
+const sizeStyles = ({
+  $containerWidth = '1em',
+  $containerHeight = '0.9em',
+  $fontSize = 'inherit'
+}: IStyledSVGProps) => {
+  const [value, unit] = getValueAndUnit($fontSize);
+  let fontSize;
+
+  if (unit === undefined) {
+    fontSize = $fontSize;
+  } else {
+    fontSize = `${value}${unit === '' ? 'px' : unit}`;
+  }
+
+  return css`
+    width: ${$containerWidth};
+    height: ${$containerHeight};
+    font-size: ${fontSize};
+  `;
+};
+
 export const StyledSVG = styled.svg.attrs<IStyledSVGProps>(props => ({
   'data-garden-version': PACKAGE_VERSION,
   xmlns: 'http://www.w3.org/2000/svg',
@@ -33,9 +55,7 @@ export const StyledSVG = styled.svg.attrs<IStyledSVGProps>(props => ({
   viewBox: `0 0 ${props.$width} ${props.$height}`,
   role: 'img'
 }))<IStyledSVGProps>`
-  width: ${props => props.$containerWidth || '1em'};
-  height: ${props => props.$containerHeight || '0.9em'};
-  font-size: ${props => props.$fontSize || 'inherit'};
+  ${sizeStyles};
 
   ${colorStyles};
 


### PR DESCRIPTION
## Description

During the `styled-components` transient naming work, a few props got missed. This PR ensures the following are properly ferried to the underlying view components:
- `<Header.ItemWrapper isRound={...} maxX={...} maxY={...}>`
- `<Dots size={...}>`
- `<Spinner size={...}>`

## Detail

Also cleans up Storybook `VARIABLES` context args that were leaking into rendered styled components.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :black_circle: ~renders as expected in dark mode~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
