### PR TITLE
fix(tooltips): prevent `Tooltip` from interfering with a popup (menu, dialog, etc.) trigger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12346,14 +12346,13 @@
       }
     },
     "node_modules/@zendeskgarden/container-tooltip": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-tooltip/-/container-tooltip-1.0.20.tgz",
-      "integrity": "sha512-D1cC531nglG7e2wrU5q1c4eO7JGb/9FciOsEsZZOdU+84u7E2aGBTWTD1F+6lFZ2Ns9kj78FBCEU4Pxg3vIwiw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-tooltip/-/container-tooltip-2.0.0.tgz",
+      "integrity": "sha512-jJeEbt3ssn0ZdcYR9p0ojkaP3UiIronkhZV6XbPzz7lyFVxjWkhBtSwJO4a3UUAuot+qffQuGbKmA8aLv7YFBg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
-        "@zendeskgarden/container-utilities": "^2.0.2",
-        "react-uid": "^2.2.0"
+        "@zendeskgarden/container-utilities": "^2.0.2"
       },
       "peerDependencies": {
         "prop-types": "^15.6.1",
@@ -31244,6 +31243,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -31283,6 +31324,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.14.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
@@ -31298,11 +31345,33 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -31682,6 +31751,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -34971,6 +35056,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.15.1",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.15.1.tgz",
@@ -36665,6 +36756,15 @@
         "ipx": "bin/ipx.mjs"
       }
     },
+    "node_modules/netlify-cli/node_modules/ipx/node_modules/@netlify/blobs": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-6.5.0.tgz",
+      "integrity": "sha512-wRFlNnL/Qv3WNLZd3OT/YYqF1zb6iPSo8T31sl9ccL1ahBxW1fBqKgF4b1XL7Z+6mRIkatvcsVPkWBcO+oJMNA==",
+      "extraneous": true,
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
     "node_modules/netlify-cli/node_modules/ipx/node_modules/lru-cache": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
