### PR TITLE
fix(dropdowns): prevent menu `Item` anchor hover styling from leaking through

### DIFF
--- a/packages/dropdowns/src/views/menu/StyledItemAnchor.ts
+++ b/packages/dropdowns/src/views/menu/StyledItemAnchor.ts
@@ -25,6 +25,7 @@ export const StyledItemAnchor = styled(StyledOption).attrs({
 
   &&:hover {
     text-decoration: none; /* [1] */
+    color: inherit; /* [1] */
   }
 
   &[aria-current='page'] > ${StyledItemTypeIcon} {


### PR DESCRIPTION
## Description

Seeing some unintended overrides from overly aggressive product global CSS.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [ ] :globe_with_meridians: ~demo is up-to-date (`npm start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :black_circle: renders as expected in dark mode
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
