### PR TITLE
fix(tables): cross-browser border styling for headers

### DIFF
--- a/packages/tables/src/styled/StyledHead.ts
+++ b/packages/tables/src/styled/StyledHead.ts
@@ -8,6 +8,7 @@
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import { componentStyles, getColor } from '@zendeskgarden/react-theming';
 import { StyledHeaderRow } from './StyledHeaderRow';
+import { StyledHeaderCell } from './StyledHeaderCell';
 
 const COMPONENT_ID = 'tables.head';
 
@@ -23,11 +24,14 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const backgroundColor = getColor({ variable: 'background.default', theme });
 
   return css`
-    box-shadow: inset 0 -${theme.borderWidths.sm} 0 ${borderColor}; /* [1] */
     background-color: ${backgroundColor};
 
     & > ${StyledHeaderRow}:last-child {
       border-bottom-color: transparent; /* [1] */
+
+      & > ${StyledHeaderCell} {
+        box-shadow: inset 0 -${theme.borderWidths.sm} 0 ${borderColor}; /* [1] */
+      }
     }
   `;
 };


### PR DESCRIPTION
## Description

Fixes missing header border treatment in Safari. While I'm not loving taking the `box-shadow` border out of the `thead` block and applying it to the individual `th` elements, Safari will not display it with a sticky header + Garden tables designed around `border-collapse: collapse`.

## Detail

Technically, this was broken in Safari for v8 [scrolling tables](https://zendeskgarden-v8.netlify.app/components/table#scroll) with #1482. And subsequently spread to all Safari tables with the v9 color work and styling simplification in #1833.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :black_circle: renders as expected in dark mode
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
