### PR TITLE
fix(dropdowns): ensure iframed Menu dropdowns close correctly when clicking outside the iframe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12197,9 +12197,9 @@
       }
     },
     "node_modules/@zendeskgarden/container-menu": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-menu/-/container-menu-0.5.0.tgz",
-      "integrity": "sha512-X2iQPHqls+8O3d8Ohm3t6oNnh+lQ6KRhpySYwvfaVEdsnxQtchHBImnrAJt33GVGMz1lBQu0dj5DxT4AALVHUQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-menu/-/container-menu-0.5.1.tgz",
+      "integrity": "sha512-ctbuQGHSjmsGqKmJ9uyk1TvUjA4Im6xF64VpLwJhYwsmQV4ddp3/tMxu3t2gaB+cG9GsjJLzGVOuTfjwhVQlJg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
@@ -51904,7 +51904,7 @@
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
         "@zendeskgarden/container-combobox": "^2.0.0",
-        "@zendeskgarden/container-menu": "^0.5.0",
+        "@zendeskgarden/container-menu": "^0.5.1",
         "@zendeskgarden/container-utilities": "^2.0.0",
         "@zendeskgarden/react-buttons": "^9.5.3",
         "@zendeskgarden/react-forms": "^9.5.3",

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
     "@zendeskgarden/container-combobox": "^2.0.0",
-    "@zendeskgarden/container-menu": "^0.5.0",
+    "@zendeskgarden/container-menu": "^0.5.1",
     "@zendeskgarden/container-utilities": "^2.0.0",
     "@zendeskgarden/react-buttons": "^9.5.3",
     "@zendeskgarden/react-forms": "^9.5.3",


### PR DESCRIPTION
## Description

This PR applies the `@zendeskgarden/container-menu` [fix](https://github.com/zendeskgarden/react-containers/pull/691) to Menu to ensure iframed Menu dropdowns close correctly when clicking outside the iframe (even in another window).

## Checklist

- ~~[ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~[ ] :arrow_left: renders as expected with reversed (RTL) direction~~
- ~~[ ] :black_circle: renders as expected in dark mode~~
- ~~[ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
