### PR TITLE
feat(avatars): allow `null` aria-label on `StatusIndicator` to mark as decorative

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14890,9 +14890,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001668",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001668.tgz",
-      "integrity": "sha512-nWLrdxqCdblixUO+27JtGJJE/txpJlyUy5YN1u53wLZkP0emYCo5zgS6QYft7VUYR42LGgi/S5hdLZTrnyIddw==",
+      "version": "1.0.30001727",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
+      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
       "dev": true,
       "funding": [
         {
@@ -31243,6 +31243,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -31282,6 +31324,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.14.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
@@ -31297,11 +31345,33 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -31681,6 +31751,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -34970,6 +35056,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.15.1",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.15.1.tgz",
@@ -36664,6 +36756,15 @@
         "ipx": "bin/ipx.mjs"
       }
     },
+    "node_modules/netlify-cli/node_modules/ipx/node_modules/@netlify/blobs": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-6.5.0.tgz",
+      "integrity": "sha512-wRFlNnL/Qv3WNLZd3OT/YYqF1zb6iPSo8T31sl9ccL1ahBxW1fBqKgF4b1XL7Z+6mRIkatvcsVPkWBcO+oJMNA==",
+      "extraneous": true,
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
     "node_modules/netlify-cli/node_modules/ipx/node_modules/lru-cache": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
@@ -37218,6 +37319,12 @@
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       }
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",

--- a/packages/avatars/demo/~patterns/stories/StatusMenuStory.tsx
+++ b/packages/avatars/demo/~patterns/stories/StatusMenuStory.tsx
@@ -43,22 +43,22 @@ export const StatusMenuStory: Story = ({ isCompact }) => {
             isCompact={isCompact}
           >
             <Item value="offline">
-              <StatusIndicator isCompact={isCompact} type="offline">
+              <StatusIndicator aria-label={null} isCompact={isCompact} type="offline">
                 Offline
               </StatusIndicator>
             </Item>
             <Item value="available">
-              <StatusIndicator isCompact={isCompact} type="available">
+              <StatusIndicator aria-label={null} isCompact={isCompact} type="available">
                 Online
               </StatusIndicator>
             </Item>
             <Item value="transfers">
-              <StatusIndicator isCompact={isCompact} type="transfers">
+              <StatusIndicator aria-label={null} isCompact={isCompact} type="transfers">
                 Transfers only
               </StatusIndicator>
             </Item>
             <Item value="away">
-              <StatusIndicator isCompact={isCompact} type="away">
+              <StatusIndicator aria-label={null} isCompact={isCompact} type="away">
                 Away
               </StatusIndicator>
             </Item>

--- a/packages/avatars/src/elements/StatusIndicator.spec.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.spec.tsx
@@ -55,5 +55,13 @@ describe('StatusIndicator', () => {
 
       expect(getByRole('img')).toHaveAttribute('aria-label', `status: ${type}`);
     });
+
+    it.each(STATUS)('renders "$1" status type, and with aria label removed', type => {
+      const { container } = render(<StatusIndicator aria-label={null} type={type} />);
+      const imgElement = container.firstChild?.firstChild;
+
+      expect(imgElement).not.toHaveAttribute('aria-label');
+      expect(imgElement).toHaveAttribute('aria-hidden');
+    });
   });
 });

--- a/packages/avatars/src/elements/StatusIndicator.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.tsx
@@ -41,7 +41,13 @@ export const StatusIndicator = forwardRef<HTMLElement, IStatusIndicatorProps>(
     }
 
     const defaultLabel = useMemo(() => ['status'].concat(type || []).join(': '), [type]);
