### PR TITLE
fix(notifications): update `GlobalAlert` box-shadow to inset

### DIFF
--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlert.spec.tsx
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlert.spec.tsx
@@ -45,7 +45,7 @@ describe('StyledGlobalAlert', () => {
 
     expect(container.firstChild).toHaveStyleRule(
       'box-shadow',
-      `0 ${DEFAULT_THEME.borderWidths.sm} ${DEFAULT_THEME.borderWidths.sm} ${color}`
+      `inset 0 -${DEFAULT_THEME.borderWidths.sm} 0 ${color}`
     );
   });
 });

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlert.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlert.ts
@@ -74,7 +74,7 @@ const colorStyles = ({ theme, $alertType }: ThemeProps<DefaultTheme> & IStyledGl
   }
 
   // Apply a border without affecting the element's size
-  const boxShadow = `0 ${theme.borderWidths.sm} ${theme.borderWidths.sm} ${borderColor}`;
+  const boxShadow = `inset 0 -${theme.borderWidths.sm} 0 ${borderColor}`;
 
   /* stylelint-disable selector-no-qualifying-type */
   return css`


### PR DESCRIPTION
## Description

The original `GlobalAlert` was designed to support stacking by defining a bottom border. The implementation used `box-shadow` to avoid affecting size. However, without `inset` the "border" was cut off. This PR fixes `GlobalAlert` to honor the original design intent.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [ ] :globe_with_meridians: ~demo is up-to-date (`npm start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :black_circle: renders as expected in dark mode
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
