### PR TITLE
fix(accordion): restore `data-garden-id` and `data-garden-version` attributes on `Accordion.Label`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,10 +63,6 @@ jobs:
           cache: pnpm
 
       - run: pnpm install
-      - uses: actions/download-artifact@v8
-        with:
-          name: dist-artifact
-          path: dist
       - run: pnpm test run --coverage --coverage.reporter lcov
       - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
         with:
           name: dist-artifact
           path: dist
+          include-hidden-files: true
 
   lint:
     needs: [initialize]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,10 @@ jobs:
           cache: pnpm
 
       - run: pnpm install
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist-artifact
+          path: dist
       - run: pnpm test run --coverage --coverage.reporter lcov
       - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:

--- a/src/elements/accordion/Label.tsx
+++ b/src/elements/accordion/Label.tsx
@@ -10,6 +10,7 @@ import { ButtonHTMLAttributes, forwardRef } from 'react';
 import { useAccordionContext } from '../../hooks/accordion/useAccordionContext';
 import { useHeaderContext } from '../../hooks/accordion/useHeaderContext';
 import { StyledLabel } from '../../views/accordion/StyledLabel';
+import { COMPONENT_IDS } from '../utils';
 
 /**
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
@@ -27,6 +28,8 @@ export const Label = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButt
           ...(buttonProps as any) /* HACK to workaround https://github.com/styled-components/styled-components/issues/5652 */
         }
         {...props}
+        data-garden-id={COMPONENT_IDS['accordions.button']}
+        data-garden-version={PACKAGE_VERSION}
         ref={ref}
       />
     );


### PR DESCRIPTION
## Description

Restores the attribute used for styling overrides.

## Detail

The `dist/node_modules` directory was not being uploaded to the CI `dist-artifact` which ends up publishing an invalid package without necessary inline SVG references.

- [before](https://github.com/zendeskgarden/react-components/actions/runs/23313562697/job/67806974192#step:8:13) 55 files
- [after](https://github.com/zendeskgarden/react-components/actions/runs/23315096635/job/67812339390?pr=2114#step:8:13) 57 files (aka, includes the 2 missing built SVGs from `node_modules`)
