### PR TITLE
feat(react-tooltips): suppress tooltips that normally trigger on focus immediately after closing expanded popups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12346,13 +12346,13 @@
       }
     },
     "node_modules/@zendeskgarden/container-tooltip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-tooltip/-/container-tooltip-2.0.0.tgz",
-      "integrity": "sha512-jJeEbt3ssn0ZdcYR9p0ojkaP3UiIronkhZV6XbPzz7lyFVxjWkhBtSwJO4a3UUAuot+qffQuGbKmA8aLv7YFBg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-tooltip/-/container-tooltip-2.1.0.tgz",
+      "integrity": "sha512-j/9zUD4kzrEkoqxO22tvlX2jHPlZF2JeWa1ambH5YuMC+pniJduOg7sXT4G7Gor5FlIa6TSURSnfsr6DDJtOSA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
-        "@zendeskgarden/container-utilities": "^2.0.2"
+        "@zendeskgarden/container-utilities": "^2.0.3"
       },
       "peerDependencies": {
         "prop-types": "^15.6.1",
@@ -12361,9 +12361,9 @@
       }
     },
     "node_modules/@zendeskgarden/container-utilities": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-utilities/-/container-utilities-2.0.2.tgz",
-      "integrity": "sha512-IvPxhHwR8AaaZuS7yZM4Ea0GLgrfTblbNd+4fWbg8a4zioExdMU8uy036cjL97A0Ega7v++PAqFLR3Y9dWCNRQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-utilities/-/container-utilities-2.0.3.tgz",
+      "integrity": "sha512-yuKvmlxw8InxdFuzRBUQc0xYn1pSgMZn4F5TMLJfHIas3FmFxNbwIB5njkQAc4tI5yXco65QX/FOvVHlQklyEg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
@@ -52200,7 +52200,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
-        "@zendeskgarden/container-tooltip": "^2.0.0",
+        "@zendeskgarden/container-tooltip": "^2.1.0",
         "@zendeskgarden/container-utilities": "^2.0.0",
         "polished": "^4.3.1",
         "prop-types": "^15.5.7",

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -22,7 +22,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
-    "@zendeskgarden/container-tooltip": "^2.0.0",
+    "@zendeskgarden/container-tooltip": "^2.1.0",
     "@zendeskgarden/container-utilities": "^2.0.0",
     "polished": "^4.3.1",
     "prop-types": "^15.5.7",


### PR DESCRIPTION
## Description

This PR builds on the work from [#700](https://github.com/zendeskgarden/react-containers/pull/700). It updates the `Tooltip` component so that tooltips no longer appear immediately on focus after closing expanded popups, like menu dropdowns. This makes the UX smoother and less distracting.

## Detail

### Before
https://github.com/user-attachments/assets/cb8ed237-71a1-442d-b677-235a2860c3f2

### After
Tooltip no longer shows when focus is returned to the `Menu` trigger.

https://github.com/user-attachments/assets/aebcd35d-647a-4275-94b2-4f522ca48fc2


## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:black_circle: renders as expected in dark mode~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
