### PR TITLE
fix(publishing): ensure `latest` tag is applied to most recent release

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -21,7 +21,6 @@
   ],
   "command": {
     "publish": {
-      "distTag": "v9",
       "preDistTag": "next",
       "registry": "https://registry.npmjs.org/"
     },


### PR DESCRIPTION
## Description

Removes the hardcoded `distTag: "v9"` from the Lerna publish config so that releases from this branch are tagged `latest` on npm instead of `v9`.

## Details

- Drops `"distTag": "v9"` from `lerna.json` `command.publish`
- npm defaults to `latest` when no `distTag` is set, which is now the correct behavior for this branch
- `preDistTag` (`next`) is unchanged