@@ -37219,6 +37319,12 @@
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       }
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",
@@ -52200,13 +52306,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
-        "@zendeskgarden/container-tooltip": "^1.0.16",
+        "@zendeskgarden/container-tooltip": "^2.0.0",
         "@zendeskgarden/container-utilities": "^2.0.0",
         "polished": "^4.3.1",
         "prop-types": "^15.5.7",
         "react-merge-refs": "^2.0.0"
       },
       "devDependencies": {
+        "@zendeskgarden/react-buttons": "^9.7.0",
+        "@zendeskgarden/react-dropdowns": "^9.7.0",
+        "@zendeskgarden/react-grid": "^9.7.0",
         "@zendeskgarden/react-theming": "^9.7.0"
       },
       "peerDependencies": {

--- a/packages/tooltips/demo/~patterns/patterns.stories.mdx
+++ b/packages/tooltips/demo/~patterns/patterns.stories.mdx
@@ -8,11 +8,20 @@ import { MenuStory } from './stories/MenuStory';
 
 ## Menu
 
+The following example demonstrates `Tooltip` behavior together with a popup
+menu. The tooltip is designed to hide when the popup is expanded.
+
 <Canvas>
   <Story
     name="Menu"
-    parameters={{ controls: { include: ['placement'] } }}
-    args={{ placement: 'bottom-start' }}
+    parameters={{ controls: { include: ['appendToNode', 'placement'] } }}
+    args={{
+      appendToNode: false,
+      placement: 'bottom'
+    }}
+    argTypes={{
+      appendToNode: { control: 'boolean' }
+    }}
   >
     {args => <MenuStory {...args} />}
   </Story>

--- a/packages/tooltips/demo/~patterns/patterns.stories.mdx
+++ b/packages/tooltips/demo/~patterns/patterns.stories.mdx
@@ -1,0 +1,19 @@
+import { Meta, Canvas, Story } from '@storybook/addon-docs';
+import { Tooltip } from '@zendeskgarden/react-tooltips';
+import { MenuStory } from './stories/MenuStory';
+
+<Meta title="Packages/Tooltips/[patterns]" component={Tooltip} />
+
+# Patterns
+
+## Menu
+
+<Canvas>
+  <Story
+    name="Menu"
+    parameters={{ controls: { include: ['placement'] } }}
+    args={{ placement: 'bottom-start' }}
+  >
+    {args => <MenuStory {...args} />}
+  </Story>
+</Canvas>

--- a/packages/tooltips/demo/~patterns/stories/MenuStory.tsx
+++ b/packages/tooltips/demo/~patterns/stories/MenuStory.tsx
@@ -6,47 +6,57 @@
  */
 
 import React, { forwardRef } from 'react';
+import { useTheme } from 'styled-components';
 import { StoryFn } from '@storybook/react';
 import Icon from '@zendeskgarden/svg-icons/src/16/leaf-stroke.svg';
+import { useDocument } from '@zendeskgarden/react-theming';
 import { Grid } from '@zendeskgarden/react-grid';
 import { Menu, Item, IMenuProps } from '@zendeskgarden/react-dropdowns';
 import { ITooltipProps, Tooltip } from '@zendeskgarden/react-tooltips';
 import { IButtonProps, IconButton } from '@zendeskgarden/react-buttons';
 
 interface IMenuButtonProps extends IButtonProps {
+  appendToNode: boolean;
   placement: IMenuProps['placement'];
 }
 
 const MenuButton = forwardRef<HTMLButtonElement, IMenuButtonProps>(
-  ({ placement, ...props }, ref) => (
-    <Tooltip content="Menu" placement={placement}>
-      <IconButton {...props} ref={ref}>
-        <Icon />
-      </IconButton>
-    </Tooltip>
-  )
+  ({ appendToNode, placement, ...props }, ref) => {
+    const theme = useTheme();
+    const body = useDocument(theme)?.body;
+
+    return (
+      <Tooltip content="Menu" placement={placement} appendToNode={appendToNode ? body : undefined}>
+        <IconButton {...props} ref={ref}>
+          <Icon />
+        </IconButton>
+      </Tooltip>
+    );
+  }
 );
 
 MenuButton.displayName = 'MenuButton';
 
-export const MenuStory: StoryFn<ITooltipProps> = ({ placement }) => {
-  return (
-    <Grid>
-      <Grid.Row style={{ height: 'calc(100vh - 80px)' }}>
-        <Grid.Col textAlign="center" alignSelf="center">
-          <Menu
-            button={
-              /* eslint-disable-next-line react/no-unstable-nested-components */
-              props => <MenuButton placement={placement} {...props} />
-            }
-            placement={placement}
-          >
-            <Item value="One" />
-            <Item value="Two" />
-            <Item value="Three" />
-          </Menu>
-        </Grid.Col>
-      </Grid.Row>
-    </Grid>
-  );
-};
+interface IArgs extends Omit<ITooltipProps, 'appendToNode'> {
+  appendToNode: boolean;
+}
+
+export const MenuStory: StoryFn<IArgs> = ({ appendToNode, placement }) => (
+  <Grid>
+    <Grid.Row style={{ height: 'calc(100vh - 80px)' }}>
+      <Grid.Col textAlign="center" alignSelf="center">
+        <Menu
+          button={
+            /* eslint-disable-next-line react/no-unstable-nested-components */
+            props => <MenuButton appendToNode={appendToNode} placement={placement} {...props} />
+          }
+          placement={placement}
+        >
+          <Item value="One" />
+          <Item value="Two" />
+          <Item value="Three" />
+        </Menu>
+      </Grid.Col>
+    </Grid.Row>
+  </Grid>
+);

--- a/packages/tooltips/demo/~patterns/stories/MenuStory.tsx
+++ b/packages/tooltips/demo/~patterns/stories/MenuStory.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { forwardRef } from 'react';
+import { StoryFn } from '@storybook/react';
+import Icon from '@zendeskgarden/svg-icons/src/16/leaf-stroke.svg';
+import { Grid } from '@zendeskgarden/react-grid';
+import { Menu, Item, IMenuProps } from '@zendeskgarden/react-dropdowns';
+import { ITooltipProps, Tooltip } from '@zendeskgarden/react-tooltips';
+import { IButtonProps, IconButton } from '@zendeskgarden/react-buttons';
+
+interface IMenuButtonProps extends IButtonProps {
+  placement: IMenuProps['placement'];
+}
+
+const MenuButton = forwardRef<HTMLButtonElement, IMenuButtonProps>(
+  ({ placement, ...props }, ref) => (
+    <Tooltip content="Menu" placement={placement}>
+      <IconButton {...props} ref={ref}>
+        <Icon />
+      </IconButton>
+    </Tooltip>
+  )
+);
+
+MenuButton.displayName = 'MenuButton';
+
+export const MenuStory: StoryFn<ITooltipProps> = ({ placement }) => {
+  return (
+    <Grid>
+      <Grid.Row style={{ height: 'calc(100vh - 80px)' }}>
+        <Grid.Col textAlign="center" alignSelf="center">
+          <Menu
+            button={
+              /* eslint-disable-next-line react/no-unstable-nested-components */
+              props => <MenuButton placement={placement} {...props} />
+            }
+            placement={placement}
+          >
+            <Item value="One" />
+            <Item value="Two" />
+            <Item value="Three" />
+          </Menu>
+        </Grid.Col>
+      </Grid.Row>
+    </Grid>
+  );
+};

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -35,6 +35,9 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
+    "@zendeskgarden/react-buttons": "^9.7.0",
+    "@zendeskgarden/react-dropdowns": "^9.7.0",
+    "@zendeskgarden/react-grid": "^9.7.0",
     "@zendeskgarden/react-theming": "^9.7.0"
   },
   "keywords": [

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -22,7 +22,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
-    "@zendeskgarden/container-tooltip": "^1.0.16",
+    "@zendeskgarden/container-tooltip": "^2.0.0",
     "@zendeskgarden/container-utilities": "^2.0.0",
     "polished": "^4.3.1",
     "prop-types": "^15.5.7",

--- a/packages/tooltips/src/elements/Tooltip.tsx
+++ b/packages/tooltips/src/elements/Tooltip.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { cloneElement, useRef, useEffect, useContext } from 'react';
+import React, { cloneElement, useRef, useEffect, useContext, HTMLAttributes } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';
@@ -99,16 +99,16 @@ export const TooltipComponent = ({
       aria-hidden={!controlledIsVisible}
     >
       <StyledTooltip
+        $hasArrow={hasArrow}
+        $placement={placement}
+        $size={toSize(size, type)}
+        $type={type}
         {...(getTooltipProps({
           'aria-hidden': !controlledIsVisible,
-          $hasArrow: hasArrow,
-          $placement: placement,
-          $size: toSize(size, type),
-          $type: type,
           onBlur: composeEventHandlers(onBlur, () => closeTooltip(0)),
           onFocus: composeEventHandlers(onFocus, openTooltip),
           ...props
-        }) as any)}
+        }) as HTMLAttributes<HTMLDivElement>)}
       >
         {content}
       </StyledTooltip>

