### PR TITLE
feat(datepickers): Add DateTimePicker component

### DIFF
--- a/packages/datepickers/demo/dateTimePicker.mdx
+++ b/packages/datepickers/demo/dateTimePicker.mdx
@@ -1,0 +1,17 @@
+import { Meta, ArgTypes, Canvas, Story, Markdown } from '@storybook/addon-docs/blocks';
+import README from '../README.md';
+import * as Stories from './dateTimePicker.stories';
+
+<Meta of={Stories} />
+
+# API
+
+<ArgTypes />
+
+# Demo
+
+<Canvas>
+  <Story of={Stories.Example} />
+</Canvas>
+
+<Markdown>{README}</Markdown>

--- a/packages/datepickers/demo/dateTimePicker.stories.tsx
+++ b/packages/datepickers/demo/dateTimePicker.stories.tsx
@@ -10,6 +10,7 @@ import type { StoryObj } from '@storybook/react-vite';
 import { useArgs } from 'storybook/preview-api';
 import { DateTimePicker } from '@zendeskgarden/react-datepickers';
 import { DateTimePickerStory } from './stories/DateTimePickerStory';
+import { DATE_STYLE_OPTIONS } from './stories/data';
 
 export default {
   title: 'Packages/Datepickers/DateTimePicker',
@@ -29,6 +30,7 @@ export const Example: StoryObj<typeof DateTimePickerStory> = {
   },
   name: 'DateTimePicker',
   args: {
+    dateStyle: DATE_STYLE_OPTIONS[1],
     isAnimated: true,
     timeStep: 1,
     isAmPm: 'auto' as any,
@@ -39,6 +41,11 @@ export const Example: StoryObj<typeof DateTimePickerStory> = {
     value: { control: 'date' },
     minValue: { control: 'date' },
     maxValue: { control: 'date' },
+    dateStyle: {
+      control: 'radio',
+      options: DATE_STYLE_OPTIONS,
+      table: { category: 'Story' }
+    },
     timeStep: {
       control: { type: 'select' },
       options: [1, 5, 10, 15, 30]

--- a/packages/datepickers/demo/dateTimePicker.stories.tsx
+++ b/packages/datepickers/demo/dateTimePicker.stories.tsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import type { StoryObj } from '@storybook/react-vite';
+import { useArgs } from 'storybook/preview-api';
+import { DateTimePicker } from '@zendeskgarden/react-datepickers';
+import { DateTimePickerStory } from './stories/DateTimePickerStory';
+
+export default {
+  title: 'Packages/Datepickers/DateTimePicker',
+  component: DateTimePicker
+};
+
+export const Example: StoryObj<typeof DateTimePickerStory> = {
+  render: args => {
+    const updateArgs = useArgs()[1];
+
+    const handleChange = (value: any) =>
+      updateArgs({
+        value
+      });
+
+    return <DateTimePickerStory {...args} onChange={handleChange} />;
+  },
+  name: 'DateTimePicker',
+  args: {
+    isAnimated: true,
+    timeStep: 1,
+    isAmPm: 'auto' as any,
+    message: 'Message'
+  },
+  argTypes: {
+    appendToNode: { control: false },
+    value: { control: 'date' },
+    minValue: { control: 'date' },
+    maxValue: { control: 'date' },
+    timeStep: {
+      control: { type: 'select' },
+      options: [1, 5, 10, 15, 30]
+    },
+    isAmPm: {
+      control: { type: 'radio' },
+      options: ['auto', 'true', 'false'],
+      mapping: { auto: undefined, true: true, false: false }
+    },
+    hasMessage: {
+      name: 'Message',
+      control: { type: 'boolean' },
+      table: { category: 'Story' }
+    },
+    message: {
+      name: 'children',
+      control: { type: 'text' },
+      table: { category: 'Message' }
+    },
+    validation: {
+      options: ['success', 'warning', 'error'],
+      control: { type: 'radio' },
+      table: { category: 'Input' }
+    },
+    validationLabel: {
+      control: { type: 'text' },
+      table: { category: 'Message' }
+    }
+  }
+};

--- a/packages/datepickers/demo/stories/DateTimePickerStory.tsx
+++ b/packages/datepickers/demo/stories/DateTimePickerStory.tsx
@@ -27,6 +27,8 @@ export const DateTimePickerStory: StoryFn<IArgs> = ({
   ...args
 }) => {
   const value = args.value ? new Date(args.value) : undefined;
+  const minValue = args.minValue ? new Date(args.minValue) : undefined;
+  const maxValue = args.maxValue ? new Date(args.maxValue) : undefined;
 
   return (
     <Grid>
@@ -34,7 +36,13 @@ export const DateTimePickerStory: StoryFn<IArgs> = ({
         <Grid.Col alignSelf="center">
           <Field>
             <Field.Label hidden>{DateTimePicker.displayName}</Field.Label>
-            <DateTimePicker {...args} value={value} isCompact={isCompact}>
+            <DateTimePicker
+              {...args}
+              value={value}
+              minValue={minValue}
+              maxValue={maxValue}
+              isCompact={isCompact}
+            >
               <Input isCompact={isCompact} validation={validation} />
             </DateTimePicker>
             {!!hasMessage && (

--- a/packages/datepickers/demo/stories/DateTimePickerStory.tsx
+++ b/packages/datepickers/demo/stories/DateTimePickerStory.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { StoryFn } from '@storybook/react-vite';
+import { Grid } from '@zendeskgarden/react-grid';
+import { Field, Input } from '@zendeskgarden/react-forms';
+import { DateTimePicker, IDateTimePickerProps } from '@zendeskgarden/react-datepickers';
+
+interface IArgs extends IDateTimePickerProps {
+  hasMessage?: boolean;
+  message?: string;
+  validation?: 'success' | 'warning' | 'error';
+  validationLabel?: string;
+}
+
+export const DateTimePickerStory: StoryFn<IArgs> = ({
+  isCompact,
+  hasMessage,
+  message,
+  validation,
+  validationLabel,
+  ...args
+}) => {
+  const value = args.value ? new Date(args.value) : undefined;
+
+  return (
+    <Grid>
+      <Grid.Row justifyContent="center" style={{ height: 'calc(100vh - 80px)' }}>
+        <Grid.Col alignSelf="center">
+          <Field>
+            <Field.Label hidden>{DateTimePicker.displayName}</Field.Label>
+            <DateTimePicker {...args} value={value} isCompact={isCompact}>
+              <Input isCompact={isCompact} validation={validation} />
+            </DateTimePicker>
+            {!!hasMessage && (
+              <Field.Message validation={validation} validationLabel={validationLabel}>
+                {message}
+              </Field.Message>
+            )}
+          </Field>
+        </Grid.Col>
+      </Grid.Row>
+    </Grid>
+  );
+};

--- a/packages/datepickers/demo/stories/DateTimePickerStory.tsx
+++ b/packages/datepickers/demo/stories/DateTimePickerStory.tsx
@@ -10,8 +10,10 @@ import { StoryFn } from '@storybook/react-vite';
 import { Grid } from '@zendeskgarden/react-grid';
 import { Field, Input } from '@zendeskgarden/react-forms';
 import { DateTimePicker, IDateTimePickerProps } from '@zendeskgarden/react-datepickers';
+import { DATE_STYLE } from './types';
 
 interface IArgs extends IDateTimePickerProps {
+  dateStyle: DATE_STYLE;
   hasMessage?: boolean;
   message?: string;
   validation?: 'success' | 'warning' | 'error';
@@ -19,6 +21,7 @@ interface IArgs extends IDateTimePickerProps {
 }
 
 export const DateTimePickerStory: StoryFn<IArgs> = ({
+  dateStyle,
   isCompact,
   hasMessage,
   message,
@@ -29,6 +32,8 @@ export const DateTimePickerStory: StoryFn<IArgs> = ({
   const value = args.value ? new Date(args.value) : undefined;
   const minValue = args.minValue ? new Date(args.minValue) : undefined;
   const maxValue = args.maxValue ? new Date(args.maxValue) : undefined;
+  const formatDate = (date: Date) =>
+    new Intl.DateTimeFormat(args.locale, { dateStyle, timeStyle: 'short' }).format(date);
 
   return (
     <Grid>
@@ -41,6 +46,7 @@ export const DateTimePickerStory: StoryFn<IArgs> = ({
               value={value}
               minValue={minValue}
               maxValue={maxValue}
+              formatDate={formatDate}
               isCompact={isCompact}
             >
               <Input isCompact={isCompact} validation={validation} />

--- a/packages/datepickers/src/elements/DateTimePicker/DateTimePicker.spec.tsx
+++ b/packages/datepickers/src/elements/DateTimePicker/DateTimePicker.spec.tsx
@@ -1,0 +1,538 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, renderRtl, fireEvent, act } from 'garden-test-utils';
+import { addDays } from 'date-fns/addDays';
+import { subDays } from 'date-fns/subDays';
+import mockDate from 'mockdate';
+import { KEYS } from '@zendeskgarden/container-utilities';
+import { DateTimePicker } from './DateTimePicker';
+import { IDateTimePickerProps } from '../../types';
+
+const DEFAULT_DATE = new Date(2019, 1, 5, 14, 30);
+
+const Example = (props: Omit<IDateTimePickerProps, 'children'>) => (
+  <>
+    <label data-test-id="label" htmlFor="input">
+      Label
+    </label>
+    <DateTimePicker {...props}>
+      <input data-test-id="input" id="input" />
+    </DateTimePicker>
+  </>
+);
+
+jest.useFakeTimers();
+
+describe('DateTimePicker', () => {
+  const user = userEvent.setup({ delay: null });
+
+  let onChangeSpy: (date: Date) => void;
+
+  beforeEach(() => {
+    onChangeSpy = jest.fn();
+    mockDate.set(DEFAULT_DATE);
+  });
+
+  afterEach(() => {
+    mockDate.reset();
+  });
+
+  describe('Calendar display', () => {
+    it('doesnt render calendar elements when hidden', () => {
+      const { queryByTestId } = render(<Example value={DEFAULT_DATE} />);
+
+      expect(queryByTestId('datetimepicker-menu')).toBeEmptyDOMElement();
+    });
+
+    it('displays dates with correct previous styling', async () => {
+      const { getByTestId, getAllByTestId } = render(<Example value={DEFAULT_DATE} />);
+
+      await user.click(getByTestId('input'));
+      const days = getAllByTestId('day');
+
+      for (let x = 0; x < days.length; x++) {
+        if (x <= 4) {
+          expect(days[x]).toHaveAttribute('data-test-previous', 'true');
+        } else if (x >= 33) {
+          expect(days[x]).toHaveAttribute('data-test-previous', 'true');
+        } else {
+          expect(days[x]).toHaveAttribute('data-test-previous', 'false');
+        }
+      }
+    });
+
+    it('displays dates with selected and today styling', async () => {
+      const { getByTestId, getAllByTestId } = render(<Example value={DEFAULT_DATE} />);
+
+      await user.click(getByTestId('input'));
+      const days = getAllByTestId('day');
+
+      expect(days[9]).toHaveAttribute('data-test-selected', 'true');
+      expect(days[9]).toHaveAttribute('data-test-today', 'true');
+    });
+
+    it('displays "Sun" as default first day of week', async () => {
+      const { getByTestId, getAllByTestId } = render(<Example value={DEFAULT_DATE} />);
+
+      await user.click(getByTestId('input'));
+      const dayLabels = getAllByTestId('day-label');
+
+      expect(dayLabels[0]).toHaveTextContent('Sun');
+    });
+
+    it('displays locale based first day of week', async () => {
+      const { getByTestId, getAllByTestId } = render(
+        <Example value={DEFAULT_DATE} locale="en-GB" />
+      );
+
+      await user.click(getByTestId('input'));
+      const dayLabels = getAllByTestId('day-label');
+
+      expect(dayLabels[0]).toHaveTextContent('Mon');
+    });
+
+    it('displays disabled styling for minimum and maximum values', async () => {
+      const { getByTestId, getAllByTestId } = render(
+        <Example
+          value={DEFAULT_DATE}
+          minValue={subDays(DEFAULT_DATE, 2)}
+          maxValue={addDays(DEFAULT_DATE, 2)}
+        />
+      );
+
+      await user.click(getByTestId('input'));
+      const days = getAllByTestId('day');
+
+      for (let x = 0; x < days.length; x++) {
+        const element = days[x];
+
+        if (x <= 6) {
+          expect(element).toHaveAttribute('data-test-disabled', 'true');
+        } else if (x > 11) {
+          expect(element).toHaveAttribute('data-test-disabled', 'true');
+        } else {
+          expect(element).toHaveAttribute('data-test-disabled', 'false');
+        }
+      }
+    });
+
+    it('displays selected month in correct format', async () => {
+      const { getByTestId } = render(<Example value={DEFAULT_DATE} />);
+
+      await user.click(getByTestId('input'));
+
+      expect(getByTestId('month-display')).toHaveTextContent('February 2019');
+    });
+
+    it('displays previous month if previous paddle is clicked', async () => {
+      const { getByTestId } = render(<Example value={DEFAULT_DATE} />);
+
+      await user.click(getByTestId('input'));
+      fireEvent.click(getByTestId('previous-month'));
+
+      expect(getByTestId('month-display')).toHaveTextContent('January 2019');
+    });
+
+    it('displays next month if next paddle is clicked', async () => {
+      const { getByTestId } = render(<Example value={DEFAULT_DATE} />);
+
+      await user.click(getByTestId('input'));
+      fireEvent.click(getByTestId('next-month'));
+
+      expect(getByTestId('month-display')).toHaveTextContent('March 2019');
+    });
+
+    it('displays current month if no value is provided', async () => {
+      const { getByTestId } = render(<Example />);
+
+      await user.click(getByTestId('input'));
+
+      expect(getByTestId('month-display')).toHaveTextContent('February 2019');
+    });
+  });
+
+  describe('Calendar selection', () => {
+    it('calls onChange when date is selected', async () => {
+      const { getByTestId, getAllByTestId } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
+      );
+
+      await user.click(getByTestId('input'));
+      fireEvent.click(getAllByTestId('day')[1]);
+
+      expect(onChangeSpy).toHaveBeenCalledWith(new Date(2019, 0, 28, 14, 30, 0, 0));
+    });
+
+    it('does not close popup on date selection', async () => {
+      const { getByTestId, getAllByTestId } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
+      );
+
+      await user.click(getByTestId('input'));
+      fireEvent.click(getAllByTestId('day')[1]);
+
+      expect(getByTestId('datetimepicker-menu')).toHaveAttribute('data-test-open', 'true');
+    });
+
+    it('does not select date if before minDate', async () => {
+      const { getByTestId, getAllByTestId } = render(
+        <Example
+          value={DEFAULT_DATE}
+          onChange={onChangeSpy}
+          minValue={subDays(DEFAULT_DATE, 2)}
+          maxValue={addDays(DEFAULT_DATE, 2)}
+        />
+      );
+
+      await user.click(getByTestId('input'));
+      const days = getAllByTestId('day');
+
+      fireEvent.click(days[0]);
+      fireEvent.click(days[days.length - 1]);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Time panel', () => {
+    it('renders time panel when open', async () => {
+      const { getByTestId } = render(<Example value={DEFAULT_DATE} />);
+
+      await user.click(getByTestId('input'));
+
+      expect(getByTestId('time-panel')).toBeInTheDocument();
+    });
+
+    it('renders hour and minute columns', async () => {
+      const { getByTestId, getAllByTestId } = render(
+        <Example value={DEFAULT_DATE} isAmPm={false} />
+      );
+
+      await user.click(getByTestId('input'));
+      const columns = getAllByTestId('time-column');
+
+      expect(columns).toHaveLength(2);
+    });
+
+    it('renders AM/PM column when isAmPm is true', async () => {
+      const { getByTestId, getAllByTestId } = render(<Example value={DEFAULT_DATE} isAmPm />);
+
+      await user.click(getByTestId('input'));
+      const columns = getAllByTestId('time-column');
+
+      expect(columns).toHaveLength(3);
+    });
+
+    it('calls onChange when hour is selected', async () => {
+      const { getByTestId, getAllByTestId } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} isAmPm={false} />
+      );
+
+      await user.click(getByTestId('input'));
+      const options = getAllByTestId('time-option');
+      const hour10Option = options.find(el => el.textContent === '10');
+
+      fireEvent.click(hour10Option!);
+
+      expect(onChangeSpy).toHaveBeenCalledWith(new Date(2019, 1, 5, 10, 30, 0, 0));
+    });
+
+    it('calls onChange when minute is selected', async () => {
+      const { getByTestId, getAllByTestId } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} isAmPm={false} />
+      );
+
+      await user.click(getByTestId('input'));
+      const columns = getAllByTestId('time-column');
+      const minuteColumn = columns[1];
+      const minuteOptions = minuteColumn.querySelectorAll('[data-test-id="time-option"]');
+      const minute15Option = Array.from(minuteOptions).find(el => el.textContent === '15');
+
+      fireEvent.click(minute15Option!);
+
+      expect(onChangeSpy).toHaveBeenCalledWith(new Date(2019, 1, 5, 14, 15, 0, 0));
+    });
+
+    it('calls onChange when AM/PM is toggled', async () => {
+      const { getByTestId, getAllByTestId } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} isAmPm />
+      );
+
+      await user.click(getByTestId('input'));
+      const columns = getAllByTestId('time-column');
+      const periodColumn = columns[2];
+      const periodOptions = periodColumn.querySelectorAll('[data-test-id="time-option"]');
+      const amOption = Array.from(periodOptions).find(el => el.textContent === 'AM');
+
+      fireEvent.click(amOption!);
+
+      expect(onChangeSpy).toHaveBeenCalledWith(new Date(2019, 1, 5, 2, 30, 0, 0));
+    });
+
+    it('respects timeStep for minute intervals', async () => {
+      const { getByTestId, getAllByTestId } = render(
+        <Example value={DEFAULT_DATE} timeStep={15} isAmPm={false} />
+      );
+
+      await user.click(getByTestId('input'));
+      const columns = getAllByTestId('time-column');
+      const minuteColumn = columns[1];
+      const minuteOptions = minuteColumn.querySelectorAll('[data-test-id="time-option"]');
+
+      expect(minuteOptions).toHaveLength(4);
+      expect(minuteOptions[0]).toHaveTextContent('00');
+      expect(minuteOptions[1]).toHaveTextContent('15');
+      expect(minuteOptions[2]).toHaveTextContent('30');
+      expect(minuteOptions[3]).toHaveTextContent('45');
+    });
+
+    it('shows selected hour highlighted', async () => {
+      const { getByTestId, getAllByTestId } = render(
+        <Example value={DEFAULT_DATE} isAmPm={false} />
+      );
+
+      await user.click(getByTestId('input'));
+      const columns = getAllByTestId('time-column');
+      const hourColumn = columns[0];
+      const selected = hourColumn.querySelector('[data-test-selected="true"]');
+
+      expect(selected).toHaveTextContent('14');
+    });
+
+    it('shows selected minute highlighted', async () => {
+      const { getByTestId, getAllByTestId } = render(
+        <Example value={DEFAULT_DATE} isAmPm={false} />
+      );
+
+      await user.click(getByTestId('input'));
+      const columns = getAllByTestId('time-column');
+      const minuteColumn = columns[1];
+      const selected = minuteColumn.querySelector('[data-test-selected="true"]');
+
+      expect(selected).toHaveTextContent('30');
+    });
+  });
+
+  describe('Input', () => {
+    it('displays provided value with time', () => {
+      const { getByTestId } = render(<Example value={DEFAULT_DATE} onChange={onChangeSpy} />);
+
+      expect(getByTestId('input')).toHaveValue('February 5, 2019 at 2:30 PM');
+    });
+
+    it('displays empty string if no value provided', () => {
+      const { getByTestId } = render(<Example onChange={onChangeSpy} />);
+
+      expect(getByTestId('input')).toHaveValue('');
+    });
+
+    it('opens datetimepicker on focus', async () => {
+      const { getByTestId, queryByTestId } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
+      );
+
+      await user.click(getByTestId('input'));
+
+      expect(queryByTestId('datetimepicker-menu')).toHaveAttribute('data-test-open', 'true');
+    });
+
+    it('leaves datetimepicker closed on label click', () => {
+      const { getByTestId, queryByTestId } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
+      );
+
+      act(() => {
+        fireEvent.mouseUp(getByTestId('input'));
+        jest.runOnlyPendingTimers();
+        fireEvent.click(getByTestId('input'));
+      });
+
+      expect(queryByTestId('datetimepicker-menu')).toHaveAttribute('data-test-open', 'false');
+    });
+
+    it('closes datetimepicker on blur', async () => {
+      const { getByTestId, queryByTestId } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
+      );
+      const input = getByTestId('input');
+
+      await user.click(input);
+      await user.tab();
+
+      expect(queryByTestId('datetimepicker-menu')).toHaveAttribute('data-test-open', 'false');
+    });
+
+    it('closes datetimepicker when not animated', async () => {
+      const { getByTestId, queryByTestId } = render(
+        <Example isAnimated={false} value={DEFAULT_DATE} onChange={onChangeSpy} />
+      );
+      const input = getByTestId('input');
+
+      await user.click(input);
+      await user.tab();
+
+      expect(queryByTestId('datetimepicker-menu')).toHaveAttribute('data-test-open', 'false');
+    });
+
+    it('opens datetimepicker when correct keys are used', async () => {
+      const { getByTestId, queryByTestId } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
+      );
+      const input = getByTestId('input');
+
+      fireEvent.keyDown(input, { key: KEYS.UP });
+      expect(queryByTestId('datetimepicker-menu')).toHaveAttribute('data-test-open', 'true');
+      await user.tab();
+
+      fireEvent.keyDown(input, { key: KEYS.DOWN });
+      expect(queryByTestId('datetimepicker-menu')).toHaveAttribute('data-test-open', 'true');
+      await user.tab();
+
+      await user.type(input, ' ');
+      expect(queryByTestId('datetimepicker-menu')).toHaveAttribute('data-test-open', 'true');
+      await user.tab();
+    });
+
+    it('closes datetimepicker when correct keys are used', async () => {
+      const { getByTestId, queryByTestId } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
+      );
+      const input = getByTestId('input');
+
+      await user.click(input);
+      fireEvent.keyDown(input, { key: KEYS.ESCAPE });
+
+      expect(queryByTestId('datetimepicker-menu')).toHaveAttribute('data-test-open', 'false');
+
+      await user.click(input);
+      fireEvent.keyDown(input, { key: KEYS.ENTER });
+
+      expect(queryByTestId('datetimepicker-menu')).toHaveAttribute('data-test-open', 'false');
+    });
+
+    it('leaves datetimepicker open if calendar is moused down', async () => {
+      const { getByTestId } = render(<Example value={DEFAULT_DATE} onChange={onChangeSpy} />);
+      const input = getByTestId('input');
+
+      await user.click(input);
+      fireEvent.click(getByTestId('calendar-wrapper'));
+
+      expect(getByTestId('datetimepicker-menu')).toHaveAttribute('data-test-open', 'true');
+    });
+
+    it('leaves datetimepicker open if time panel is moused down', async () => {
+      const { getByTestId } = render(<Example value={DEFAULT_DATE} onChange={onChangeSpy} />);
+      const input = getByTestId('input');
+
+      await user.click(input);
+      fireEvent.click(getByTestId('time-panel'));
+
+      expect(getByTestId('datetimepicker-menu')).toHaveAttribute('data-test-open', 'true');
+    });
+
+    it('does not call onChange with provided date if invalid', () => {
+      const { getByTestId } = render(<Example value={DEFAULT_DATE} onChange={onChangeSpy} />);
+      const input = getByTestId('input');
+
+      fireEvent.change(input, { target: { value: 'invalid date' } });
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('updates input value when controlled value is changed', () => {
+      const { getByTestId, rerender } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
+      );
+
+      expect(getByTestId('input')).toHaveValue('February 5, 2019 at 2:30 PM');
+
+      rerender(<Example value={addDays(DEFAULT_DATE, 1)} onChange={onChangeSpy} />);
+
+      expect(getByTestId('input')).toHaveValue('February 6, 2019 at 2:30 PM');
+    });
+  });
+
+  describe('customParseDate()', () => {
+    it('uses customParseDate to determine date validity if provided', async () => {
+      const MOCK_DATE = new Date(2019, 0, 1, 10, 0);
+      const customParseDateSpy: (input: string) => Date = jest.fn().mockReturnValue(MOCK_DATE);
+      const { getByTestId } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} customParseDate={customParseDateSpy} />
+      );
+      const input = getByTestId('input');
+
+      await user.clear(input);
+      await user.type(input, 'invalid date');
+
+      expect(customParseDateSpy).toHaveBeenCalled();
+      expect(onChangeSpy).toHaveBeenCalledWith(MOCK_DATE);
+    });
+
+    it('does not call onChange if parsed date is the current value', async () => {
+      const customParseDateSpy: (input: string) => Date = jest.fn().mockReturnValue(DEFAULT_DATE);
+      const { getByTestId } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} customParseDate={customParseDateSpy} />
+      );
+      const input = getByTestId('input');
+
+      await user.clear(input);
+      await user.type(input, 'invalid date');
+
+      expect(customParseDateSpy).toHaveBeenCalled();
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('formatDate()', () => {
+    it('uses custom formatDate method if provided', () => {
+      const FORMATTED_DATE = 'test';
+      const { getByTestId } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} formatDate={() => FORMATTED_DATE} />
+      );
+      const input = getByTestId('input');
+
+      expect(input).toHaveValue(FORMATTED_DATE);
+    });
+  });
+
+  describe('Calendar', () => {
+    it('applies LTR classes by default', async () => {
+      const { getByTestId } = render(<Example value={DEFAULT_DATE} />);
+
+      await user.click(getByTestId('input'));
+
+      expect(getByTestId('datetimepicker-menu')).toHaveAttribute('data-test-rtl', 'false');
+    });
+
+    it('applies RTL classes if provided', async () => {
+      const { getByTestId } = renderRtl(<Example value={DEFAULT_DATE} />);
+
+      await user.click(getByTestId('input'));
+
+      expect(getByTestId('datetimepicker-menu')).toHaveAttribute('data-test-rtl', 'true');
+    });
+
+    it('portals as expected', () => {
+      const { container, rerender } = render(<Example />);
+      const selector = '[data-test-id="datetimepicker-menu"]';
+
+      expect(container.querySelector(selector)).not.toBeNull();
+
+      const node = document.createElement('DIV');
+
+      document.body.appendChild(node);
+
+      rerender(<Example appendToNode={node} />);
+
+      expect(container.querySelector(selector)).toBeNull();
+      expect(node.querySelector(selector)).not.toBeNull();
+    });
+  });
+});

--- a/packages/datepickers/src/elements/DateTimePicker/DateTimePicker.tsx
+++ b/packages/datepickers/src/elements/DateTimePicker/DateTimePicker.tsx
@@ -1,0 +1,215 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, {
+  useRef,
+  useEffect,
+  useReducer,
+  useCallback,
+  useState,
+  useContext,
+  useMemo,
+  forwardRef
+} from 'react';
+import { createPortal } from 'react-dom';
+import PropTypes from 'prop-types';
+import { mergeRefs } from 'react-merge-refs';
+import { ThemeContext } from 'styled-components';
+import { autoPlacement, autoUpdate, flip, platform, useFloating } from '@floating-ui/react-dom';
+import { IDateTimePickerProps, PLACEMENT, WEEK_STARTS_ON } from '../../types';
+import { Calendar } from './components/Calendar';
+import { TimePanel } from './components/TimePanel';
+import { dateTimepickerReducer, retrieveInitialState } from './utils/date-time-picker-reducer';
+import { DateTimePickerContext } from './utils/useDateTimePickerContext';
+import { StyledMenu, StyledMenuWrapper, StyledDateTimePicker } from '../../styled';
+import { DEFAULT_THEME, getFloatingPlacements } from '@zendeskgarden/react-theming';
+import { Input } from './components/Input';
+import { is12HourLocale } from './utils/time-utils';
+
+const PLACEMENT_DEFAULT = 'bottom-start';
+
+/**
+ * @extends HTMLAttributes<HTMLDivElement>
+ */
+export const DateTimePicker = forwardRef<HTMLDivElement, IDateTimePickerProps>(
+  (props, calendarRef) => {
+    const {
+      appendToNode,
+      children,
+      placement: _placement = PLACEMENT_DEFAULT,
+      zIndex = 1000,
+      isAnimated = true,
+      refKey = 'ref',
+      value,
+      isCompact,
+      onChange,
+      formatDate,
+      minValue,
+      maxValue,
+      locale = 'en-US',
+      weekStartsOn,
+      customParseDate,
+      timeStep = 1,
+      isAmPm,
+      ...menuProps
+    } = props;
+    const theme = useContext(ThemeContext) || DEFAULT_THEME;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const memoizedReducer = useCallback(
+      dateTimepickerReducer({ value, formatDate, locale, customParseDate, onChange }),
+      [value, formatDate, locale, onChange, customParseDate]
+    );
+    const [state, dispatch] = useReducer(memoizedReducer, retrieveInitialState(props));
+    const triggerRef = useRef<HTMLInputElement>(null);
+    const floatingRef = useRef<HTMLDivElement>(null);
+    const [isVisible, setIsVisible] = useState(state.isOpen);
+    const resolvedIsAmPm = useMemo(
+      () => (isAmPm === undefined ? is12HourLocale(locale) : isAmPm),
+      [isAmPm, locale]
+    );
+
+    const contextValue = useMemo(
+      () => ({
+        state,
+        dispatch,
+        isAmPm: resolvedIsAmPm,
+        timeStep,
+        minValue,
+        maxValue,
+        value,
+        isCompact,
+        locale
+      }),
+      [state, dispatch, resolvedIsAmPm, timeStep, minValue, maxValue, value, isCompact, locale]
+    );
+
+    const [floatingPlacement] = getFloatingPlacements(
+      theme,
+      _placement === 'auto' ? PLACEMENT_DEFAULT : _placement!
+    );
+
+    const {
+      refs,
+      placement,
+      update,
+      floatingStyles: { transform }
+    } = useFloating({
+      platform: {
+        ...platform,
+        isRTL: () => theme.rtl
+      },
+      elements: { reference: triggerRef?.current, floating: floatingRef?.current },
+      placement: floatingPlacement,
+      middleware: [_placement === 'auto' ? autoPlacement() : flip()]
+    });
+
+    const Child = React.Children.only<React.ReactElement & React.RefAttributes<HTMLInputElement>>(
+      children
+    );
+
+    useEffect(() => {
+      let cleanup: () => void;
+
+      if (state.isOpen && refs.reference.current && refs.floating.current) {
+        cleanup = autoUpdate(refs.reference.current, refs.floating.current, update, {
+          elementResize: typeof ResizeObserver === 'function'
+        });
+      }
+
+      return () => cleanup && cleanup();
+    }, [state.isOpen, refs.reference, refs.floating, update]);
+
+    useEffect(() => {
+      let timeout: NodeJS.Timeout;
+
+      if (state.isOpen) {
+        setIsVisible(true);
+      } else if (isAnimated) {
+        timeout = setTimeout(() => setIsVisible(false), 200);
+      } else {
+        setIsVisible(false);
+      }
+
+      return () => clearTimeout(timeout);
+    }, [state.isOpen, isAnimated]);
+
+    useEffect(() => {
+      dispatch({ type: 'CONTROLLED_VALUE_CHANGE', value });
+    }, [value]);
+
+    useEffect(() => {
+      dispatch({ type: 'CONTROLLED_LOCALE_CHANGE' });
+    }, [locale]);
+
+    const Node = (
+      <StyledMenuWrapper
+        ref={floatingRef}
+        style={{ transform }}
+        $isAnimated={!!isAnimated && (state.isOpen || isVisible)}
+        $placement={placement}
+        $zIndex={zIndex}
+        aria-hidden={!state.isOpen || undefined}
+        data-test-id="datetimepicker-menu"
+        data-test-open={state.isOpen}
+        data-test-rtl={theme.rtl}
+      >
+        {!!(state.isOpen || isVisible) && (
+          <StyledMenu {...menuProps}>
+            <StyledDateTimePicker $isCompact={!!isCompact}>
+              <Calendar
+                ref={calendarRef}
+                isCompact={isCompact}
+                value={value}
+                minValue={minValue}
+                maxValue={maxValue}
+                locale={locale}
+                weekStartsOn={weekStartsOn}
+              />
+              <TimePanel />
+            </StyledDateTimePicker>
+          </StyledMenu>
+        )}
+      </StyledMenuWrapper>
+    );
+
+    return (
+      <>
+        <Input
+          element={Child}
+          dispatch={dispatch}
+          state={state}
+          refKey={refKey!}
+          ref={mergeRefs([triggerRef, Child.ref ? Child.ref : null])}
+        />
+        <DateTimePickerContext.Provider value={contextValue}>
+          {appendToNode ? createPortal(Node, appendToNode) : Node}
+        </DateTimePickerContext.Provider>
+      </>
+    );
+  }
+);
+
+DateTimePicker.displayName = 'DateTimePicker';
+
+DateTimePicker.propTypes = {
+  appendToNode: PropTypes.any,
+  value: PropTypes.any,
+  onChange: PropTypes.any,
+  formatDate: PropTypes.func,
+  locale: PropTypes.any,
+  weekStartsOn: PropTypes.oneOf(WEEK_STARTS_ON),
+  minValue: PropTypes.any,
+  maxValue: PropTypes.any,
+  isCompact: PropTypes.bool,
+  customParseDate: PropTypes.any,
+  refKey: PropTypes.string,
+  placement: PropTypes.oneOf(PLACEMENT),
+  isAnimated: PropTypes.bool,
+  zIndex: PropTypes.number,
+  timeStep: PropTypes.number,
+  isAmPm: PropTypes.bool
+};

--- a/packages/datepickers/src/elements/DateTimePicker/components/Calendar.tsx
+++ b/packages/datepickers/src/elements/DateTimePicker/components/Calendar.tsx
@@ -1,0 +1,141 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { forwardRef, HTMLAttributes, useCallback } from 'react';
+import { addDays } from 'date-fns/addDays';
+import { eachDayOfInterval } from 'date-fns/eachDayOfInterval';
+import { endOfMonth } from 'date-fns/endOfMonth';
+import { endOfWeek } from 'date-fns/endOfWeek';
+import { getDate } from 'date-fns/getDate';
+import { isAfter } from 'date-fns/isAfter';
+import { isBefore } from 'date-fns/isBefore';
+import { isSameDay } from 'date-fns/isSameDay';
+import { isSameMonth } from 'date-fns/isSameMonth';
+import { isToday } from 'date-fns/isToday';
+import { startOfMonth } from 'date-fns/startOfMonth';
+import { startOfWeek } from 'date-fns/startOfWeek';
+
+import {
+  StyledDatePicker,
+  StyledCalendar,
+  StyledCalendarItem,
+  StyledDayLabel,
+  StyledDay
+} from '../../../styled';
+import { DateFnsIndex, getStartOfWeek } from '../../../utils/calendar-utils';
+import useDateTimePickerContext from '../utils/useDateTimePickerContext';
+import { MonthSelector } from './MonthSelector';
+
+interface ICalendarProps extends HTMLAttributes<HTMLDivElement> {
+  value?: Date;
+  minValue?: Date;
+  maxValue?: Date;
+  isCompact?: boolean;
+  locale?: string;
+  weekStartsOn?: DateFnsIndex;
+}
+
+export const Calendar = forwardRef<HTMLDivElement, ICalendarProps>(
+  ({ value, minValue, maxValue, isCompact, locale, weekStartsOn }, ref) => {
+    const { state, dispatch } = useDateTimePickerContext();
+
+    const preferredWeekStartsOn = weekStartsOn || getStartOfWeek(locale);
+    const monthStartDate = startOfMonth(state.previewDate);
+    const monthEndDate = endOfMonth(monthStartDate);
+    const startDate = startOfWeek(monthStartDate, {
+      weekStartsOn: preferredWeekStartsOn
+    });
+    const endDate = endOfWeek(monthEndDate, {
+      weekStartsOn: preferredWeekStartsOn
+    });
+
+    const dayLabelFormatter = useCallback<(date: Date) => string>(
+      date => {
+        const formatter = new Intl.DateTimeFormat(locale, {
+          weekday: 'short'
+        });
+
+        return formatter.format(date);
+      },
+      [locale]
+    );
+
+    const dayLabels = eachDayOfInterval({ start: startDate, end: addDays(startDate, 6) }).map(
+      date => {
+        const formattedDayLabel = dayLabelFormatter(date);
+
+        return (
+          <StyledCalendarItem key={`day-label-${formattedDayLabel}`} $isCompact={isCompact}>
+            <StyledDayLabel $isCompact={isCompact!} data-test-id="day-label">
+              {formattedDayLabel}
+            </StyledDayLabel>
+          </StyledCalendarItem>
+        );
+      }
+    );
+
+    const items = eachDayOfInterval({ start: startDate, end: endDate }).map(date => {
+      const formattedDayLabel = getDate(date);
+      const isCurrentDate = isToday(date);
+      const isPreviousMonth = !isSameMonth(date, state.previewDate);
+      const isSelected = value && isSameDay(date, value);
+
+      let isDisabled = false;
+
+      if (minValue !== undefined) {
+        isDisabled = isBefore(date, minValue) && !isSameDay(date, minValue);
+      }
+
+      if (maxValue !== undefined) {
+        isDisabled = isDisabled || (isAfter(date, maxValue) && !isSameDay(date, maxValue));
+      }
+
+      return (
+        <StyledCalendarItem key={date.toISOString()} $isCompact={isCompact}>
+          <StyledDay
+            $isToday={isCurrentDate}
+            $isPreviousMonth={isPreviousMonth}
+            $isCompact={isCompact!}
+            aria-selected={isSelected || undefined}
+            aria-disabled={isDisabled || undefined}
+            onClick={() => {
+              if (!isDisabled) {
+                dispatch({ type: 'SELECT_DATE', value: date });
+              }
+            }}
+            data-test-id="day"
+            data-test-previous={isPreviousMonth}
+            data-test-selected={isSelected}
+            data-test-disabled={isDisabled}
+            data-test-today={isCurrentDate}
+          >
+            {formattedDayLabel}
+          </StyledDay>
+        </StyledCalendarItem>
+      );
+    });
+
+    return (
+      <StyledDatePicker
+        ref={ref}
+        $isCompact={isCompact!}
+        data-test-id="calendar-wrapper"
+        onMouseDown={e => {
+          e.preventDefault();
+        }}
+      >
+        <MonthSelector locale={locale} isCompact={isCompact!} />
+        <StyledCalendar $isCompact={isCompact!}>
+          {dayLabels}
+          {items}
+        </StyledCalendar>
+      </StyledDatePicker>
+    );
+  }
+);
+
+Calendar.displayName = 'Calendar';

--- a/packages/datepickers/src/elements/DateTimePicker/components/Input.tsx
+++ b/packages/datepickers/src/elements/DateTimePicker/components/Input.tsx
@@ -1,0 +1,76 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { Dispatch, ReactElement, RefAttributes, cloneElement, forwardRef, useRef } from 'react';
+import { KEYS, composeEventHandlers } from '@zendeskgarden/container-utilities';
+
+import { DateTimePickerAction, IDateTimePickerState } from '../utils/date-time-picker-reducer';
+
+interface IInputProps {
+  dispatch: Dispatch<DateTimePickerAction>;
+  element: ReactElement & RefAttributes<HTMLInputElement>;
+  refKey: string;
+  state: IDateTimePickerState;
+}
+
+export const Input = forwardRef<HTMLInputElement, IInputProps>(
+  ({ element, dispatch, state, refKey }, ref) => {
+    const isInputMouseDownRef = useRef(false);
+
+    const handleBlur = () => {
+      dispatch({ type: 'CLOSE' });
+    };
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      dispatch({ type: 'MANUALLY_UPDATE_INPUT', value: e.target.value });
+    };
+
+    const handleClick = () => {
+      if (isInputMouseDownRef.current && !state.isOpen) {
+        dispatch({ type: 'OPEN' });
+      }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      switch (e.key) {
+        case KEYS.ESCAPE:
+        case KEYS.ENTER:
+          dispatch({ type: 'CLOSE' });
+          break;
+        case KEYS.UP:
+        case KEYS.DOWN:
+        case KEYS.SPACE:
+          dispatch({ type: 'OPEN' });
+          break;
+      }
+    };
+
+    const handleMouseDown = () => {
+      isInputMouseDownRef.current = true;
+    };
+
+    const handleMouseUp = () => {
+      setTimeout(() => {
+        isInputMouseDownRef.current = false;
+      }, 0);
+    };
+
+    return cloneElement(element, {
+      [refKey!]: ref,
+      onMouseDown: composeEventHandlers(element.props.onMouseDown, handleMouseDown),
+      onMouseUp: composeEventHandlers(element.props.onMouseUp, handleMouseUp),
+      onClick: composeEventHandlers(element.props.onClick, handleClick),
+      onBlur: composeEventHandlers(element.props.onBlur, handleBlur),
+      onChange: composeEventHandlers(element.props.onChange, handleChange),
+      onKeyDown: composeEventHandlers(element.props.onKeyDown, handleKeyDown),
+      autoComplete: 'off',
+      value: state.inputValue
+    });
+  }
+);
+
+Input.displayName = 'Input';

--- a/packages/datepickers/src/elements/DateTimePicker/components/MonthSelector.tsx
+++ b/packages/datepickers/src/elements/DateTimePicker/components/MonthSelector.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useCallback } from 'react';
+import ChevronLeftStrokeIcon from '@zendeskgarden/svg-icons/src/16/chevron-left-stroke.svg';
+import ChevronRightStrokeIcon from '@zendeskgarden/svg-icons/src/16/chevron-right-stroke.svg';
+
+import { StyledHeader, StyledHeaderPaddle, StyledHeaderLabel } from '../../../styled';
+import useDateTimePickerContext from '../utils/useDateTimePickerContext';
+
+interface IMonthSelectorProps {
+  locale?: string;
+  isCompact: boolean;
+}
+
+export const MonthSelector: React.FunctionComponent<IMonthSelectorProps> = ({
+  locale,
+  isCompact
+}) => {
+  const { state, dispatch } = useDateTimePickerContext();
+
+  const headerLabelFormatter = useCallback<(date: Date) => string>(
+    date => {
+      const formatter = new Intl.DateTimeFormat(locale, {
+        month: 'long',
+        year: 'numeric'
+      });
+
+      return formatter.format(date);
+    },
+    [locale]
+  );
+
+  return (
+    <StyledHeader $isCompact={isCompact}>
+      <StyledHeaderPaddle
+        $isCompact={isCompact}
+        onClick={() => {
+          dispatch({ type: 'PREVIEW_PREVIOUS_MONTH' });
+        }}
+        data-test-id="previous-month"
+      >
+        <ChevronLeftStrokeIcon />
+      </StyledHeaderPaddle>
+      <StyledHeaderLabel $isCompact={isCompact} data-test-id="month-display">
+        {headerLabelFormatter(state.previewDate)}
+      </StyledHeaderLabel>
+      <StyledHeaderPaddle
+        $isCompact={isCompact}
+        onClick={() => {
+          dispatch({ type: 'PREVIEW_NEXT_MONTH' });
+        }}
+        data-test-id="next-month"
+      >
+        <ChevronRightStrokeIcon />
+      </StyledHeaderPaddle>
+    </StyledHeader>
+  );
+};

--- a/packages/datepickers/src/elements/DateTimePicker/components/TimeColumn.tsx
+++ b/packages/datepickers/src/elements/DateTimePicker/components/TimeColumn.tsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useEffect, useRef } from 'react';
+
+import { StyledTimeColumn, StyledTimeOption } from '../../../styled';
+
+interface ITimeColumnProps {
+  options: { value: string; label: string }[];
+  selectedValue: string;
+  disabledValues?: string[];
+  isCompact?: boolean;
+  isScrollable?: boolean;
+  onSelect: (value: string) => void;
+}
+
+export const TimeColumn: React.FunctionComponent<ITimeColumnProps> = ({
+  options,
+  selectedValue,
+  disabledValues = [],
+  isCompact,
+  isScrollable = true,
+  onSelect
+}) => {
+  const selectedRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (selectedRef.current?.scrollIntoView) {
+      selectedRef.current.scrollIntoView({ block: 'nearest' });
+    }
+  }, [selectedValue]);
+
+  return (
+    <StyledTimeColumn
+      $isCompact={isCompact}
+      $isScrollable={isScrollable}
+      data-test-id="time-column"
+    >
+      {options.map(option => {
+        const isSelected = option.value === selectedValue;
+        const isDisabled = disabledValues.includes(option.value);
+
+        return (
+          <StyledTimeOption
+            key={option.value}
+            ref={isSelected ? selectedRef : undefined}
+            $isCompact={isCompact}
+            aria-selected={isSelected || undefined}
+            aria-disabled={isDisabled || undefined}
+            onClick={() => {
+              if (!isDisabled) {
+                onSelect(option.value);
+              }
+            }}
+            data-test-id="time-option"
+            data-test-selected={isSelected}
+            data-test-disabled={isDisabled}
+          >
+            {option.label}
+          </StyledTimeOption>
+        );
+      })}
+    </StyledTimeColumn>
+  );
+};
+
+TimeColumn.displayName = 'TimeColumn';

