### PR TITLE
fix(dropdowns): ensure Menu closes on outside click when nested item is auto-focused

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51904,7 +51904,7 @@
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
         "@zendeskgarden/container-combobox": "^2.0.5",
-        "@zendeskgarden/container-menu": "1.0.1",
+        "@zendeskgarden/container-menu": "^1.0.1",
         "@zendeskgarden/container-utilities": "^2.0.0",
         "@zendeskgarden/react-buttons": "^9.8.0",
         "@zendeskgarden/react-forms": "^9.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12197,9 +12197,9 @@
       }
     },
     "node_modules/@zendeskgarden/container-menu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-menu/-/container-menu-1.0.0.tgz",
-      "integrity": "sha512-GnG3IqKBmuNkbnDp9bHnwHpGyy/4/MUe3RmaDllVQNyG+uP0BsGondCRWZQE1ULwjfbGBeadAawQhEJcdoSPSA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-menu/-/container-menu-1.0.1.tgz",
+      "integrity": "sha512-mc8cukVZz9Uko++M+tuOI5yUtWAQ18+60IkazyHZ5hElb2flzVjbLlbQHTsljfYmau6JHJKV4m3zjvJEpHe41A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
@@ -51904,7 +51904,7 @@
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
         "@zendeskgarden/container-combobox": "^2.0.5",
-        "@zendeskgarden/container-menu": "^1.0.0",
+        "@zendeskgarden/container-menu": "1.0.1",
         "@zendeskgarden/container-utilities": "^2.0.0",
         "@zendeskgarden/react-buttons": "^9.8.0",
         "@zendeskgarden/react-forms": "^9.8.0",

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
     "@zendeskgarden/container-combobox": "^2.0.5",
-    "@zendeskgarden/container-menu": "1.0.1",
+    "@zendeskgarden/container-menu": "^1.0.1",
     "@zendeskgarden/container-utilities": "^2.0.0",
     "@zendeskgarden/react-buttons": "^9.8.0",
     "@zendeskgarden/react-forms": "^9.8.0",

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
     "@zendeskgarden/container-combobox": "^2.0.5",
-    "@zendeskgarden/container-menu": "^1.0.0",
+    "@zendeskgarden/container-menu": "1.0.1",
     "@zendeskgarden/container-utilities": "^2.0.0",
     "@zendeskgarden/react-buttons": "^9.8.0",
     "@zendeskgarden/react-forms": "^9.8.0",


### PR DESCRIPTION

## Description
Description
This PR is a follow-up to https://github.com/zendeskgarden/react-containers/pull/699 and resolves an issue where clicking outside a menu dropdown does not close it when a nested item is auto-focused.

## Detail

### Before

https://github.com/user-attachments/assets/ae46dcb4-9132-45b7-92b1-ad2a9d7a46e1

## After

https://github.com/user-attachments/assets/209e9f36-1320-4934-98cf-1ac147e44c75



## Checklist


- ~~[ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- ~~[ ] :black_circle: renders as expected in dark mode~~
- ~~[ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~[ ] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