-    const ariaLabel = useText(StatusIndicator, { 'aria-label': label }, 'aria-label', defaultLabel);
+    const ariaLabel = useText(
+      StatusIndicator,
+      { 'aria-label': label },
+      'aria-label',
+      defaultLabel,
+      label !== null
+    );
 
     return (
       // [1]
@@ -50,10 +56,11 @@ export const StatusIndicator = forwardRef<HTMLElement, IStatusIndicatorProps>(
         {/* [2] */}
         {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
         <StyledStandaloneStatusIndicator
+          aria-hidden={label === null ? true : undefined}
+          aria-label={ariaLabel}
           role="img"
           $type={type}
           $size={isCompact ? 'small' : 'medium'}
-          aria-label={ariaLabel}
         >
           {type === 'away' ? <ClockIcon data-icon-status={type} aria-hidden="true" /> : null}
           {type === 'transfers' ? (
@@ -69,6 +76,7 @@ export const StatusIndicator = forwardRef<HTMLElement, IStatusIndicatorProps>(
 StatusIndicator.displayName = 'StatusIndicator';
 
 StatusIndicator.propTypes = {
+  'aria-label': PropTypes.string,
   type: PropTypes.oneOf(STATUS),
   isCompact: PropTypes.bool
 };

--- a/packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -25,7 +25,8 @@ const COMPONENT_ID = 'avatars.status_indicator';
 const [xxs, xs, s, m, l] = SIZE;
 
 const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
-  const isVisible = !includes([xxs, xs], props.$size);
+  const isVisible = props.$size !== xxs;
+  const iconSize = props.$size === xs ? `${props.theme.space.base * 2}px` : undefined;
   const borderWidth = getStatusBorderOffset(props);
 
   let padding = '0';
@@ -58,6 +59,8 @@ const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => 
 
     & > svg {
       ${!isVisible && 'display: none;'}
+      width: ${iconSize};
+      height: ${iconSize};
     }
   `;
 };

--- a/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
@@ -57,7 +57,7 @@ const sizeStyles = (props: IStyledStatusIndicatorProps) => {
       /* stylelint-disable-next-line selector-no-qualifying-type */
       &[data-icon-status='transfers'] {
         transform: scale(${props.theme.rtl ? -1 : 1}, 1);
-        inset-inline-start: -1px; /* [3] */
+        inset-inline-start: ${props.$size === 'extrasmall' ? '-1px' : undefined}; /* [3] */
       }
 
       /* stylelint-disable-next-line selector-no-qualifying-type */

--- a/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
@@ -37,6 +37,7 @@ const sizeStyles = (props: IStyledStatusIndicatorProps) => {
    *    we need to remove the circle
    * 2. when @zendeskgarden/css-bedrock is present, max-height needs to be unset due to icon being
    *    resized incorrectly
+   * 3. prevent arrowhead cutting off in the transfers icon
    */
   return css`
     border: ${offset} ${props.theme.borderStyles.solid};
@@ -48,7 +49,7 @@ const sizeStyles = (props: IStyledStatusIndicatorProps) => {
     & > svg {
       position: absolute;
       top: -${offset};
-      left: -${offset};
+      inset-inline-start: -${offset};
       transform-origin: 50% 50%;
       animation: ${iconFadeIn} ${TRANSITION_DURATION}s;
       max-height: unset; /* [2] */
@@ -56,6 +57,7 @@ const sizeStyles = (props: IStyledStatusIndicatorProps) => {
       /* stylelint-disable-next-line selector-no-qualifying-type */
       &[data-icon-status='transfers'] {
         transform: scale(${props.theme.rtl ? -1 : 1}, 1);
+        inset-inline-start: -1px; /* [3] */
       }
 
       /* stylelint-disable-next-line selector-no-qualifying-type */

--- a/packages/avatars/src/types/index.ts
+++ b/packages/avatars/src/types/index.ts
@@ -44,7 +44,9 @@ export interface IAvatarProps extends HTMLAttributes<HTMLElement> {
   badge?: string | number;
 }
 
-export interface IStatusIndicatorProps extends HTMLAttributes<HTMLElement> {
+export interface IStatusIndicatorProps extends Omit<HTMLAttributes<HTMLElement>, 'aria-label'> {
+  /** Overrides the label for the status indicator. Use `null` to mark the indicator as decorative. */
+  'aria-label'?: string | null;
   /** Applies status type for styling and default aria-label */
   type?: (typeof STATUS)[number];
   /** Applies compact styling */


### PR DESCRIPTION
## Description

Used to prevent a duplicate screenreader output of "status: online, image Online" when the `<StatusIndicator>` is used within an interactive context – such as a status menu.

## Detail

Emerging designs are calling for the `extrasmall` avatar to render its status SVG. The updates look like this...

<img width="37" height="38" alt="Screenshot 2025-07-15 at 4 41 32 PM" src="https://github.com/user-attachments/assets/e4b1c0f0-69b5-412b-b891-92ce9e99703c" />
<img width="38" height="35" alt="Screenshot 2025-07-15 at 4 42 16 PM" src="https://github.com/user-attachments/assets/7c1d83da-b9c0-4b3d-8e7e-3c45c00efb1e" />

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :black_circle: ~renders as expected in dark mode~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
