### PR TITLE
fix(dropdowns): restore isMountedRef on remount to fix StrictMode regression

### DIFF
--- a/packages/dropdowns/src/elements/combobox/Listbox.spec.tsx
+++ b/packages/dropdowns/src/elements/combobox/Listbox.spec.tsx
@@ -1,0 +1,132 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useRef } from 'react';
+import { act, render } from 'garden-test-utils';
+import { Listbox } from './Listbox';
+
+interface ITestListboxProps {
+  isExpanded?: boolean;
+}
+
+const TestListbox = ({ isExpanded }: ITestListboxProps) => {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <>
+      <button ref={triggerRef} type="button">
+        trigger
+      </button>
+      <Listbox isExpanded={isExpanded} triggerRef={triggerRef}>
+        <option data-test-id="option" aria-selected={false}>
+          option
+        </option>
+      </Listbox>
+    </>
+  );
+};
+
+describe('Listbox', () => {
+  describe('isMountedRef', () => {
+    it('renders children when expanded', () => {
+      const { queryByTestId, rerender } = render(<TestListbox isExpanded={false} />);
+
+      expect(queryByTestId('option')).toBeNull();
+
+      rerender(<TestListbox isExpanded />);
+
+      expect(queryByTestId('option')).not.toBeNull();
+    });
+
+    it('renders children when expanded inside React.StrictMode', () => {
+      // Regression: in StrictMode, components are mounted, unmounted, and
+      // remounted on first mount. The mount-tracking effect must reset
+      // `isMountedRef.current` to `true` on (re)mount, otherwise every
+      // guarded `setState` (including `setIsVisible(true)`) is suppressed
+      // and children never become visible.
+      const { queryByTestId, rerender } = render(
+        <React.StrictMode>
+          <TestListbox isExpanded={false} />
+        </React.StrictMode>
+      );
+
+      expect(queryByTestId('option')).toBeNull();
+
+      rerender(
+        <React.StrictMode>
+          <TestListbox isExpanded />
+        </React.StrictMode>
+      );
+
+      expect(queryByTestId('option')).not.toBeNull();
+    });
+
+    it('hides children after collapse animation completes', () => {
+      jest.useFakeTimers();
+
+      try {
+        const { queryByTestId, rerender } = render(<TestListbox isExpanded />);
+
+        expect(queryByTestId('option')).not.toBeNull();
+
+        rerender(<TestListbox isExpanded={false} />);
+
+        expect(queryByTestId('option')).not.toBeNull();
+
+        act(() => {
+          jest.advanceTimersByTime(200);
+        });
+
+        expect(queryByTestId('option')).toBeNull();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('hides children after collapse animation completes inside React.StrictMode', () => {
+      jest.useFakeTimers();
+
+      try {
+        const { queryByTestId, rerender } = render(
+          <React.StrictMode>
+            <TestListbox isExpanded />
+          </React.StrictMode>
+        );
+
+        expect(queryByTestId('option')).not.toBeNull();
+
+        rerender(
+          <React.StrictMode>
+            <TestListbox isExpanded={false} />
+          </React.StrictMode>
+        );
+
+        act(() => {
+          jest.advanceTimersByTime(200);
+        });
+
+        expect(queryByTestId('option')).toBeNull();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('does not warn about state updates after unmount', () => {
+      const error = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      try {
+        const { unmount } = render(<TestListbox isExpanded />);
+
+        unmount();
+
+        expect(error).not.toHaveBeenCalled();
+      } finally {
+        error.mockRestore();
+      }
+    });
+  });
+});

--- a/packages/dropdowns/src/elements/combobox/Listbox.tsx
+++ b/packages/dropdowns/src/elements/combobox/Listbox.tsx
@@ -76,12 +76,13 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
     /* Prevent listbox close on scrollbar click */
     const handleMouseDown: MouseEventHandler = event => event.preventDefault();
 
-    useEffect(
-      () => () => {
+    useEffect(() => {
+      isMountedRef.current = true;
+
+      return () => {
         isMountedRef.current = false;
-      },
-      []
-    );
+      };
+    }, []);
 
     useEffect(() => {
       // Only allow listbox positioning updates on expanded combobox.

--- a/packages/dropdowns/src/elements/menu/MenuList.spec.tsx
+++ b/packages/dropdowns/src/elements/menu/MenuList.spec.tsx
@@ -1,0 +1,132 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useRef } from 'react';
+import { act, render } from 'garden-test-utils';
+import { MenuList } from './MenuList';
+
+interface ITestMenuListProps {
+  isExpanded?: boolean;
+}
+
+const TestMenuList = ({ isExpanded }: ITestMenuListProps) => {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <>
+      <button ref={triggerRef} type="button">
+        trigger
+      </button>
+      <MenuList isExpanded={isExpanded} triggerRef={triggerRef}>
+        <li data-test-id="item" role="menuitem">
+          item
+        </li>
+      </MenuList>
+    </>
+  );
+};
+
+describe('MenuList', () => {
+  describe('isMountedRef', () => {
+    it('renders children when expanded', () => {
+      const { queryByTestId, rerender } = render(<TestMenuList isExpanded={false} />);
+
+      expect(queryByTestId('item')).toBeNull();
+
+      rerender(<TestMenuList isExpanded />);
+
+      expect(queryByTestId('item')).not.toBeNull();
+    });
+
+    it('renders children when expanded inside React.StrictMode', () => {
+      // Regression: in StrictMode, components are mounted, unmounted, and
+      // remounted on first mount. The mount-tracking effect must reset
+      // `isMountedRef.current` to `true` on (re)mount, otherwise every
+      // guarded `setState` (including `setIsVisible(true)`) is suppressed
+      // and children never become visible.
+      const { queryByTestId, rerender } = render(
+        <React.StrictMode>
+          <TestMenuList isExpanded={false} />
+        </React.StrictMode>
+      );
+
+      expect(queryByTestId('item')).toBeNull();
+
+      rerender(
+        <React.StrictMode>
+          <TestMenuList isExpanded />
+        </React.StrictMode>
+      );
+
+      expect(queryByTestId('item')).not.toBeNull();
+    });
+
+    it('hides children after collapse animation completes', () => {
+      jest.useFakeTimers();
+
+      try {
+        const { queryByTestId, rerender } = render(<TestMenuList isExpanded />);
+
+        expect(queryByTestId('item')).not.toBeNull();
+
+        rerender(<TestMenuList isExpanded={false} />);
+
+        expect(queryByTestId('item')).not.toBeNull();
+
+        act(() => {
+          jest.advanceTimersByTime(200);
+        });
+
+        expect(queryByTestId('item')).toBeNull();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('hides children after collapse animation completes inside React.StrictMode', () => {
+      jest.useFakeTimers();
+
+      try {
+        const { queryByTestId, rerender } = render(
+          <React.StrictMode>
+            <TestMenuList isExpanded />
+          </React.StrictMode>
+        );
+
+        expect(queryByTestId('item')).not.toBeNull();
+
+        rerender(
+          <React.StrictMode>
+            <TestMenuList isExpanded={false} />
+          </React.StrictMode>
+        );
+
+        act(() => {
+          jest.advanceTimersByTime(200);
+        });
+
+        expect(queryByTestId('item')).toBeNull();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('does not warn about state updates after unmount', () => {
+      const error = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      try {
+        const { unmount } = render(<TestMenuList isExpanded />);
+
+        unmount();
+
+        expect(error).not.toHaveBeenCalled();
+      } finally {
+        error.mockRestore();
+      }
+    });
+  });
+});

--- a/packages/dropdowns/src/elements/menu/MenuList.tsx
+++ b/packages/dropdowns/src/elements/menu/MenuList.tsx
@@ -94,12 +94,13 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
       ]
     });
 
-    useEffect(
-      () => () => {
+    useEffect(() => {
+      isMountedRef.current = true;
+
+      return () => {
         isMountedRef.current = false;
-      },
-      []
-    );
+      };
+    }, []);
 
     useEffect(() => {
       // Only allow positioning updates on expanded menu.


### PR DESCRIPTION
## Description

Fixes a regression introduced in #2124  where `Listbox` and `MenuList` would silently fail to show or hide content when rendered inside `React.StrictMode`.

## Details

- In React 18+ StrictMode, every component is mounted, unmounted, and immediately remounted. The cleanup-only effect in #2124 set `isMountedRef.current = false` but never reset it to `true`, leaving all guarded `setState` calls permanently suppressed after the simulated unmount.
- Fix: add `isMountedRef.current = true` to the effect setup body in both `Listbox.tsx` and `MenuList.tsx`.
- Regression specs added for both components covering expand/collapse visibility and animation timing inside `React.StrictMode`.    


- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :black_circle: renders as expected in dark mode
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
