### PR TITLE
fix(theming): reflect updated `lg` borderRadius in `IGardenTheme` definition

### DIFF
--- a/packages/theming/src/types/index.ts
+++ b/packages/theming/src/types/index.ts
@@ -104,6 +104,7 @@ export interface IGardenTheme {
   borderRadii: {
     sm: string;
     md: string;
+    lg: string;
   };
   borderStyles: {
     solid: string;


### PR DESCRIPTION
## Description
This PR updates the outdated `IGardenTheme` type to reflect the new value for the `lg` `borderRadius` token. 

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- ~~[ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- ~~[ ] :globe_with_meridians: demo is up-to-date (`npm start`)~~
- ~~[ ] :arrow_left: renders as expected with reversed (RTL) direction~~
- ~~[ ] :black_circle: renders as expected in dark mode~~
- ~~[ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~[ ] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~[ ] :wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- ~~[ ] :memo: tested in Chrome, Firefox, Safari, and Edge~~
