### PR TITLE
fix(avatars): status ring styling and accessibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31244,6 +31244,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -31283,6 +31325,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.14.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
@@ -31298,11 +31346,33 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -31682,6 +31752,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -34971,6 +35057,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.15.1",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.15.1.tgz",
@@ -36665,6 +36757,15 @@
         "ipx": "bin/ipx.mjs"
       }
     },
+    "node_modules/netlify-cli/node_modules/ipx/node_modules/@netlify/blobs": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-6.5.0.tgz",
+      "integrity": "sha512-wRFlNnL/Qv3WNLZd3OT/YYqF1zb6iPSo8T31sl9ccL1ahBxW1fBqKgF4b1XL7Z+6mRIkatvcsVPkWBcO+oJMNA==",
+      "extraneous": true,
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
     "node_modules/netlify-cli/node_modules/ipx/node_modules/lru-cache": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
@@ -37219,6 +37320,12 @@
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       }
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",
@@ -51719,6 +51826,7 @@
       "version": "9.7.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@zendeskgarden/react-typography": "^9.7.0",
         "polished": "^4.3.1",
         "prop-types": "^15.5.7"
       },

--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -21,6 +21,7 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
+    "@zendeskgarden/react-typography": "^9.7.0",
     "polished": "^4.3.1",
     "prop-types": "^15.5.7"
   },

