### PR TITLE
fix(accordions): prevent step content overflow when collapsed

### DIFF
--- a/packages/accordions/src/styled/stepper/StyledInnerContent.ts
+++ b/packages/accordions/src/styled/stepper/StyledInnerContent.ts
@@ -25,5 +25,10 @@ export const StyledInnerContent = styled.div.attrs({
   color: ${({ theme }) => getColor({ theme, variable: 'foreground.default' })};
   font-size: ${props => props.theme.fontSizes.md};
 
+  &[aria-hidden='true'] {
+    margin: 0;
+    padding: 0;
+  }
+
   ${componentStyles};
 `;


### PR DESCRIPTION
## Description

Fixes a visual overflow in the Stepper component where content from collapsed steps bled through the animated grid container.

## Details

- `StyledInnerContent` uses a negative margin and padding offset to ensure focus rings are not clipped
- When a step collapses to `0fr`, that offset creates a zone where content remains visible despite the grid row having zero height
- Zeroing out `margin` and `padding` on `StyledInnerContent[aria-hidden="true"]` eliminates the bleed without affecting the expand/collapse animation or the focus ring behavior on active steps


## Checklist

- ~~[ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :black_circle: renders as expected in dark mode
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- ~~[ ] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~[ ] :wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
