### PR TITLE
fix(typography): improve `Kbd` font

### DIFF
--- a/packages/typography/demo/kbd.stories.mdx
+++ b/packages/typography/demo/kbd.stories.mdx
@@ -12,7 +12,7 @@ import README from '../README.md';
 # Demo
 
 <Canvas>
-  <Story name="Kbd" args={{ children: '⌃ ⌥ /', size: 'inherit' }}>
+  <Story name="Kbd" args={{ children: '⇧ ⌃ ⌥ /', size: 'inherit' }}>
     {args => <KbdStory {...args} />}
   </Story>
 </Canvas>

--- a/packages/typography/src/styled/StyledKbd.ts
+++ b/packages/typography/src/styled/StyledKbd.ts
@@ -18,23 +18,28 @@ interface IStyledKbdProps extends ThemeProps<DefaultTheme> {
 }
 
 const sizeStyles = ({ theme, $size }: IStyledKbdProps) => {
+  let minWidth;
   let paddingHorizontal;
   let paddingVertical = '0';
 
   switch ($size) {
     case 'small':
+      minWidth = math(`${theme.lineHeights.sm} - 1px`);
       paddingHorizontal = `${theme.space.base}px`;
       break;
 
     case 'medium':
+      minWidth = math(`${theme.lineHeights.md} - 1px`);
       paddingHorizontal = `${theme.space.base * 1.5}px`;
       break;
 
     case 'large':
+      minWidth = math(`${theme.lineHeights.lg} - 1px`);
       paddingHorizontal = `${theme.space.base * 1.75}px`;
       break;
 
     default:
+      minWidth = 'calc(1.2em + 3px)'; // "normal" line-height + vertical padding
       paddingHorizontal = `${stripUnit(math(`${theme.space.base * 1.5} / (${theme.fontSizes.md} - 1px)`))}em`;
       paddingVertical = '1.5px';
       break;
@@ -44,13 +49,17 @@ const sizeStyles = ({ theme, $size }: IStyledKbdProps) => {
 
   return css`
     && {
+      box-sizing: border-box;
       padding: ${padding};
+      min-width: ${minWidth};
     }
   `;
 };
 
 /*
  * 1. Force left-to-right text direction
+ * 2. Prevent the monospace stack fallback, which doesn't render individual
+ *    keyboard characters well
  */
 export const StyledKbd = styled(StyledCode as 'kbd').attrs({
   'data-garden-id': COMPONENT_ID,
@@ -59,6 +68,8 @@ export const StyledKbd = styled(StyledCode as 'kbd').attrs({
 })<IStyledKbdProps>`
   display: inline-block; /* [1] */
   direction: ltr; /* [1] */
+  text-align: center;
+  font-family: sans-serif; /* [2] */
 
   ${sizeStyles};
 


### PR DESCRIPTION
## Description

Switch to the well-supported browser `font-family: sans-serif` vs. Garden's monospace font stack. The monospace stack is good for rendering `Code` & `Codeblock`. But substandard when it comes to rendering individual special characters.

## Detail

**Before**

<img width="221" height="53" alt="Screenshot 2025-08-26 at 3 07 15 PM" src="https://github.com/user-attachments/assets/f2239bc7-83fc-48eb-b7a8-2f9d17a01526" />

**After**

<img width="242" height="56" alt="Screenshot 2025-08-26 at 3 07 35 PM" src="https://github.com/user-attachments/assets/ef43aba7-0926-4519-a77f-2eb3e4e35db1" />


## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :black_circle: ~renders as expected in dark mode~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