--- a/packages/datepickers/src/elements/DateTimePicker/components/TimePanel.tsx
+++ b/packages/datepickers/src/elements/DateTimePicker/components/TimePanel.tsx
@@ -1,0 +1,132 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useContext, useMemo } from 'react';
+import { ThemeContext } from 'styled-components';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+import { StyledTimePanel } from '../../../styled';
+import {
+  formatTimeOption,
+  generateHourOptions,
+  generateMinuteOptions,
+  getDayPeriodLabels,
+  getDisabledHours,
+  getDisabledMinutes,
+  to12Hour
+} from '../utils/time-utils';
+import useDateTimePickerContext from '../utils/useDateTimePickerContext';
+import { TimeColumn } from './TimeColumn';
+
+export const TimePanel: React.FunctionComponent = () => {
+  const theme = useContext(ThemeContext) || DEFAULT_THEME;
+  const { state, dispatch, isAmPm, timeStep, minValue, maxValue, value, isCompact, locale } =
+    useDateTimePickerContext();
+
+  const hourOptions = useMemo(() => generateHourOptions(isAmPm), [isAmPm]);
+  const minuteOptions = useMemo(() => generateMinuteOptions(timeStep), [timeStep]);
+
+  const disabledHours = useMemo(
+    () => getDisabledHours(value, minValue, maxValue),
+    [value, minValue, maxValue]
+  );
+
+  const disabledMinutes = useMemo(
+    () => getDisabledMinutes(value, state.selectedHour, minValue, maxValue),
+    [value, state.selectedHour, minValue, maxValue]
+  );
+
+  const dayPeriodLabels = useMemo(() => getDayPeriodLabels(locale), [locale]);
+
+  const selectedHourDisplay = isAmPm
+    ? to12Hour(state.selectedHour).hour.toString()
+    : state.selectedHour.toString();
+
+  const selectedPeriod = state.selectedHour >= 12 ? 'PM' : 'AM';
+
+  const hourItems = hourOptions.map(h => ({
+    value: h.toString(),
+    label: isAmPm ? h.toString() : formatTimeOption(h)
+  }));
+
+  const disabledHourValues = isAmPm
+    ? disabledHours
+        .map(h => {
+          const { hour, period } = to12Hour(h);
+
+          return period === selectedPeriod ? hour.toString() : null;
+        })
+        .filter((v): v is string => v !== null)
+    : disabledHours.map(h => h.toString());
+
+  const minuteItems = minuteOptions.map(m => ({
+    value: m.toString(),
+    label: formatTimeOption(m)
+  }));
+
+  const disabledMinuteValues = disabledMinutes.map(m => m.toString());
+
+  const periodItems = [
+    { value: 'AM', label: dayPeriodLabels.am },
+    { value: 'PM', label: dayPeriodLabels.pm }
+  ];
+
+  const periodColumn = isAmPm ? (
+    <TimeColumn
+      options={periodItems}
+      selectedValue={selectedPeriod}
+      isCompact={isCompact}
+      isScrollable={false}
+      onSelect={val => {
+        dispatch({ type: 'SELECT_PERIOD', value: val as 'AM' | 'PM' });
+      }}
+    />
+  ) : null;
+
+  return (
+    <StyledTimePanel
+      $isCompact={isCompact}
+      data-test-id="time-panel"
+      onMouseDown={e => {
+        e.preventDefault();
+      }}
+    >
+      {theme.rtl ? periodColumn : null}
+      <TimeColumn
+        options={hourItems}
+        selectedValue={selectedHourDisplay}
+        disabledValues={disabledHourValues}
+        isCompact={isCompact}
+        onSelect={val => {
+          let hour = parseInt(val, 10);
+
+          if (isAmPm) {
+            if (selectedPeriod === 'PM' && hour !== 12) {
+              hour += 12;
+            } else if (selectedPeriod === 'AM' && hour === 12) {
+              hour = 0;
+            }
+          }
+
+          dispatch({ type: 'SELECT_HOUR', value: hour });
+        }}
+      />
+      <TimeColumn
+        options={minuteItems}
+        selectedValue={state.selectedMinute.toString()}
+        disabledValues={disabledMinuteValues}
+        isCompact={isCompact}
+        onSelect={val => {
+          dispatch({ type: 'SELECT_MINUTE', value: parseInt(val, 10) });
+        }}
+      />
+      {theme.rtl ? null : periodColumn}
+    </StyledTimePanel>
+  );
+};
+
+TimePanel.displayName = 'TimePanel';