--- a/packages/avatars/src/elements/Avatar.spec.tsx
+++ b/packages/avatars/src/elements/Avatar.spec.tsx
@@ -27,14 +27,15 @@ describe('Avatar', () => {
   });
 
   it('renders badge if provided', () => {
-    const badge = '2';
     const { getByText } = render(
-      <Avatar badge={badge}>
+      <Avatar badge={2}>
         <img alt="" />
       </Avatar>
     );
 
-    expect(getByText(badge)).not.toBeEmptyDOMElement();
+    const element = getByText(/2/u);
+
+    expect(element).toBeInTheDocument();
   });
 
   it('applies active styling to available status if provided with badge', () => {
@@ -75,49 +76,48 @@ describe('Avatar', () => {
         </Avatar>
       );
 
-      const statusIndicatorElement = getByText('2')?.parentElement;
+      const element = getByText('status: active. 2 notifications');
 
-      expect(statusIndicatorElement).toHaveAttribute(
-        'aria-label',
-        'status: active. 2 notifications'
-      );
+      expect(element).toBeInTheDocument();
     });
 
     it('renders with badge and with a provided status label', () => {
+      const label = 'two notifications';
       const { getByText } = render(
-        <Avatar badge="2" statusLabel="two notifications">
+        <Avatar badge="2" statusLabel={label}>
           <img alt="" />
         </Avatar>
       );
 
-      const statusIndicatorElement = getByText('2')?.parentElement;
+      const element = getByText(label);
 
-      expect(statusIndicatorElement).toHaveAttribute('aria-label', 'two notifications');
+      expect(element).toBeInTheDocument();
     });
 
-    it('renders with status and applies default aria-label for available status', () => {
-      const { getByLabelText } = render(
+    it('renders with status and applies default label for available status', () => {
+      const { getByText } = render(
         <Avatar status="available">
           <img alt="" />
         </Avatar>
       );
 
-      const statusIndicatorElement = getByLabelText('status: available');
+      const element = getByText('status: available');
 
-      expect(statusIndicatorElement).toBeEmptyDOMElement();
+      expect(element).toBeInTheDocument();
     });
 
-    it('renders with status and applies default aria-label for away status', () => {
-      const { getByLabelText, container } = render(
+    it('renders with status and applies default label for away status', () => {
+      const { getByText, container } = render(
         <Avatar status="away">
           <img alt="" />
         </Avatar>
       );
 
-      const statusIndicatorElement = getByLabelText('status: away');
+      const element = getByText('status: away');
       const statusIndicatorSVG = container.querySelector('svg');
 
-      expect(statusIndicatorElement).toContainElement(statusIndicatorSVG);
+      expect(element).toBeInTheDocument();
+      expect(statusIndicatorSVG).toBeInTheDocument();
     });
   });
 

--- a/packages/avatars/src/elements/Avatar.spec.tsx
+++ b/packages/avatars/src/elements/Avatar.spec.tsx
@@ -27,15 +27,16 @@ describe('Avatar', () => {
   });
 
   it('renders badge if provided', () => {
+    const badge = '2';
     const { getByText } = render(
-      <Avatar badge={2}>
+      <Avatar badge={badge}>
         <img alt="" />
       </Avatar>
     );
 
-    const element = getByText(/2/u);
+    const element = getByText(badge);
 
-    expect(element).toBeInTheDocument();
+    expect(element).toHaveAttribute('aria-hidden');
   });
 
   it('applies active styling to available status if provided with badge', () => {

--- a/packages/avatars/src/elements/Avatar.tsx
+++ b/packages/avatars/src/elements/Avatar.tsx
@@ -17,6 +17,7 @@ import { IAvatarProps, SIZE, STATUS } from '../types';
 import { StyledAvatar, StyledStatusIndicator } from '../styled';
 
 import { Text } from './components/Text';
+import { Span } from '@zendeskgarden/react-typography';
 
 const AvatarComponent = forwardRef<HTMLElement, IAvatarProps>(
   (
@@ -59,7 +60,7 @@ const AvatarComponent = forwardRef<HTMLElement, IAvatarProps>(
     }, [computedStatus, badge]);
 
     const shouldValidate = computedStatus !== undefined;
-    const ariaLabel = useText(
+    const label = useText(
       AvatarComponent,
       { statusLabel },
       'statusLabel',
@@ -86,19 +87,13 @@ const AvatarComponent = forwardRef<HTMLElement, IAvatarProps>(
             $size={size}
             $type={computedStatus}
             $surfaceColor={surfaceColor}
-            aria-label={ariaLabel}
             as="figcaption"
           >
-            {computedStatus === 'active' ? (
-              <span aria-hidden="true">{badge}</span>
-            ) : (
-              <>
-                {computedStatus === 'away' ? <ClockIcon data-icon-status={computedStatus} /> : null}
-                {computedStatus === 'transfers' ? (
-                  <ArrowLeftIcon data-icon-status={computedStatus} />
-                ) : null}
-              </>
-            )}
+            <Span hidden>{label}</Span>
+            <>
+              {computedStatus === 'away' ? <ClockIcon /> : null}
+              {computedStatus === 'transfers' ? <ArrowLeftIcon /> : null}
+            </>
           </StyledStatusIndicator>
         )}
       </StyledAvatar>

--- a/packages/avatars/src/elements/Avatar.tsx
+++ b/packages/avatars/src/elements/Avatar.tsx
@@ -90,10 +90,14 @@ const AvatarComponent = forwardRef<HTMLElement, IAvatarProps>(
             as="figcaption"
           >
             <Span hidden>{label}</Span>
-            <>
-              {computedStatus === 'away' ? <ClockIcon /> : null}
-              {computedStatus === 'transfers' ? <ArrowLeftIcon /> : null}
-            </>
+            {computedStatus === 'active' ? (
+              <span aria-hidden>{badge}</span>
+            ) : (
+              <>
+                {computedStatus === 'away' ? <ClockIcon /> : null}
+                {computedStatus === 'transfers' ? <ArrowLeftIcon /> : null}
+              </>
+            )}
           </StyledStatusIndicator>
         )}
       </StyledAvatar>

--- a/packages/avatars/src/elements/Avatar.tsx
+++ b/packages/avatars/src/elements/Avatar.tsx
@@ -94,8 +94,10 @@ const AvatarComponent = forwardRef<HTMLElement, IAvatarProps>(
               <span aria-hidden>{badge}</span>
             ) : (
               <>
-                {computedStatus === 'away' ? <ClockIcon /> : null}
-                {computedStatus === 'transfers' ? <ArrowLeftIcon /> : null}
+                {computedStatus === 'away' ? <ClockIcon data-icon-status={computedStatus} /> : null}
+                {computedStatus === 'transfers' ? (
+                  <ArrowLeftIcon data-icon-status={computedStatus} />
+                ) : null}
               </>
             )}
           </StyledStatusIndicator>

--- a/packages/avatars/src/elements/Avatar.tsx
+++ b/packages/avatars/src/elements/Avatar.tsx
@@ -8,6 +8,7 @@
 import React, { Children, forwardRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useText } from '@zendeskgarden/react-theming';
+import { Span } from '@zendeskgarden/react-typography';
 import ClockIcon12 from '@zendeskgarden/svg-icons/src/12/clock-stroke.svg';
 import ClockIcon16 from '@zendeskgarden/svg-icons/src/16/clock-stroke.svg';
 import ArrowLeftIcon12 from '@zendeskgarden/svg-icons/src/12/arrow-left-sm-stroke.svg';
@@ -17,7 +18,6 @@ import { IAvatarProps, SIZE, STATUS } from '../types';
 import { StyledAvatar, StyledStatusIndicator } from '../styled';
 
 import { Text } from './components/Text';
-import { Span } from '@zendeskgarden/react-typography';
 
 const AvatarComponent = forwardRef<HTMLElement, IAvatarProps>(
   (

--- a/packages/avatars/src/styled/StyledAvatar.ts
+++ b/packages/avatars/src/styled/StyledAvatar.ts
@@ -153,7 +153,7 @@ const sizeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
     height: ${size} !important; /* [1] */
     /* stylelint-enable declaration-no-important */
 
-    ::before {
+    &::before {
       box-shadow: ${boxShadow};
     }
 


### PR DESCRIPTION
## Description

This PR addresses two problems with the `Avatar` component:
- missing `box-shadow` status ring (due to stricter `&` reference with styled-components v7)
- problematic `statusLabel` accessibility structure detailed in the image below


## Detail

<img width="612" alt="Screenshot 2025-05-30 at 3 26 16 PM" src="https://github.com/user-attachments/assets/b59a3258-086e-4fcd-8f02-aa8ccf9c3c31" />

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :black_circle: renders as expected in dark mode
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
