### PR TITLE
fix(modals): prevent `useText` evaluation until fully mounted

### DIFF
--- a/packages/modals/src/elements/Drawer/Drawer.tsx
+++ b/packages/modals/src/elements/Drawer/Drawer.tsx
@@ -144,7 +144,13 @@ const DrawerComponent = forwardRef<HTMLDivElement, IDrawerProps>(
     const labelValue = hasHeader ? modalProps['aria-labelledby'] : props['aria-label'];
 
     const ariaProps = {
-      [attribute]: useText(DrawerComponent, { [attribute]: labelValue }, attribute, defaultValue!)
+      [attribute]: useText(
+        DrawerComponent,
+        { [attribute]: labelValue },
+        attribute,
+        defaultValue!,
+        modalRef.current !== null /* prevents `useText` evaluation until fully mounted */
+      )
     };
 
     if (!rootNode) {

--- a/packages/modals/src/elements/Modal.tsx
+++ b/packages/modals/src/elements/Modal.tsx
@@ -160,7 +160,13 @@ export const ModalComponent = forwardRef<HTMLDivElement, IModalProps>(
       : modalProps['aria-label'];
 
     const ariaProps = {
-      [attribute]: useText(ModalComponent, { [attribute]: labelValue }, attribute, defaultValue!)
+      [attribute]: useText(
+        ModalComponent,
+        { [attribute]: labelValue },
+        attribute,
+        defaultValue!,
+        modalRef.current !== null /* prevents `useText` evaluation until fully mounted */
+      )
     };
 
     if (!rootNode) {

--- a/packages/modals/src/elements/TooltipDialog/TooltipDialog.tsx
+++ b/packages/modals/src/elements/TooltipDialog/TooltipDialog.tsx
@@ -133,7 +133,8 @@ const TooltipDialogComponent = React.forwardRef<HTMLDivElement, ITooltipDialogPr
         TooltipDialogComponent,
         { [attribute]: labelValue },
         attribute,
-        defaultValue!
+        defaultValue!,
+        modalRef.current !== null /* prevents `useText` evaluation until fully mounted */
       )
     };
 


### PR DESCRIPTION
## Description

Modals with valid `aria-labelledby` were getting `useText` console warnings. This PR addresses that.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :black_circle: ~renders as expected in dark mode~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