--- a/packages/datepickers/src/elements/DateTimePicker/utils/date-time-picker-reducer.ts
+++ b/packages/datepickers/src/elements/DateTimePicker/utils/date-time-picker-reducer.ts
@@ -1,0 +1,265 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { addMonths } from 'date-fns/addMonths';
+import { isBefore } from 'date-fns/isBefore';
+import { isSameDay } from 'date-fns/isSameDay';
+import { isValid } from 'date-fns/isValid';
+import { parse } from 'date-fns/parse';
+import { subMonths } from 'date-fns/subMonths';
+
+import { IDateTimePickerProps } from '../../../types';
+
+export interface IDateTimePickerState {
+  isOpen: boolean;
+  previewDate: Date;
+  inputValue: string;
+  selectedHour: number;
+  selectedMinute: number;
+}
+
+function parseInputValue({
+  inputValue,
+  customParseDate
+}: {
+  inputValue: string;
+  customParseDate?: (value: string) => Date;
+}): Date {
+  if (customParseDate) {
+    return customParseDate(inputValue);
+  }
+
+  const MINIMUM_DATE = new Date(1001, 0, 0);
+  let tryParseDate = parse(inputValue, 'Pp', new Date());
+
+  if (isValid(tryParseDate) && !isBefore(tryParseDate, MINIMUM_DATE)) {
+    return tryParseDate;
+  }
+
+  tryParseDate = parse(inputValue, 'PPp', new Date());
+
+  if (isValid(tryParseDate) && !isBefore(tryParseDate, MINIMUM_DATE)) {
+    return tryParseDate;
+  }
+
+  tryParseDate = parse(inputValue, 'PPPp', new Date());
+
+  if (isValid(tryParseDate) && !isBefore(tryParseDate, MINIMUM_DATE)) {
+    return tryParseDate;
+  }
+
+  return new Date(NaN);
+}
+
+function formatInputValue({
+  date,
+  locale,
+  formatDate
+}: {
+  date?: Date;
+  locale: string;
+  formatDate?: (d: Date) => string;
+}) {
+  if (!date) {
+    return '';
+  }
+
+  if (formatDate) {
+    return formatDate(date);
+  }
+
+  return new Intl.DateTimeFormat(locale, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  }).format(date);
+}
+
+export type DateTimePickerAction =
+  | { type: 'OPEN' }
+  | { type: 'CLOSE' }
+  | { type: 'PREVIEW_NEXT_MONTH' }
+  | { type: 'PREVIEW_PREVIOUS_MONTH' }
+  | { type: 'MANUALLY_UPDATE_INPUT'; value: string }
+  | { type: 'CONTROLLED_VALUE_CHANGE'; value?: Date }
+  | { type: 'CONTROLLED_LOCALE_CHANGE' }
+  | { type: 'SELECT_DATE'; value: Date }
+  | { type: 'SELECT_HOUR'; value: number }
+  | { type: 'SELECT_MINUTE'; value: number }
+  | { type: 'SELECT_PERIOD'; value: 'AM' | 'PM' };
+
+export const dateTimepickerReducer =
+  ({
+    value,
+    formatDate,
+    locale,
+    customParseDate,
+    onChange
+  }: {
+    value?: Date;
+    formatDate?: (date: Date) => string;
+    locale: string;
+    customParseDate?: (inputValue: string) => Date;
+    onChange?: (date: Date) => void;
+  }) =>
+  (state: IDateTimePickerState, action: DateTimePickerAction): IDateTimePickerState => {
+    switch (action.type) {
+      case 'OPEN':
+        return { ...state, isOpen: true, previewDate: value || new Date() };
+      case 'CLOSE': {
+        const inputValue = formatInputValue({ date: value, locale, formatDate });
+
+        return { ...state, isOpen: false, inputValue };
+      }
+      case 'PREVIEW_NEXT_MONTH': {
+        const previewDate = addMonths(state.previewDate, 1);
+
+        return { ...state, previewDate };
+      }
+      case 'PREVIEW_PREVIOUS_MONTH': {
+        const previewDate = subMonths(state.previewDate, 1);
+
+        return { ...state, previewDate };
+      }
+      case 'MANUALLY_UPDATE_INPUT': {
+        const inputValue = action.value;
+        const currentDate = parseInputValue({ inputValue, customParseDate });
+
+        if (onChange && currentDate && isValid(currentDate)) {
+          const isDifferent = !value || currentDate.getTime() !== value.getTime();
+
+          if (isDifferent) {
+            onChange(currentDate);
+          }
+        }
+
+        return { ...state, isOpen: true, inputValue };
+      }
+      case 'CONTROLLED_VALUE_CHANGE': {
+        const previewDate = action.value || new Date();
+        const inputValue = formatInputValue({ date: action.value, locale, formatDate });
+        const selectedHour = action.value ? action.value.getHours() : 0;
+        const selectedMinute = action.value ? action.value.getMinutes() : 0;
+
+        return { ...state, previewDate, inputValue, selectedHour, selectedMinute };
+      }
+      case 'CONTROLLED_LOCALE_CHANGE': {
+        const inputValue = formatInputValue({ date: value, locale, formatDate });
+
+        return { ...state, inputValue };
+      }
+      case 'SELECT_DATE': {
+        const newDate = new Date(action.value);
+
+        newDate.setHours(state.selectedHour, state.selectedMinute, 0, 0);
+
+        const inputValue = formatInputValue({ date: newDate, locale, formatDate });
+
+        if (
+          onChange &&
+          isValid(newDate) &&
+          (!value ||
+            !isSameDay(value, action.value) ||
+            value.getHours() !== state.selectedHour ||
+            value.getMinutes() !== state.selectedMinute)
+        ) {
+          onChange(newDate);
+        }
+
+        return { ...state, inputValue };
+      }
+      case 'SELECT_HOUR': {
+        const selectedHour = action.value;
+        const baseDate = value ? new Date(value) : new Date();
+
+        baseDate.setHours(selectedHour, state.selectedMinute, 0, 0);
+
+        const inputValue = formatInputValue({ date: baseDate, locale, formatDate });
+
+        if (onChange && isValid(baseDate)) {
+          onChange(baseDate);
+        }
+
+        return { ...state, selectedHour, inputValue };
+      }
+      case 'SELECT_MINUTE': {
+        const selectedMinute = action.value;
+        const baseDate = value ? new Date(value) : new Date();
+
+        baseDate.setHours(state.selectedHour, selectedMinute, 0, 0);
+
+        const inputValue = formatInputValue({ date: baseDate, locale, formatDate });
+
+        if (onChange && isValid(baseDate)) {
+          onChange(baseDate);
+        }
+
+        return { ...state, selectedMinute, inputValue };
+      }
+      case 'SELECT_PERIOD': {
+        let selectedHour = state.selectedHour;
+
+        if (action.value === 'AM' && selectedHour >= 12) {
+          selectedHour -= 12;
+        } else if (action.value === 'PM' && selectedHour < 12) {
+          selectedHour += 12;
+        }
+
+        const baseDate = value ? new Date(value) : new Date();
+
+        baseDate.setHours(selectedHour, state.selectedMinute, 0, 0);
+
+        const inputValue = formatInputValue({ date: baseDate, locale, formatDate });
+
+        if (onChange && isValid(baseDate)) {
+          onChange(baseDate);
+        }
+
+        return { ...state, selectedHour, inputValue };
+      }
+      /* istanbul ignore next */
+      default:
+        throw new Error();
+    }
+  };
+
+export function retrieveInitialState(initialProps: IDateTimePickerProps): IDateTimePickerState {
+  let previewDate = initialProps.value;
+
+  if (previewDate === undefined || !isValid(previewDate)) {
+    previewDate = new Date();
+  }
+
+  let inputValue = '';
+
+  if (initialProps.value !== undefined) {
+    if (initialProps.formatDate) {
+      inputValue = initialProps.formatDate(initialProps.value);
+    } else {
+      inputValue = new Intl.DateTimeFormat(initialProps.locale, {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit'
+      }).format(previewDate);
+    }
+  }
+
+  const selectedHour = initialProps.value ? initialProps.value.getHours() : 0;
+  const selectedMinute = initialProps.value ? initialProps.value.getMinutes() : 0;
+
+  return {
+    isOpen: false,
+    previewDate,
+    inputValue,
+    selectedHour,
+    selectedMinute
+  };
+}

