### PR TITLE
fix(dropdowns): ensure `Menu` item anchors do not render with underline styling

### DIFF
--- a/packages/dropdowns/src/views/menu/StyledItemAnchor.ts
+++ b/packages/dropdowns/src/views/menu/StyledItemAnchor.ts
@@ -12,6 +12,9 @@ import { StyledOption } from '../combobox/StyledOption';
 
 const COMPONENT_ID = 'dropdowns.menu.item_anchor';
 
+/*
+ * 1. Ensure hover styling doesn't leak through
+ */
 export const StyledItemAnchor = styled(StyledOption).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
@@ -19,6 +22,10 @@ export const StyledItemAnchor = styled(StyledOption).attrs({
 })`
   text-decoration: none;
   color: unset;
+
+  &&:hover {
+    text-decoration: none; /* [1] */
+  }
 
   &[aria-current='page'] > ${StyledItemTypeIcon} {
     opacity: 1;


### PR DESCRIPTION
## Description

Applies styling that prevents global `a:hover` styling from leaking through to `Item` `<a>` elements.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [ ] :globe_with_meridians: ~demo is up-to-date (`npm start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :black_circle: ~renders as expected in dark mode~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