--- a/packages/tooltips/src/elements/Tooltip.tsx
+++ b/packages/tooltips/src/elements/Tooltip.tsx
@@ -48,7 +48,8 @@ export const TooltipComponent = ({
   const { isVisible, getTooltipProps, getTriggerProps, openTooltip, closeTooltip } = useTooltip({
     id,
     delayMilliseconds: delayMS,
-    isVisible: isInitialVisible
+    isVisible: isInitialVisible,
+    triggerRef
   });
 
   const controlledIsVisible = getControlledValue(externalIsVisible, isVisible);

--- a/packages/tooltips/src/styled/StyledTooltip.ts
+++ b/packages/tooltips/src/styled/StyledTooltip.ts
@@ -24,7 +24,7 @@ interface IStyledTooltipProps {
   $hasArrow: ITooltipProps['hasArrow'];
   $placement: Placement;
   $size: NonNullable<ITooltipProps['size']>;
-  $type: NonNullable<ITooltipProps['type']>;
+  $type: ITooltipProps['type'];
 }
 
 const sizeStyles = ({


### PR DESCRIPTION
## Description

Upgrades to `@zendeskgarden/container-tooltip` v2.0.0 and adds a menu pattern story to demonstrate that tooltips are dismissed when an associated trigger popup is opened.

## Detail

Important note: we need to revisit the `container-tooltip` at some point to add a document listener (similar to the work done with `container-menu` that catches all un-focus events. Currently, the auto refocus to the trigger on menu close re-opens the tooltip. This is currently expected, but not the ultimate desired outcome. That bug will be dealt with under separate PRs.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :black_circle: ~renders as expected in dark mode~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