--- a/packages/datepickers/src/elements/DateTimePicker/utils/time-utils.spec.ts
+++ b/packages/datepickers/src/elements/DateTimePicker/utils/time-utils.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import {
+  is12HourLocale,
+  getDayPeriodLabels,
+  generateHourOptions,
+  generateMinuteOptions,
+  formatTimeOption,
+  to12Hour,
+  to24Hour,
+  getDisabledHours,
+  getDisabledMinutes
+} from './time-utils';
+
+describe('time-utils', () => {
+  describe('is12HourLocale', () => {
+    it('returns true for en-US', () => {
+      expect(is12HourLocale('en-US')).toBe(true);
+    });
+
+    it('returns false for de-DE', () => {
+      expect(is12HourLocale('de-DE')).toBe(false);
+    });
+
+    it('returns false for en-GB', () => {
+      expect(is12HourLocale('en-GB')).toBe(false);
+    });
+
+    it('returns true for ko', () => {
+      expect(is12HourLocale('ko')).toBe(true);
+    });
+  });
+
+  describe('getDayPeriodLabels', () => {
+    it('returns AM/PM for en-US', () => {
+      const labels = getDayPeriodLabels('en-US');
+
+      expect(labels.am).toBe('AM');
+      expect(labels.pm).toBe('PM');
+    });
+
+    it('returns locale-specific labels for ja', () => {
+      const labels = getDayPeriodLabels('ja');
+
+      expect(labels.am).toBeDefined();
+      expect(labels.pm).toBeDefined();
+      expect(labels.am).not.toBe(labels.pm);
+    });
+  });
+
+  describe('generateHourOptions', () => {
+    it('returns 1-12 for 12-hour mode', () => {
+      const options = generateHourOptions(true);
+
+      expect(options).toStrictEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    });
+
+    it('returns 0-23 for 24-hour mode', () => {
+      const options = generateHourOptions(false);
+
+      expect(options).toHaveLength(24);
+      expect(options[0]).toBe(0);
+      expect(options[23]).toBe(23);
+    });
+  });
+
+  describe('generateMinuteOptions', () => {
+    it('returns 0-59 for step of 1', () => {
+      const options = generateMinuteOptions(1);
+
+      expect(options).toHaveLength(60);
+      expect(options[0]).toBe(0);
+      expect(options[59]).toBe(59);
+    });
+
+    it('returns correct intervals for step of 15', () => {
+      const options = generateMinuteOptions(15);
+
+      expect(options).toStrictEqual([0, 15, 30, 45]);
+    });
+
+    it('returns correct intervals for step of 30', () => {
+      const options = generateMinuteOptions(30);
+
+      expect(options).toStrictEqual([0, 30]);
+    });
+  });
+
+  describe('formatTimeOption', () => {
+    it('pads single digit with zero', () => {
+      expect(formatTimeOption(5)).toBe('05');
+    });
+
+    it('does not pad double digits', () => {
+      expect(formatTimeOption(15)).toBe('15');
+    });
+
+    it('formats zero correctly', () => {
+      expect(formatTimeOption(0)).toBe('00');
+    });
+  });
+
+  describe('to12Hour', () => {
+    it('converts 0 to 12 AM', () => {
+      expect(to12Hour(0)).toStrictEqual({ hour: 12, period: 'AM' });
+    });
+
+    it('converts 12 to 12 PM', () => {
+      expect(to12Hour(12)).toStrictEqual({ hour: 12, period: 'PM' });
+    });
+
+    it('converts 13 to 1 PM', () => {
+      expect(to12Hour(13)).toStrictEqual({ hour: 1, period: 'PM' });
+    });
+
+    it('converts 11 to 11 AM', () => {
+      expect(to12Hour(11)).toStrictEqual({ hour: 11, period: 'AM' });
+    });
+  });
+
+  describe('to24Hour', () => {
+    it('converts 12 AM to 0', () => {
+      expect(to24Hour(12, 'AM')).toBe(0);
+    });
+
+    it('converts 12 PM to 12', () => {
+      expect(to24Hour(12, 'PM')).toBe(12);
+    });
+
+    it('converts 1 PM to 13', () => {
+      expect(to24Hour(1, 'PM')).toBe(13);
+    });
+
+    it('converts 11 AM to 11', () => {
+      expect(to24Hour(11, 'AM')).toBe(11);
+    });
+  });
+
+  describe('getDisabledHours', () => {
+    it('returns empty array when no constraints', () => {
+      const result = getDisabledHours(new Date(2019, 1, 5, 10, 0), undefined, undefined);
+
+      expect(result).toStrictEqual([]);
+    });
+
+    it('disables hours before minValue on same day', () => {
+      const value = new Date(2019, 1, 5, 10, 0);
+      const minValue = new Date(2019, 1, 5, 8, 0);
+      const result = getDisabledHours(value, minValue, undefined);
+
+      expect(result).toContain(0);
+      expect(result).toContain(7);
+      expect(result).not.toContain(8);
+      expect(result).not.toContain(10);
+    });
+
+    it('disables hours after maxValue on same day', () => {
+      const value = new Date(2019, 1, 5, 10, 0);
+      const maxValue = new Date(2019, 1, 5, 16, 0);
+      const result = getDisabledHours(value, undefined, maxValue);
+
+      expect(result).not.toContain(16);
+      expect(result).toContain(17);
+      expect(result).toContain(23);
+    });
+
+    it('returns empty array when value is on a different day than constraints', () => {
+      const value = new Date(2019, 1, 5, 10, 0);
+      const minValue = new Date(2019, 1, 4, 8, 0);
+      const result = getDisabledHours(value, minValue, undefined);
+
+      expect(result).toStrictEqual([]);
+    });
+  });
+
+  describe('getDisabledMinutes', () => {
+    it('returns empty array when no constraints', () => {
+      const result = getDisabledMinutes(new Date(2019, 1, 5, 10, 0), 10, undefined, undefined);
+
+      expect(result).toStrictEqual([]);
+    });
+
+    it('disables minutes before minValue on same day and hour', () => {
+      const value = new Date(2019, 1, 5, 10, 30);
+      const minValue = new Date(2019, 1, 5, 10, 15);
+      const result = getDisabledMinutes(value, 10, minValue, undefined);
+
+      expect(result).toContain(0);
+      expect(result).toContain(14);
+      expect(result).not.toContain(15);
+      expect(result).not.toContain(30);
+    });
+
+    it('disables minutes after maxValue on same day and hour', () => {
+      const value = new Date(2019, 1, 5, 10, 30);
+      const maxValue = new Date(2019, 1, 5, 10, 45);
+      const result = getDisabledMinutes(value, 10, undefined, maxValue);
+
+      expect(result).not.toContain(45);
+      expect(result).toContain(46);
+      expect(result).toContain(59);
+    });
+
+    it('returns empty array when selected hour differs from constraint hour', () => {
+      const value = new Date(2019, 1, 5, 10, 30);
+      const minValue = new Date(2019, 1, 5, 8, 15);
+      const result = getDisabledMinutes(value, 10, minValue, undefined);
+
+      expect(result).toStrictEqual([]);
+    });
+  });
+});

