### PR TITLE
fix(modals): change StyledModal's max-height, when viewport max-height is less than 400 CSS px

### DIFF
--- a/packages/modals/src/styled/StyledModal.spec.tsx
+++ b/packages/modals/src/styled/StyledModal.spec.tsx
@@ -22,6 +22,10 @@ describe('StyledModal', () => {
     expect(container.firstChild).not.toHaveStyleRule('direction');
     expect(container.firstChild).not.toHaveStyleRule('animation-duration', '0.3s');
     expect(container.firstChild).not.toHaveStyleRule('animation-timing-function', 'ease-in-out');
+    expect(container.firstChild).toHaveStyleRule('max-height', 'calc(100vh - 96px)');
+    expect(container.firstChild).toHaveStyleRule('max-height', 'calc(100vh - 48px)', {
+      media: `(max-height:  399px)`
+    });
   });
 
   it('renders RTL styling if provided', () => {

--- a/packages/modals/src/styled/StyledModal.ts
+++ b/packages/modals/src/styled/StyledModal.ts
@@ -100,7 +100,7 @@ export const StyledModal = styled.div.attrs<IStyledModalProps>({
     top: ${props => props.theme.space.base * 6}px;
     bottom: auto;
     margin-bottom: ${props => props.theme.space.base * 6}px;
-    max-height: none;
+    max-height: calc(100vh - ${props => props.theme.space.base * 12}px);
   }
 
   @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

While reviewing outstanding accessibility bugs related to [WCAG 2.2 SC 1.4.4, Resize Text](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html), Zendesk's Product Accessibility team discovered that the Modal component was at the root of several bugs assigned to consuming teams. At some point, code was introduced into the Modal that causes the scrollbar within its main body — the one that normally allows users to view overflow content — to disappear, when the viewport is 400 CSS pixels or shorter.

This PR adjusts the Modal's `max-height` on shorter viewports, so that the vertical scrollbar will appear, as expected.

## Detail

### Before

`max-height: none;` set on `role="dialog"` element causes Modal body's scrollbar to become hidden when viewport is less than 400px tall. This prevents users from viewing overflow content.

<img width="2560" height="1250" alt="Garden Modal in Storybook on production, within a 2560px by 320px viewport" src="https://github.com/user-attachments/assets/74ae37e0-9182-405c-b2cd-5869c11014a9" />


### After

`max-height: calc(100vh - 48px;` set on `role="dialog"` element causes Modal body's scrollbar to become visible when viewport is less than 400px tall. This allows users to view overflow content.

<img width="2560" height="1250" alt="Garden Modal in Storybook on localhost, within a 2560px by 320px viewport" src="https://github.com/user-attachments/assets/567b11a7-dd11-4819-a812-08fe3bd97d04" />


<!-- closes GITHUB_ISSUE -->

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :black_circle: renders as expected in dark mode
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
