### PR TITLE
fix(accordions): prevent focus ring clipping in stepper content

### DIFF
--- a/packages/accordions/src/styled/stepper/StyledInnerContent.ts
+++ b/packages/accordions/src/styled/stepper/StyledInnerContent.ts
@@ -18,6 +18,8 @@ export const StyledInnerContent = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledInnerContentProps>`
+  margin: -${props => props.theme.space.xxs};
+  padding: ${props => props.theme.space.xxs};
   overflow: hidden;
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   color: ${({ theme }) => getColor({ theme, variable: 'foreground.default' })};

--- a/packages/dropdowns/src/elements/combobox/Listbox.tsx
+++ b/packages/dropdowns/src/elements/combobox/Listbox.tsx
@@ -76,9 +76,12 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
     /* Prevent listbox close on scrollbar click */
     const handleMouseDown: MouseEventHandler = event => event.preventDefault();
 
-    useEffect(() => () => {
-      isMountedRef.current = false;
-    }, []);
+    useEffect(
+      () => () => {
+        isMountedRef.current = false;
+      },
+      []
+    );
 
     useEffect(() => {
       // Only allow listbox positioning updates on expanded combobox.

--- a/packages/dropdowns/src/elements/menu/MenuList.tsx
+++ b/packages/dropdowns/src/elements/menu/MenuList.tsx
@@ -94,9 +94,12 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
       ]
     });
 
-    useEffect(() => () => {
-      isMountedRef.current = false;
-    }, []);
+    useEffect(
+      () => () => {
+        isMountedRef.current = false;
+      },
+      []
+    );
 
     useEffect(() => {
       // Only allow positioning updates on expanded menu.


### PR DESCRIPTION
## Description

`StyledInnerContent` used `overflow: hidden` without any surrounding space, which caused the focus ring (box-shadow) of focusable elements — such as inputs — placed inside `Stepper.Content` to be clipped at the container edge.

## Solution

Add a negative margin equal to `theme.space.xxs` (4px) and a matching positive padding on `StyledInnerContent`. This expands the visible paint area beyond the layout boundary before `overflow: hidden` clips it, giving focus rings enough room to render without affecting the component's layout or spacing.


- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:black_circle: renders as expected in dark mode~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