--- a/packages/datepickers/src/elements/DateTimePicker/utils/time-utils.ts
+++ b/packages/datepickers/src/elements/DateTimePicker/utils/time-utils.ts
@@ -1,0 +1,155 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { isSameDay } from 'date-fns/isSameDay';
+
+/**
+ * Detect whether a locale uses 12-hour time format
+ */
+export function is12HourLocale(locale: string): boolean {
+  const parts = new Intl.DateTimeFormat(locale, { hour: 'numeric' }).formatToParts(
+    new Date(2020, 0, 1, 13)
+  );
+
+  return parts.some(part => part.type === 'dayPeriod');
+}
+
+/**
+ * Get locale-aware AM/PM labels
+ */
+export function getDayPeriodLabels(locale: string): { am: string; pm: string } {
+  const amParts = new Intl.DateTimeFormat(locale, { hour: 'numeric', hour12: true }).formatToParts(
+    new Date(2020, 0, 1, 8)
+  );
+  const pmParts = new Intl.DateTimeFormat(locale, { hour: 'numeric', hour12: true }).formatToParts(
+    new Date(2020, 0, 1, 20)
+  );
+
+  const am = amParts.find(p => p.type === 'dayPeriod')?.value ?? 'AM';
+  const pm = pmParts.find(p => p.type === 'dayPeriod')?.value ?? 'PM';
+
+  return { am, pm };
+}
+
+/**
+ * Generate hour options based on 12h/24h mode
+ */
+export function generateHourOptions(is12Hour: boolean): number[] {
+  if (is12Hour) {
+    return Array.from({ length: 12 }, (_, i) => i + 1);
+  }
+
+  return Array.from({ length: 24 }, (_, i) => i);
+}
+
+/**
+ * Generate minute options based on step interval
+ */
+export function generateMinuteOptions(step: number): number[] {
+  const options: number[] = [];
+
+  for (let i = 0; i < 60; i += step) {
+    options.push(i);
+  }
+
+  return options;
+}
+
+/**
+ * Format a time number with leading zero
+ */
+export function formatTimeOption(value: number): string {
+  return value.toString().padStart(2, '0');
+}
+
+/**
+ * Convert 12-hour value + period to 24-hour
+ */
+export function to24Hour(hour12: number, period: 'AM' | 'PM'): number {
+  if (period === 'AM') {
+    return hour12 === 12 ? 0 : hour12;
+  }
+
+  return hour12 === 12 ? 12 : hour12 + 12;
+}
+
+/**
+ * Convert 24-hour value to 12-hour + period
+ */
+export function to12Hour(hour24: number): { hour: number; period: 'AM' | 'PM' } {
+  const period: 'AM' | 'PM' = hour24 >= 12 ? 'PM' : 'AM';
+  let hour = hour24 % 12;
+
+  if (hour === 0) {
+    hour = 12;
+  }
+
+  return { hour, period };
+}
+
+/**
+ * Get disabled hours based on min/max constraints for a given date
+ */
+export function getDisabledHours(
+  selectedDate: Date | undefined,
+  minValue: Date | undefined,
+  maxValue: Date | undefined
+): number[] {
+  const disabled: number[] = [];
+
+  if (!selectedDate) return disabled;
+
+  if (minValue && isSameDay(selectedDate, minValue)) {
+    const minHour = minValue.getHours();
+
+    for (let i = 0; i < minHour; i++) {
+      disabled.push(i);
+    }
+  }
+
+  if (maxValue && isSameDay(selectedDate, maxValue)) {
+    const maxHour = maxValue.getHours();
+
+    for (let i = maxHour + 1; i < 24; i++) {
+      disabled.push(i);
+    }
+  }
+
+  return disabled;
+}
+
+/**
+ * Get disabled minutes based on min/max constraints for a given date and hour
+ */
+export function getDisabledMinutes(
+  selectedDate: Date | undefined,
+  selectedHour: number,
+  minValue: Date | undefined,
+  maxValue: Date | undefined
+): number[] {
+  const disabled: number[] = [];
+
+  if (!selectedDate) return disabled;
+
+  if (minValue && isSameDay(selectedDate, minValue) && selectedHour === minValue.getHours()) {
+    const minMinute = minValue.getMinutes();
+
+    for (let i = 0; i < minMinute; i++) {
+      disabled.push(i);
+    }
+  }
+
+  if (maxValue && isSameDay(selectedDate, maxValue) && selectedHour === maxValue.getHours()) {
+    const maxMinute = maxValue.getMinutes();
+
+    for (let i = maxMinute + 1; i < 60; i++) {
+      disabled.push(i);
+    }
+  }
+
+  return disabled;
+}

