### PR TITLE
fix(dropdowns): avoid unwanted page scroll when Combobox mounts or re-renders

### DIFF
--- a/packages/dropdowns/src/elements/combobox/Combobox.spec.tsx
+++ b/packages/dropdowns/src/elements/combobox/Combobox.spec.tsx
@@ -718,4 +718,68 @@ describe('Combobox', () => {
       expect(selectionValue).toMatchObject(['value-2']);
     });
   });
+
+  describe('scrollIntoView', () => {
+    it('does not scroll the input into view on mount', () => {
+      const scrollIntoView = jest.fn();
+
+      window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      render(
+        <TestCombobox>
+          <Option isSelected value="value" />
+        </TestCombobox>
+      );
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+
+    it('does not scroll the input into view on mount with initial selection', () => {
+      const scrollIntoView = jest.fn();
+
+      window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      render(
+        <TestCombobox selectionValue="value">
+          <Option value="value" />
+        </TestCombobox>
+      );
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+
+    it('scrolls the input into view when selection changes after mount', async () => {
+      const scrollIntoView = jest.fn();
+
+      window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      const { getByTestId } = render(
+        <TestCombobox defaultExpanded>
+          <Option data-test-id="option" value="value" />
+        </TestCombobox>
+      );
+
+      // Reset mock to ignore any scrollIntoView calls from Option active state on initial render
+      scrollIntoView.mockClear();
+
+      await user.click(getByTestId('option'));
+
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
+    });
+
+    it('does not scroll the last tag into view on mount for non-editable multiselectable', () => {
+      const scrollIntoView = jest.fn();
+
+      window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      render(
+        <TestCombobox isEditable={false} isMultiselectable selectionValue={['value-1', 'value-2']}>
+          <Option value="value-1" />
+          <Option value="value-2" />
+        </TestCombobox>
+      );
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/dropdowns/src/elements/combobox/Combobox.tsx
+++ b/packages/dropdowns/src/elements/combobox/Combobox.tsx
@@ -249,9 +249,20 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
       return () => messageProps && setMessageProps(undefined);
     }, [getMessageProps, messageProps, setMessageProps]);
 
+    // Derive a stable primitive from selection so the effect only fires when values actually change,
+    // not when the selection object/array reference changes on re-render.
+    const selectionFingerprint = Array.isArray(selection)
+      ? selection.map(o => o.value).join('\0')
+      : (selection?.value ?? null);
+
+    const prevSelectionRef = useRef(selectionFingerprint);
+
     useEffect(() => {
-      inputRef.current?.scrollIntoView?.();
-    }, [selection]);
+      if (prevSelectionRef.current !== selectionFingerprint) {
+        prevSelectionRef.current = selectionFingerprint;
+        inputRef.current?.scrollIntoView?.();
+      }
+    }, [selectionFingerprint]);
 
     return (
       <ComboboxContext.Provider value={contextValue}>

--- a/packages/dropdowns/src/elements/combobox/TagGroup.tsx
+++ b/packages/dropdowns/src/elements/combobox/TagGroup.tsx
@@ -20,13 +20,22 @@ export const TagGroup = ({
   selection
 }: PropsWithChildren<ITagGroupProps>) => {
   const lastTagRef = useRef<HTMLDivElement>(null);
+  const isMountedRef = useRef(false);
+
+  // Derive a stable primitive from selection so the effect only fires when values actually change,
+  // not when the selection array reference changes on re-render.
+  const selectionFingerprint = selection.map(o => o.value).join('\0');
 
   useEffect(() => {
-    if (!isEditable) {
-      // Scroll the last tag into view.
-      lastTagRef.current?.scrollIntoView?.();
+    if (isMountedRef.current) {
+      if (!isEditable) {
+        // Scroll the last tag into view.
+        lastTagRef.current?.scrollIntoView?.();
+      }
+    } else {
+      isMountedRef.current = true;
     }
-  }, [isEditable, selection]);
+  }, [isEditable, selectionFingerprint]);
 
   return (
     <>


### PR DESCRIPTION
## Description

`Combobox` and `TagGroup` were calling `scrollIntoView` on every mount and re-render
because they depended on the `selection` object reference, which is recreated on each
render by `useCombobox`. This caused unwanted page-level scrolling whenever a combobox
appeared or the user typed.

## Details

- Replaced the `selection` dependency in both `Combobox.tsx` and `TagGroup.tsx` with a
  primitive fingerprint: option values joined with `\0`. The null character `\0` is used as the join separator because it cannot appear in user-facing option values, preventing fingerprint collisions between arrays like `["a,b", "c"]` and `["a", "b,c"]`.
- In `Combobox.tsx`, a `prevSelectionRef` gates the `scrollIntoView` call so it only
  runs when the fingerprint actually changes.
- In `TagGroup.tsx`, an `isMountedRef` guard skips the effect on the initial mount.

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :black_circle: renders as expected in dark mode
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
