### PR TITLE
fix(modals): upgrade `container-modal` to v2 to fix blur-close behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9220,9 +9220,9 @@
       }
     },
     "node_modules/@zendeskgarden/container-modal": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-modal/-/container-modal-1.0.24.tgz",
-      "integrity": "sha512-U3dxXINIjAfIdylc4o7nfj8jTNdPqx5VbL+6GhY/Vr7J3PWgaj7hYh/X0z2BBkCGMQTtBuuiSh4gNmQanYcNKg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-modal/-/container-modal-2.0.0.tgz",
+      "integrity": "sha512-+uM44GUJLeBHXuJwhpNJ9ApLP91omdl+q6eCFeNUYufoBIkgmbDKl8YnKIb7IwtmUMOGsb6IPI+8HVerwDibFA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
@@ -30824,7 +30824,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
-        "@zendeskgarden/container-modal": "^1.0.24",
+        "@zendeskgarden/container-modal": "^2.0.0",
         "@zendeskgarden/container-utilities": "^2.0.4",
         "@zendeskgarden/react-buttons": "^9.15.3",
         "dom-helpers": "^5.1.0",

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -22,7 +22,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
-    "@zendeskgarden/container-modal": "^1.0.24",
+    "@zendeskgarden/container-modal": "^2.0.0",
     "@zendeskgarden/container-utilities": "^2.0.4",
     "@zendeskgarden/react-buttons": "^9.15.3",
     "dom-helpers": "^5.1.0",

--- a/packages/modals/src/elements/Drawer/Drawer.spec.tsx
+++ b/packages/modals/src/elements/Drawer/Drawer.spec.tsx
@@ -177,6 +177,18 @@ describe('Drawer', () => {
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
   });
 
+  it('does not close the drawer modal when focus moves outside', async () => {
+    const { getByText, getByRole } = render(<Example />);
+
+    await user.click(getByText('Open Drawer'));
+
+    expect(getByRole('dialog')).toBeInTheDocument();
+
+    await user.click(document.body);
+
+    expect(getByRole('dialog')).toBeInTheDocument();
+  });
+
   describe('focus management', () => {
     it('correctly focuses on the Drawer when open', async () => {
       const { getByText, getByRole } = render(<Example />);

--- a/packages/modals/src/elements/Modal.spec.tsx
+++ b/packages/modals/src/elements/Modal.spec.tsx
@@ -155,6 +155,13 @@ describe('Modal', () => {
       await user.type(getByTestId('modal'), '{escape}');
       expect(onCloseSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('is not triggered when focus moves outside the modal', async () => {
+      render(<BasicExample onClose={onCloseSpy} />);
+
+      await user.click(document.body);
+      expect(onCloseSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('appendToNode', () => {

--- a/packages/modals/src/elements/TooltipDialog/TooltipDialog.spec.tsx
+++ b/packages/modals/src/elements/TooltipDialog/TooltipDialog.spec.tsx
@@ -231,6 +231,35 @@ describe('TooltipDialog', () => {
 
       expect(onCloseSpy).toHaveBeenCalled();
     });
+
+    describe('blur behavior (closeOnBlur: true)', () => {
+      it('is triggered when focus moves outside the dialog', async () => {
+        const { getByText } = render(<Example onClose={onCloseSpy} />);
+
+        await act(async () => {
+          await user.click(getByText('open'));
+        });
+
+        await waitFor(async () => {
+          await user.click(document.body);
+        });
+
+        expect(onCloseSpy).toHaveBeenCalled();
+      });
+
+      it('is not triggered when focus moves to an element inside the dialog', async () => {
+        const { getByRole, getByText } = render(<Example onClose={onCloseSpy} />);
+
+        await act(async () => {
+          await user.click(getByText('open'));
+        });
+
+        // Click the dialog itself (tabIndex=-1) — focus stays inside, no close
+        await user.click(getByRole('dialog'));
+
+        expect(onCloseSpy).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('keepMounted', () => {

--- a/packages/modals/src/elements/TooltipDialog/TooltipDialog.tsx
+++ b/packages/modals/src/elements/TooltipDialog/TooltipDialog.tsx
@@ -74,6 +74,7 @@ const TooltipDialogComponent = React.forwardRef<HTMLDivElement, ITooltipDialogPr
     };
     const { getTitleProps, getCloseProps, getContentProps, getBackdropProps, getModalProps } =
       useModal({
+        closeOnBlur: true,
         idPrefix: id,
         onClose: handleClose,
         modalRef,


### PR DESCRIPTION
## Description

Bumps `@zendeskgarden/container-modal` to `^2.0.0`, which adds native `closeOnBlur` support to `useModal`(https://github.com/zendeskgarden/react-containers/pull/734). `TooltipDialog` explicitly opts in with `closeOnBlur: true` (light-dismiss is correct for a popover). `Modal` and `Drawer` rely on the v2 `closeOnBlur: false` path to stop closing when focus moves outside, fixing a long-standing bug where opening a portaled dropdown inside a modal would unexpectedly dismiss it.

## Details

- Bump `container-modal` dep from `^1.0.24` to `^2.0.0`
- Add `closeOnBlur: true` explicitly to `TooltipDialog`'s `useModal` call
- Add regression tests for all three components: `Modal`, `Drawer`, and `TooltipDialog`

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:black_circle: renders as expected in dark mode~~
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