--- a/packages/datepickers/src/elements/DateTimePicker/utils/useDateTimePickerContext.ts
+++ b/packages/datepickers/src/elements/DateTimePicker/utils/useDateTimePickerContext.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { useContext, createContext } from 'react';
+
+import { IDateTimePickerState, DateTimePickerAction } from './date-time-picker-reducer';
+
+export interface IDateTimePickerContext {
+  state: IDateTimePickerState;
+  dispatch: React.Dispatch<DateTimePickerAction>;
+  isAmPm: boolean;
+  timeStep: number;
+  minValue?: Date;
+  maxValue?: Date;
+  value?: Date;
+  isCompact?: boolean;
+  locale: string;
+}
+
+export const DateTimePickerContext = createContext<IDateTimePickerContext | undefined>(undefined);
+
+const useDateTimePickerContext = () => {
+  return useContext<IDateTimePickerContext>(DateTimePickerContext as any);
+};
+
+export default useDateTimePickerContext;

--- a/packages/datepickers/src/index.ts
+++ b/packages/datepickers/src/index.ts
@@ -7,5 +7,6 @@
 
 export { DatePicker } from './elements/DatePicker/DatePicker';
 export { DatePickerRange } from './elements/DatePickerRange/DatePickerRange';
+export { DateTimePicker } from './elements/DateTimePicker/DateTimePicker';
 
