### PR TITLE
fix(dropdowns): guard Listbox and MenuList state setters against post-unmount updates

### DIFF
--- a/packages/dropdowns/src/elements/combobox/Listbox.tsx
+++ b/packages/dropdowns/src/elements/combobox/Listbox.tsx
@@ -39,6 +39,7 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
     ref
   ) => {
     const floatingRef = useRef<HTMLDivElement>(null);
+    const isMountedRef = useRef(true);
     const [isVisible, setIsVisible] = useState(false);
     const [height, setHeight] = useState<number>();
     const [width, setWidth] = useState<number>();
@@ -58,7 +59,7 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
         size({
           apply: ({ rects, availableHeight }) => {
             /* istanbul ignore if */
-            if (rects.reference.width > 0) {
+            if (rects.reference.width > 0 && isMountedRef.current) {
               setWidth(rects.reference.width);
 
               if (
@@ -74,6 +75,10 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
     });
     /* Prevent listbox close on scrollbar click */
     const handleMouseDown: MouseEventHandler = event => event.preventDefault();
+
+    useEffect(() => () => {
+      isMountedRef.current = false;
+    }, []);
 
     useEffect(() => {
       // Only allow listbox positioning updates on expanded combobox.
@@ -93,11 +98,13 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
 
       /* istanbul ignore else */
       if (isExpanded) {
-        setIsVisible(true);
+        if (isMountedRef.current) setIsVisible(true);
       } else {
         timeout = setTimeout(() => {
-          setIsVisible(false);
-          setHeight(undefined);
+          if (isMountedRef.current) {
+            setIsVisible(false);
+            setHeight(undefined);
+          }
         }, 200 /* match menu opacity transition */);
       }
 
@@ -109,7 +116,7 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
         /* istanbul ignore if */
         if (height) {
           // Reset height on options change.
-          setHeight(undefined);
+          if (isMountedRef.current) setHeight(undefined);
           update();
         }
       },

--- a/packages/dropdowns/src/elements/menu/MenuList.tsx
+++ b/packages/dropdowns/src/elements/menu/MenuList.tsx
@@ -51,6 +51,7 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
     ref
   ) => {
     const floatingRef = useRef<HTMLDivElement>(null);
+    const isMountedRef = useRef(true);
     const [isVisible, setIsVisible] = useState(isExpanded);
     const [height, setHeight] = useState<number>();
     /* istanbul ignore next */
@@ -84,7 +85,7 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
           apply: ({ rects, availableHeight }) => {
             /* istanbul ignore if */
             if (!(minHeight === null || minHeight === 'fit-content')) {
-              if (rects.floating.height > availableHeight) {
+              if (rects.floating.height > availableHeight && isMountedRef.current) {
                 setHeight(availableHeight);
               }
             }
@@ -92,6 +93,10 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
         })
       ]
     });
+
+    useEffect(() => () => {
+      isMountedRef.current = false;
+    }, []);
 
     useEffect(() => {
       // Only allow positioning updates on expanded menu.
@@ -111,11 +116,13 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
 
       /* istanbul ignore else */
       if (isExpanded) {
-        setIsVisible(true);
+        if (isMountedRef.current) setIsVisible(true);
       } else {
         timeout = setTimeout(() => {
-          setIsVisible(false);
-          setHeight(undefined);
+          if (isMountedRef.current) {
+            setIsVisible(false);
+            setHeight(undefined);
+          }
         }, 200 /* match menu opacity transition */);
       }
 
@@ -127,7 +134,7 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
         /* istanbul ignore if */
         if (height) {
           // Reset height on options change.
-          setHeight(undefined);
+          if (isMountedRef.current) setHeight(undefined);
           update();
         }
       },


### PR DESCRIPTION
## Description

In React 17, `useEffect` cleanup runs asynchronously — so after unmount, a pending `setTimeout` callback can fire before the cleanup's `clearTimeout` has cancelled it. Both `Listbox` (combobox) and `MenuList` (menu) called `setState` inside a 200ms `setTimeout` and floating-ui's `size` middleware, triggering "Can't perform a React state update on an unmounted component" warnings in React 17 consumers.

This adds an `isMountedRef` guard that skips `setState` calls after unmount which fixes the warnings.

Note: no tests added, because React 19 test env cannot reproduce the React 17 async cleanup race.