### PR TITLE
fix(forms): Added role="switch" to Toggle component, per APG Switch Pattern

### DIFF
--- a/packages/forms/src/elements/Toggle.spec.tsx
+++ b/packages/forms/src/elements/Toggle.spec.tsx
@@ -23,6 +23,16 @@ describe('Toggle', () => {
     expect(toggle).toHaveAttribute('type', 'checkbox');
   });
 
+  it('is rendered with the switch role', () => {
+    const { queryByRole } = render(
+      <Field>
+        <Toggle data-test-id="toggle" />
+      </Field>
+    );
+
+    expect(queryByRole('switch')).toBeInTheDocument();
+  });
+
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLInputElement>();
     const { getByTestId } = render(

--- a/packages/forms/src/elements/Toggle.tsx
+++ b/packages/forms/src/elements/Toggle.tsx
@@ -24,7 +24,8 @@ export const Toggle = React.forwardRef<HTMLInputElement, IToggleProps>(
     let combinedProps = {
       $isCompact: fieldsetContext ? fieldsetContext.isCompact : isCompact,
       ref,
-      ...other
+      ...other,
+      role: 'switch'
     } as any;
 
     if (fieldContext) {


### PR DESCRIPTION
## Description

While testing a new feature for accessibility, Zendesk's Product Accessibility team discovered that the [Toggle component](https://garden.zendesk.com/components/toggle)'s `input` element was missing `role="switch"`. 

According to the [APG Switch Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/switch/), it's important to add the `switch` role to controls that can't enter a `mixed` state:

> A [switch](https://w3c.github.io/aria/#switch) is an input widget that allows users to choose one of two values: on or off. Switches are similar to [checkboxes](https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/) and [toggle buttons](https://www.w3.org/WAI/ARIA/apg/patterns/button/), which can also serve as binary inputs. One difference, however, is that switches can only be used for binary input while checkboxes and toggle buttons allow implementations the option of supporting a third middle state. Checkboxes can be checked or not checked and can optionally also allow for a partially checked state. Toggle buttons can be pressed or not pressed and can optionally allow for a partially pressed state.

## Detail

### Before 

Toggle component has implicit `role="checkbox"`

<img width="2559" height="1314" alt="Screenshot 2025-08-25 at 5 21 23 PM" src="https://github.com/user-attachments/assets/6d087914-ecf2-4227-b228-2613c993ba80" />

### After

Toggle component has explicit `role="switch"`

<img width="2560" height="1314" alt="Screenshot 2025-08-25 at 5 21 34 PM" src="https://github.com/user-attachments/assets/1e48566f-9936-4951-b2e2-4c7bd5c220d4" />

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :black_circle: renders as expected in dark mode
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