-export type { IDatePickerProps, IDatePickerRangeProps } from './types';
+export type { IDatePickerProps, IDatePickerRangeProps, IDateTimePickerProps } from './types';

--- a/packages/datepickers/src/styled/StyledDateTimePicker.ts
+++ b/packages/datepickers/src/styled/StyledDateTimePicker.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { componentStyles } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'datepickers.datetimepicker';
+
+interface IStyledDateTimePickerProps {
+  $isCompact: boolean;
+}
+
+export const StyledDateTimePicker = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledDateTimePickerProps>`
+  display: flex;
+  direction: ${p => p.theme.rtl && 'rtl'};
+
+  ${componentStyles};
+`;

--- a/packages/datepickers/src/styled/StyledTimeColumn.ts
+++ b/packages/datepickers/src/styled/StyledTimeColumn.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { componentStyles } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'datepickers.time_column';
+
+interface IStyledTimeColumnProps {
+  $isCompact?: boolean;
+  $isScrollable?: boolean;
+}
+
+export const StyledTimeColumn = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledTimeColumnProps>`
+  ${p =>
+    p.$isScrollable !== false &&
+    `
+    overflow-y: scroll;
+    scrollbar-gutter: stable;
+
+    &:not(:hover) {
+      scrollbar-color: transparent transparent;
+    }
+  `}
+
+  ${componentStyles};
+`;

