### PR TITLE
chore(ci): revert v9.15.1 release and update CI for v9 branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-      - next
+      - v9
 
 permissions:
   contents: read
@@ -96,7 +96,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
   deploy:
-    if: contains(needs.initialize.outputs.teams, 'Writers') && (github.ref == 'refs/heads/main')
+    if: contains(needs.initialize.outputs.teams, 'Writers') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v9')
     needs: [initialize, lint, test]
     runs-on: ubuntu-latest
     environment:
@@ -129,7 +129,7 @@ jobs:
   publish:
     needs: [initialize, lint, test]
     runs-on: ubuntu-latest
-    if: contains(needs.initialize.outputs.teams, 'Maintainers') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next')
+    if: contains(needs.initialize.outputs.teams, 'Maintainers') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v9')
     steps:
       - uses: actions/checkout@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,6 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 <!-- DO NOT MODIFY BELOW THIS COMMENT -->
 <!-- insert-new-changelog-here -->
 
-## v9.15.1 (2026-04-02)
-
-#### :bug: Bug Fix
-* `dropdowns`
-  * [#2115](https://github.com/zendeskgarden/react-components/pull/2115) fix(dropdowns): avoid unwanted page scroll when Combobox mounts or re-renders ([@ze-flo](https://github.com/ze-flo))
-
 ## v9.15.0 (2026-03-02)
 
 #### :rocket: New Feature

--- a/lerna.json
+++ b/lerna.json
@@ -21,11 +21,12 @@
   ],
   "command": {
     "publish": {
+      "distTag": "v9",
       "preDistTag": "next",
       "registry": "https://registry.npmjs.org/"
     },
     "version": {
-      "allowBranch": "main",
+      "allowBranch": "v9",
       "message": "chore(release): publish",
       "preid": "next"
     }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "9.15.1",
+  "version": "9.15.0",
   "changelog": {
     "repo": "zendeskgarden/react-components",
     "cacheDir": ".changelog",
@@ -21,12 +21,11 @@
   ],
   "command": {
     "publish": {
-      "distTag": "v9",
       "preDistTag": "next",
       "registry": "https://registry.npmjs.org/"
     },
     "version": {
-      "allowBranch": "v9",
+      "allowBranch": "main",
       "message": "chore(release): publish",
       "preid": "next"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30472,7 +30472,7 @@
     },
     "packages/accordions": {
       "name": "@zendeskgarden/react-accordions",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-accordion": "^3.0.14",
@@ -30481,7 +30481,7 @@
         "prop-types": "^15.5.7"
       },
       "devDependencies": {
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0"
       },
       "peerDependencies": {
@@ -30493,16 +30493,16 @@
     },
     "packages/avatars": {
       "name": "@zendeskgarden/react-avatars",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@zendeskgarden/react-typography": "^9.15.1",
+        "@zendeskgarden/react-typography": "^9.15.0",
         "polished": "^4.3.1",
         "prop-types": "^15.5.7"
       },
       "devDependencies": {
-        "@zendeskgarden/react-dropdowns": "^9.15.1",
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-dropdowns": "^9.15.0",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0"
       },
       "peerDependencies": {
@@ -30514,7 +30514,7 @@
     },
     "packages/breadcrumbs": {
       "name": "@zendeskgarden/react-breadcrumbs",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-breadcrumb": "^1.0.8",
@@ -30522,7 +30522,7 @@
         "prop-types": "^15.5.7"
       },
       "devDependencies": {
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0"
       },
       "peerDependencies": {
@@ -30534,7 +30534,7 @@
     },
     "packages/buttons": {
       "name": "@zendeskgarden/react-buttons",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-utilities": "^2.0.4",
@@ -30543,7 +30543,7 @@
         "react-merge-refs": "^2.0.0"
       },
       "devDependencies": {
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0"
       },
       "peerDependencies": {
@@ -30555,18 +30555,18 @@
     },
     "packages/chrome": {
       "name": "@zendeskgarden/react-chrome",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-utilities": "^2.0.4",
-        "@zendeskgarden/react-buttons": "^9.15.1",
+        "@zendeskgarden/react-buttons": "^9.15.0",
         "dom-helpers": "^5.2.1",
         "polished": "^4.3.1",
         "prop-types": "^15.5.7",
         "react-merge-refs": "^2.0.0"
       },
       "devDependencies": {
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0"
       },
       "peerDependencies": {
@@ -30578,15 +30578,15 @@
     },
     "packages/colorpickers": {
       "name": "@zendeskgarden/react-colorpickers",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-grid": "^3.0.20",
         "@zendeskgarden/container-utilities": "^2.0.4",
-        "@zendeskgarden/react-buttons": "^9.15.1",
-        "@zendeskgarden/react-forms": "^9.15.1",
-        "@zendeskgarden/react-modals": "^9.15.1",
-        "@zendeskgarden/react-tooltips": "^9.15.1",
+        "@zendeskgarden/react-buttons": "^9.15.0",
+        "@zendeskgarden/react-forms": "^9.15.0",
+        "@zendeskgarden/react-modals": "^9.15.0",
+        "@zendeskgarden/react-tooltips": "^9.15.0",
         "lodash.isequal": "^4.5.0",
         "lodash.throttle": "^4.1.1",
         "polished": "^4.3.1",
@@ -30596,7 +30596,7 @@
       "devDependencies": {
         "@types/lodash.isequal": "4.5.8",
         "@types/lodash.throttle": "4.1.9",
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0"
       },
       "peerDependencies": {
@@ -30608,7 +30608,7 @@
     },
     "packages/datepickers": {
       "name": "@zendeskgarden/react-datepickers",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
@@ -30618,7 +30618,7 @@
         "react-merge-refs": "^2.0.0"
       },
       "devDependencies": {
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0"
       },
       "peerDependencies": {
@@ -30654,7 +30654,7 @@
     },
     "packages/draggable": {
       "name": "@zendeskgarden/react-draggable",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "polished": "^4.3.1",
@@ -30664,8 +30664,8 @@
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/sortable": "10.0.0",
         "@dnd-kit/utilities": "3.2.2",
-        "@zendeskgarden/react-theming": "^9.15.1",
-        "@zendeskgarden/react-typography": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
+        "@zendeskgarden/react-typography": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0"
       },
       "peerDependencies": {
@@ -30677,23 +30677,23 @@
     },
     "packages/dropdowns": {
       "name": "@zendeskgarden/react-dropdowns",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
         "@zendeskgarden/container-combobox": "^2.0.7",
         "@zendeskgarden/container-menu": "^2.0.1",
         "@zendeskgarden/container-utilities": "^2.0.4",
-        "@zendeskgarden/react-buttons": "^9.15.1",
-        "@zendeskgarden/react-forms": "^9.15.1",
-        "@zendeskgarden/react-tags": "^9.15.1",
-        "@zendeskgarden/react-tooltips": "^9.15.1",
+        "@zendeskgarden/react-buttons": "^9.15.0",
+        "@zendeskgarden/react-forms": "^9.15.0",
+        "@zendeskgarden/react-tags": "^9.15.0",
+        "@zendeskgarden/react-tooltips": "^9.15.0",
         "polished": "^4.3.1",
         "prop-types": "^15.7.2",
         "react-merge-refs": "^2.0.0"
       },
       "devDependencies": {
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0"
       },
       "peerDependencies": {
@@ -30705,12 +30705,12 @@
     },
     "packages/dropdowns.legacy": {
       "name": "@zendeskgarden/react-dropdowns.legacy",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-selection": "^2.0.0",
         "@zendeskgarden/container-utilities": "^1.0.14",
-        "@zendeskgarden/react-forms": "^9.15.1",
+        "@zendeskgarden/react-forms": "^9.15.0",
         "downshift": "^7.0.0",
         "polished": "^4.3.1",
         "prop-types": "^15.5.7",
@@ -30719,7 +30719,7 @@
       },
       "devDependencies": {
         "@types/lodash.debounce": "4.0.9",
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.1.1",
         "lodash.debounce": "4.0.8"
       },
@@ -30752,7 +30752,7 @@
     },
     "packages/forms": {
       "name": "@zendeskgarden/react-forms",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-field": "^3.0.21",
@@ -30764,7 +30764,7 @@
       },
       "devDependencies": {
         "@types/lodash.debounce": "4.0.9",
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0",
         "react-dropzone": "14.3.8"
       },
@@ -30777,20 +30777,20 @@
     },
     "packages/grid": {
       "name": "@zendeskgarden/react-grid",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-splitter": "^2.0.22",
         "@zendeskgarden/container-utilities": "^2.0.4",
-        "@zendeskgarden/react-buttons": "^9.15.1",
-        "@zendeskgarden/react-tooltips": "^9.15.1",
+        "@zendeskgarden/react-buttons": "^9.15.0",
+        "@zendeskgarden/react-tooltips": "^9.15.0",
         "polished": "^4.3.1",
         "prop-types": "^15.5.7",
         "react-merge-refs": "^2.0.0",
         "use-resize-observer": "^9.1.0"
       },
       "devDependencies": {
-        "@zendeskgarden/react-theming": "^9.15.1"
+        "@zendeskgarden/react-theming": "^9.15.0"
       },
       "peerDependencies": {
         "@zendeskgarden/react-theming": ">=9.14.0",
@@ -30801,7 +30801,7 @@
     },
     "packages/loaders": {
       "name": "@zendeskgarden/react-loaders",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-schedule": "^2.0.9",
@@ -30809,7 +30809,7 @@
         "prop-types": "^15.5.7"
       },
       "devDependencies": {
-        "@zendeskgarden/react-theming": "^9.15.1"
+        "@zendeskgarden/react-theming": "^9.15.0"
       },
       "peerDependencies": {
         "@zendeskgarden/react-theming": ">=9.14.0",
@@ -30820,13 +30820,13 @@
     },
     "packages/modals": {
       "name": "@zendeskgarden/react-modals",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
         "@zendeskgarden/container-modal": "^1.0.24",
         "@zendeskgarden/container-utilities": "^2.0.4",
-        "@zendeskgarden/react-buttons": "^9.15.1",
+        "@zendeskgarden/react-buttons": "^9.15.0",
         "dom-helpers": "^5.1.0",
         "prop-types": "^15.5.7",
         "react-merge-refs": "^2.0.0",
@@ -30834,7 +30834,7 @@
       },
       "devDependencies": {
         "@types/react-transition-group": "4.4.12",
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0"
       },
       "peerDependencies": {
@@ -30846,10 +30846,10 @@
     },
     "packages/notifications": {
       "name": "@zendeskgarden/react-notifications",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@zendeskgarden/react-buttons": "^9.15.1",
+        "@zendeskgarden/react-buttons": "^9.15.0",
         "polished": "^4.3.1",
         "prop-types": "^15.5.7",
         "react-transition-group": "^4.4.2",
@@ -30857,7 +30857,7 @@
       },
       "devDependencies": {
         "@types/react-transition-group": "4.4.12",
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0"
       },
       "peerDependencies": {
@@ -30869,7 +30869,7 @@
     },
     "packages/pagination": {
       "name": "@zendeskgarden/react-pagination",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-utilities": "^2.0.4",
@@ -30877,7 +30877,7 @@
         "prop-types": "^15.5.7"
       },
       "devDependencies": {
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0"
       },
       "peerDependencies": {
@@ -30889,17 +30889,17 @@
     },
     "packages/tables": {
       "name": "@zendeskgarden/react-tables",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-utilities": "^2.0.4",
-        "@zendeskgarden/react-buttons": "^9.15.1",
+        "@zendeskgarden/react-buttons": "^9.15.0",
         "dom-helpers": "^5.1.0",
         "polished": "^4.3.1",
         "prop-types": "^15.5.7"
       },
       "devDependencies": {
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0"
       },
       "peerDependencies": {
@@ -30911,7 +30911,7 @@
     },
     "packages/tabs": {
       "name": "@zendeskgarden/react-tabs",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-tabs": "^2.0.16",
@@ -30921,7 +30921,7 @@
         "react-merge-refs": "^2.0.0"
       },
       "devDependencies": {
-        "@zendeskgarden/react-theming": "^9.15.1"
+        "@zendeskgarden/react-theming": "^9.15.0"
       },
       "peerDependencies": {
         "@zendeskgarden/react-theming": ">=9.14.0",
@@ -30932,7 +30932,7 @@
     },
     "packages/tags": {
       "name": "@zendeskgarden/react-tags",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-utilities": "^2.0.4",
@@ -30940,7 +30940,7 @@
         "prop-types": "^15.5.7"
       },
       "devDependencies": {
-        "@zendeskgarden/react-theming": "^9.15.1",
+        "@zendeskgarden/react-theming": "^9.15.0",
         "@zendeskgarden/svg-icons": "7.6.0"
       },
       "peerDependencies": {
@@ -30952,7 +30952,7 @@
     },
     "packages/theming": {
       "name": "@zendeskgarden/react-theming",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
@@ -30974,7 +30974,7 @@
     },
     "packages/tooltips": {
       "name": "@zendeskgarden/react-tooltips",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
@@ -30985,10 +30985,10 @@
         "react-merge-refs": "^2.0.0"
       },
       "devDependencies": {
-        "@zendeskgarden/react-buttons": "^9.15.1",
-        "@zendeskgarden/react-dropdowns": "^9.15.1",
-        "@zendeskgarden/react-grid": "^9.15.1",
-        "@zendeskgarden/react-theming": "^9.15.1"
+        "@zendeskgarden/react-buttons": "^9.15.0",
+        "@zendeskgarden/react-dropdowns": "^9.15.0",
+        "@zendeskgarden/react-grid": "^9.15.0",
+        "@zendeskgarden/react-theming": "^9.15.0"
       },
       "peerDependencies": {
         "@zendeskgarden/react-theming": ">=9.14.0",
@@ -30999,7 +30999,7 @@
     },
     "packages/typography": {
       "name": "@zendeskgarden/react-typography",
-      "version": "9.15.1",
+      "version": "9.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-scrollregion": "^1.0.9",
@@ -31008,7 +31008,7 @@
         "prop-types": "^15.5.7"
       },
       "devDependencies": {
-        "@zendeskgarden/react-theming": "^9.15.1"
+        "@zendeskgarden/react-theming": "^9.15.0"
       },
       "peerDependencies": {
         "@zendeskgarden/react-theming": ">=9.14.0",

--- a/packages/accordions/package.json
+++ b/packages/accordions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-accordions",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components related to accordions in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -33,7 +33,7 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0"
   },
   "keywords": [

--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-avatars",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components relating to avatars in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -21,7 +21,7 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/react-typography": "^9.15.1",
+    "@zendeskgarden/react-typography": "^9.15.0",
     "polished": "^4.3.1",
     "prop-types": "^15.5.7"
   },
@@ -32,8 +32,8 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-dropdowns": "^9.15.1",
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-dropdowns": "^9.15.0",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0"
   },
   "keywords": [

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-breadcrumbs",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components relating to breadcrumbs in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -32,7 +32,7 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0"
   },
   "keywords": [

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-buttons",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components relating to buttons in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -33,7 +33,7 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0"
   },
   "keywords": [

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-chrome",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components relating to Chrome within the Garden Design System.",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -22,7 +22,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@zendeskgarden/container-utilities": "^2.0.4",
-    "@zendeskgarden/react-buttons": "^9.15.1",
+    "@zendeskgarden/react-buttons": "^9.15.0",
     "dom-helpers": "^5.2.1",
     "polished": "^4.3.1",
     "prop-types": "^15.5.7",
@@ -35,7 +35,7 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0"
   },
   "keywords": [

--- a/packages/colorpickers/package.json
+++ b/packages/colorpickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-colorpickers",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components related to color pickers in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -23,10 +23,10 @@
   "dependencies": {
     "@zendeskgarden/container-grid": "^3.0.20",
     "@zendeskgarden/container-utilities": "^2.0.4",
-    "@zendeskgarden/react-buttons": "^9.15.1",
-    "@zendeskgarden/react-forms": "^9.15.1",
-    "@zendeskgarden/react-modals": "^9.15.1",
-    "@zendeskgarden/react-tooltips": "^9.15.1",
+    "@zendeskgarden/react-buttons": "^9.15.0",
+    "@zendeskgarden/react-forms": "^9.15.0",
+    "@zendeskgarden/react-modals": "^9.15.0",
+    "@zendeskgarden/react-tooltips": "^9.15.0",
     "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "polished": "^4.3.1",
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/lodash.isequal": "4.5.8",
     "@types/lodash.throttle": "4.1.9",
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0"
   },
   "keywords": [

--- a/packages/datepickers/package.json
+++ b/packages/datepickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-datepickers",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components relating to datepickers in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -34,7 +34,7 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0"
   },
   "keywords": [

--- a/packages/draggable/package.json
+++ b/packages/draggable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-draggable",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components related to drag and drop in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -34,8 +34,8 @@
     "@dnd-kit/core": "6.3.1",
     "@dnd-kit/sortable": "10.0.0",
     "@dnd-kit/utilities": "3.2.2",
-    "@zendeskgarden/react-theming": "^9.15.1",
-    "@zendeskgarden/react-typography": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
+    "@zendeskgarden/react-typography": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0"
   },
   "keywords": [

--- a/packages/dropdowns.legacy/package.json
+++ b/packages/dropdowns.legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-dropdowns.legacy",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components relating to dropdowns in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@zendeskgarden/container-selection": "^2.0.0",
     "@zendeskgarden/container-utilities": "^1.0.14",
-    "@zendeskgarden/react-forms": "^9.15.1",
+    "@zendeskgarden/react-forms": "^9.15.0",
     "downshift": "^7.0.0",
     "polished": "^4.3.1",
     "prop-types": "^15.5.7",
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/lodash.debounce": "4.0.9",
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.1.1",
     "lodash.debounce": "4.0.8"
   },

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-dropdowns",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components related to dropdowns in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -25,10 +25,10 @@
     "@zendeskgarden/container-combobox": "^2.0.7",
     "@zendeskgarden/container-menu": "^2.0.1",
     "@zendeskgarden/container-utilities": "^2.0.4",
-    "@zendeskgarden/react-buttons": "^9.15.1",
-    "@zendeskgarden/react-forms": "^9.15.1",
-    "@zendeskgarden/react-tags": "^9.15.1",
-    "@zendeskgarden/react-tooltips": "^9.15.1",
+    "@zendeskgarden/react-buttons": "^9.15.0",
+    "@zendeskgarden/react-forms": "^9.15.0",
+    "@zendeskgarden/react-tags": "^9.15.0",
+    "@zendeskgarden/react-tooltips": "^9.15.0",
     "polished": "^4.3.1",
     "prop-types": "^15.7.2",
     "react-merge-refs": "^2.0.0"
@@ -40,7 +40,7 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0"
   },
   "keywords": [

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-forms",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components relating to form elements in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/lodash.debounce": "4.0.9",
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0",
     "react-dropzone": "14.3.8"
   },

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-grid",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components relating to layout grids in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -23,8 +23,8 @@
   "dependencies": {
     "@zendeskgarden/container-splitter": "^2.0.22",
     "@zendeskgarden/container-utilities": "^2.0.4",
-    "@zendeskgarden/react-buttons": "^9.15.1",
-    "@zendeskgarden/react-tooltips": "^9.15.1",
+    "@zendeskgarden/react-buttons": "^9.15.0",
+    "@zendeskgarden/react-tooltips": "^9.15.0",
     "polished": "^4.3.1",
     "prop-types": "^15.5.7",
     "react-merge-refs": "^2.0.0",
@@ -37,7 +37,7 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^9.15.1"
+    "@zendeskgarden/react-theming": "^9.15.0"
   },
   "keywords": [
     "components",

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-loaders",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components relating to loaders in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -32,7 +32,7 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^9.15.1"
+    "@zendeskgarden/react-theming": "^9.15.0"
   },
   "keywords": [
     "components",

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-modals",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components relating to modals in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -24,7 +24,7 @@
     "@floating-ui/react-dom": "^2.0.0",
     "@zendeskgarden/container-modal": "^1.0.24",
     "@zendeskgarden/container-utilities": "^2.0.4",
-    "@zendeskgarden/react-buttons": "^9.15.1",
+    "@zendeskgarden/react-buttons": "^9.15.0",
     "dom-helpers": "^5.1.0",
     "prop-types": "^15.5.7",
     "react-merge-refs": "^2.0.0",
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/react-transition-group": "4.4.12",
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0"
   },
   "keywords": [

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-notifications",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Notification and Well components within the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -21,7 +21,7 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/react-buttons": "^9.15.1",
+    "@zendeskgarden/react-buttons": "^9.15.0",
     "polished": "^4.3.1",
     "prop-types": "^15.5.7",
     "react-transition-group": "^4.4.2",
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/react-transition-group": "4.4.12",
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0"
   },
   "keywords": [

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-pagination",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components relating to pagination in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -32,7 +32,7 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0"
   },
   "keywords": [

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-tables",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components relating to tables in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -22,7 +22,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@zendeskgarden/container-utilities": "^2.0.4",
-    "@zendeskgarden/react-buttons": "^9.15.1",
+    "@zendeskgarden/react-buttons": "^9.15.0",
     "dom-helpers": "^5.1.0",
     "polished": "^4.3.1",
     "prop-types": "^15.5.7"
@@ -34,7 +34,7 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0"
   },
   "keywords": [

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-tabs",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components and render prop containers relating to the Garden Design System.",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -34,7 +34,7 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^9.15.1"
+    "@zendeskgarden/react-theming": "^9.15.0"
   },
   "keywords": [
     "components",

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-tags",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components relating to tags in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -32,7 +32,7 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^9.15.1",
+    "@zendeskgarden/react-theming": "^9.15.0",
     "@zendeskgarden/svg-icons": "7.6.0"
   },
   "keywords": [

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-theming",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Theming utilities and components within the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-tooltips",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Collection of components and render prop containers relating to Tooltips in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -35,10 +35,10 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-buttons": "^9.15.1",
-    "@zendeskgarden/react-dropdowns": "^9.15.1",
-    "@zendeskgarden/react-grid": "^9.15.1",
-    "@zendeskgarden/react-theming": "^9.15.1"
+    "@zendeskgarden/react-buttons": "^9.15.0",
+    "@zendeskgarden/react-dropdowns": "^9.15.0",
+    "@zendeskgarden/react-grid": "^9.15.0",
+    "@zendeskgarden/react-theming": "^9.15.0"
   },
   "keywords": [
     "components",

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/react-typography",
-  "version": "9.15.1",
+  "version": "9.15.0",
   "description": "Components relating to typography in the Garden Design System",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -33,7 +33,7 @@
     "styled-components": "^5.3.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^9.15.1"
+    "@zendeskgarden/react-theming": "^9.15.0"
   },
   "keywords": [
     "components",


### PR DESCRIPTION

Reverts the v9.15.1 release (which was never published to npm) and updates the CI workflow so it can build, deploy, and publish from the `v9` branch.

## Details

- Reverted the two v9.15.1 commits (version bump and changelog update) to bring all package versions back to `9.15.0`
- Replaced `next` with `v9` in the CI push trigger so workflows run on pushes to `v9`
- Added `v9` to the `deploy` and `publish` job conditions so GitHub Pages deployment and npm publishing work from the `v9` branch
- Removed the `next` branch from both the push trigger and the publish condition since it is no longer in use