--- a/packages/datepickers/src/styled/StyledTimeColumnHeader.ts
+++ b/packages/datepickers/src/styled/StyledTimeColumnHeader.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
+import { componentStyles, getColor } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'datepickers.time_column_header';
+
+interface IStyledTimeColumnHeaderProps {
+  $isCompact?: boolean;
+}
+
+const sizeStyles = ({
+  $isCompact,
+  theme
+}: IStyledTimeColumnHeaderProps & ThemeProps<DefaultTheme>) => {
+  const height = theme.space.base * ($isCompact ? 8 : 10);
+  const fontSize = $isCompact ? theme.fontSizes.sm : theme.fontSizes.md;
+
+  return css`
+    height: ${height}px;
+    font-size: ${fontSize};
+  `;
+};
+
+const colorStyles = ({ theme }: IStyledTimeColumnHeaderProps & ThemeProps<DefaultTheme>) => {
+  const foreground = getColor({ variable: 'foreground.subtle', theme });
+
+  return css`
+    color: ${foreground};
+  `;
+};
+
+export const StyledTimeColumnHeader = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledTimeColumnHeaderProps>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: ${props => props.theme.fontWeights.semibold};
+
+  ${sizeStyles}
+  ${colorStyles}
+
+  ${componentStyles};
+`;

--- a/packages/datepickers/src/styled/StyledTimeOption.ts
+++ b/packages/datepickers/src/styled/StyledTimeOption.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
+import { componentStyles, getColor } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'datepickers.time_option';
+
+interface IStyledTimeOptionProps {
+  $isCompact?: boolean;
+  'aria-selected'?: boolean;
+  'aria-disabled'?: boolean;
+}
+
+const sizeStyles = ({ $isCompact, theme }: IStyledTimeOptionProps & ThemeProps<DefaultTheme>) => {
+  const height = theme.space.base * ($isCompact ? 7 : 8);
+  const paddingH = theme.space.base * ($isCompact ? 2 : 3);
+  const fontSize = $isCompact ? theme.fontSizes.sm : theme.fontSizes.md;
+  const borderRadius = theme.borderRadii.md;
+
+  return css`
+    margin: 0 ${theme.space.base}px;
+    border-radius: ${borderRadius};
+    padding: 0 ${paddingH}px;
+    height: ${height}px;
+    font-size: ${fontSize};
+  `;
+};
+
+const colorStyles = ({ theme, ...props }: IStyledTimeOptionProps & ThemeProps<DefaultTheme>) => {
+  const isSelected = props['aria-selected'];
+  const isDisabled = props['aria-disabled'];
+
+  let backgroundColor = 'transparent';
+  let foreground;
+  const backgroundHover = getColor({
+    variable: 'background.primaryEmphasis',
+    theme,
+    transparency: theme.opacity[100]
+  });
+  const backgroundActive = getColor({
+    variable: 'background.primaryEmphasis',
+    theme,
+    transparency: theme.opacity[200]
+  });
+
+  if (isSelected && !isDisabled) {
+    backgroundColor = getColor({ variable: 'background.primaryEmphasis', theme });
+    foreground = getColor({ variable: 'foreground.onEmphasis', theme });
+  } else if (isDisabled) {
+    foreground = getColor({ variable: 'foreground.disabled', theme });
+  } else {
+    foreground = getColor({ variable: 'foreground.default', theme });
+  }
+
+  return css`
+    background-color: ${backgroundColor};
+    color: ${foreground};
+
+    &:not([aria-disabled]):not([aria-selected]):hover {
+      background-color: ${backgroundHover};
+    }
+
+    &:not([aria-disabled]):not([aria-selected]):active {
+      background-color: ${backgroundActive};
+    }
+  `;
+};
+
+export const StyledTimeOption = styled.div.attrs<IStyledTimeOptionProps>({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledTimeOptionProps>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: ${props => (props['aria-disabled'] ? 'default' : 'pointer')};
+
+  ${sizeStyles}
+  ${colorStyles}
+
+  ${componentStyles};
+`;

--- a/packages/datepickers/src/styled/StyledTimePanel.ts
+++ b/packages/datepickers/src/styled/StyledTimePanel.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
+import { componentStyles, getColor } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'datepickers.time_panel';
+
+interface IStyledTimePanelProps {
+  $isCompact?: boolean;
+}
+
+const sizeStyles = ({ $isCompact, theme }: IStyledTimePanelProps & ThemeProps<DefaultTheme>) => {
+  const margin = theme.space.base * ($isCompact ? 4 : 5);
+  const headerHeight = theme.space.base * ($isCompact ? 8 : 10);
+  const dayLabelRowHeight = theme.space.base * ($isCompact ? 8 : 10);
+  const dayRowHeight = theme.space.base * ($isCompact ? 8 : 10);
+  const height = headerHeight + dayLabelRowHeight + dayRowHeight * 6;
+
+  return css`
+    margin: ${margin}px 0;
+    height: ${height}px;
+  `;
+};
+
+const colorStyles = ({ theme }: IStyledTimePanelProps & ThemeProps<DefaultTheme>) => {
+  const borderColor = getColor({ variable: 'border.default', theme });
+
+  return css`
+    border-inline-start: ${theme.borders.sm} ${borderColor};
+  `;
+};
+
+export const StyledTimePanel = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledTimePanelProps>`
+  display: flex;
+  direction: ltr;
+
+  ${sizeStyles}
+  ${colorStyles}
+
+  ${componentStyles};
+`;

--- a/packages/datepickers/src/styled/index.ts
+++ b/packages/datepickers/src/styled/index.ts
@@ -17,3 +17,7 @@ export { StyledCalendarItem } from './StyledCalendarItem';
 export { StyledDayLabel } from './StyledDayLabel';
 export { StyledHighlight } from './StyledHighlight';
 export { StyledDay } from './StyledDay';
+export { StyledDateTimePicker } from './StyledDateTimePicker';
+export { StyledTimePanel } from './StyledTimePanel';
+export { StyledTimeColumn } from './StyledTimeColumn';
+export { StyledTimeOption } from './StyledTimeOption';

--- a/packages/datepickers/src/types/index.ts
+++ b/packages/datepickers/src/types/index.ts
@@ -82,6 +82,18 @@ export interface IDatePickerProps extends Omit<HTMLAttributes<HTMLDivElement>, '
   children: ReactElement;
 }
 
+export interface IDateTimePickerProps extends IDatePickerProps {
+  /**
+   * Sets the minute step interval for the time panel
+   */
+  timeStep?: number;
+  /**
+   * Applies 12-hour format with AM/PM.
+   * When unset, auto-detects from locale.
+   */
+  isAmPm?: boolean;
+}
+
 export interface IDatePickerRangeProps extends Pick<
   IDatePickerProps,
   'locale' | 'weekStartsOn' | 'minValue' | 'maxValue' | 'formatDate' | 'isCompact'


### PR DESCRIPTION
## Description

This PR adds a new `DateTimePicker` component to the `@zendeskgarden/react-datepickers` package. It extends the existing `DatePicker` pattern with an integrated time panel, letting users pick both a date and a time of day from a single popover.

## Detail

<img width="750" height="540" alt="image" src="https://github.com/user-attachments/assets/a342f487-09e4-47ee-952b-2e19c6ddfe4d" />

- New `DateTimePicker` element exported from `packages/datepickers` with composable subcomponents
- Time panel supports configurable minute granularity via the `timeStep` prop and 12/24-hour
  formatting via `isAmPm` (auto-detected from `locale` when unset)
- Reuses `IDatePickerProps` for the calendar surface
- Supports `minValue`/`maxValue` for both date and time selection so out-of-range hours/minutes are disabled
- Adds styled primitives following existing Garden styling conventions
- Includes Storybook demo and unit test coverage for the component and time utilities

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :black_circle: renders as expected in dark mode
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
