### PR TITLE
fix: keep components behavior stable for users on styled-components >= 6.3.12

### DIFF
--- a/packages/accordions/src/styled/accordion/StyledPanel.spec.tsx
+++ b/packages/accordions/src/styled/accordion/StyledPanel.spec.tsx
@@ -56,4 +56,13 @@ describe('StyledPanel', () => {
 
     expect(container.firstChild).not.toHaveStyleRule('transition');
   });
+
+  it('renders transition styling when isAnimated is explicitly undefined', () => {
+    const { container } = render(<StyledPanel $isAnimated={undefined} />);
+
+    expect(container.firstChild).toHaveStyleRule(
+      'transition',
+      'padding 0.25s ease-in-out,grid-template-rows 0.25s ease-in-out'
+    );
+  });
 });

--- a/packages/accordions/src/styled/accordion/StyledPanel.ts
+++ b/packages/accordions/src/styled/accordion/StyledPanel.ts
@@ -53,14 +53,16 @@ const sizeStyles = (props: IStyledPanel & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-export const StyledPanel = styled.section.attrs<IStyledPanel>(props => ({
+export const StyledPanel = styled.section.attrs<IStyledPanel>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $isAnimated: props.$isAnimated ?? true
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledPanel>`
   display: grid;
   transition: ${props =>
-    props.$isAnimated && 'padding 0.25s ease-in-out, grid-template-rows 0.25s ease-in-out'};
+    /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+     * explicitly passed undefined props, so `$isAnimated` may still be undefined here */
+    (props.$isAnimated ?? true) &&
+    'padding 0.25s ease-in-out, grid-template-rows 0.25s ease-in-out'};
   overflow: hidden;
 
   ${sizeStyles}

--- a/packages/avatars/src/elements/Avatar.spec.tsx
+++ b/packages/avatars/src/elements/Avatar.spec.tsx
@@ -26,6 +26,26 @@ describe('Avatar', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
+  it('renders medium size by default', () => {
+    const { container } = render(
+      <Avatar>
+        <img alt="" />
+      </Avatar>
+    );
+
+    expect(container.firstChild).toHaveStyleRule('width', '40px!important');
+  });
+
+  it('renders a medium status indicator by default', () => {
+    const { container } = render(
+      <Avatar status="available">
+        <img alt="" />
+      </Avatar>
+    );
+
+    expect(container.querySelector('figcaption')).toHaveStyleRule('height', '12px');
+  });
+
   it('renders badge if provided', () => {
     const badge = '2';
     const { getByText } = render(

--- a/packages/avatars/src/elements/StatusIndicator.spec.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.spec.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { render, renderRtl, cleanup } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
 
 import { StatusIndicator } from './StatusIndicator';
 import { STATUS } from '../types';
@@ -33,6 +34,12 @@ describe('StatusIndicator', () => {
     const { getByText } = render(<StatusIndicator type="available">{text}</StatusIndicator>);
 
     expect(getByText(text).nodeName).toBe('FIGCAPTION');
+  });
+
+  it('renders offline type by default', () => {
+    const { getByRole } = render(<StatusIndicator />);
+
+    expect(getByRole('img')).toHaveStyleRule('border-color', PALETTE.grey[500]);
   });
 
   it('renders in compact mode', () => {

--- a/packages/avatars/src/styled/StyledAvatar.spec.tsx
+++ b/packages/avatars/src/styled/StyledAvatar.spec.tsx
@@ -122,6 +122,19 @@ describe('StyledAvatar', () => {
       expect(container.firstChild).toHaveStyleRule('width', '40px!important');
     });
 
+    it('renders medium when size is explicitly undefined', () => {
+      const { container } = render(
+        <StyledAvatar $size={undefined}>
+          <StyledStatusIndicator />
+        </StyledAvatar>
+      );
+
+      expect(container.firstChild).toHaveStyleRule('width', '40px!important');
+      expect(container.firstChild).toHaveStyleRule('bottom', '-2px', {
+        modifier: `&>${StyledStatusIndicator}`
+      });
+    });
+
     it('renders large', () => {
       const { container } = render(<StyledAvatar $size="large" />);
 

--- a/packages/avatars/src/styled/StyledAvatar.ts
+++ b/packages/avatars/src/styled/StyledAvatar.ts
@@ -19,9 +19,12 @@ const COMPONENT_ID = 'avatars.avatar';
 const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
   const [xxs, xs, s, m, l] = SIZE;
 
+  /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+   * explicitly passed undefined props, so `$size` may still be undefined here */
+  const size = props.$size ?? 'medium';
   let position = `${props.theme.space.base * -1}px`;
 
-  switch (props.$size) {
+  switch (size) {
     case xxs:
     case xs:
       position = math(`${position}  + 3`);
@@ -160,10 +163,9 @@ export interface IStyledAvatarProps {
 /**
  * Accepts all `<figure>` props
  */
-export const StyledAvatar = styled.figure.attrs<IStyledAvatarProps>(props => ({
+export const StyledAvatar = styled.figure.attrs<IStyledAvatarProps>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $size: props.$size ?? 'medium'
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledAvatarProps>`
   display: inline-flex;
   position: relative;

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.spec.tsx
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.spec.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+import { StyledStandaloneStatusIndicator } from './StyledStandaloneStatusIndicator';
+
+describe('StyledStandaloneStatusIndicator', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledStandaloneStatusIndicator />);
+
+    expect(container.firstChild!.nodeName).toBe('DIV');
+  });
+
+  it('renders medium size by default', () => {
+    const { container } = render(<StyledStandaloneStatusIndicator />);
+
+    expect(container.firstChild).toHaveStyleRule('height', '12px');
+  });
+
+  it('renders medium margin-top when size is explicitly undefined', () => {
+    const { container } = render(<StyledStandaloneStatusIndicator $size={undefined} />);
+    const expectedMargin = `calc((${DEFAULT_THEME.lineHeights.md} - 16px) / 2)`;
+
+    expect(container.firstChild).toHaveStyleRule('margin-top', expectedMargin);
+  });
+
+  it('renders small size', () => {
+    const { container } = render(<StyledStandaloneStatusIndicator $size="small" />);
+
+    expect(container.firstChild).toHaveStyleRule('height', '8px');
+  });
+});

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -15,10 +15,9 @@ const COMPONENT_ID = 'avatars.status-indicator.indicator';
 
 export const StyledStandaloneStatusIndicator = styled(
   StyledStatusIndicatorBase
-).attrs<IStyledStatusIndicatorProps>(props => ({
+).attrs<IStyledStatusIndicatorProps>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $type: props.$type ?? 'offline'
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledStatusIndicatorProps>`
   position: relative;
   box-sizing: content-box;

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -21,8 +21,13 @@ export const StyledStandaloneStatusIndicator = styled(
 }))<IStyledStatusIndicatorProps>`
   position: relative;
   box-sizing: content-box;
-  margin-top: ${props =>
-    `calc((${props.theme.lineHeights.md} - ${getStatusSize(props, '0')}) / 2)`};
+  margin-top: ${props => {
+    /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+     * explicitly passed undefined props, so `$size` may still be undefined here */
+    const sizeProps = { ...props, $size: props.$size ?? 'medium' };
+
+    return `calc((${props.theme.lineHeights.md} - ${getStatusSize(sizeProps, '0')}) / 2)`;
+  }};
 
   ${componentStyles};
 `;

--- a/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
+++ b/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
@@ -82,6 +82,16 @@ describe('StyledStatusIndicator', () => {
       );
     });
 
+    it('renders medium when size is explicitly undefined', () => {
+      const { container } = render(<StyledStatusIndicator $size={undefined} />);
+
+      expect(container.firstChild).toHaveStyleRule('height', '12px');
+      expect(container.firstChild).toHaveStyleRule(
+        'border',
+        `2px ${DEFAULT_THEME.borderStyles.solid}`
+      );
+    });
+
     it('renders large', () => {
       const { container } = render(<StyledStatusIndicator $size="large" />);
 

--- a/packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -25,15 +25,18 @@ const COMPONENT_ID = 'avatars.status_indicator';
 const [xxs, xs, s, m, l] = SIZE;
 
 const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
-  const isVisible = props.$size !== xxs;
-  const iconSize = props.$size === xs ? `${props.theme.space.base * 2}px` : undefined;
+  /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+   * explicitly passed undefined props, so `$size` may still be undefined here */
+  const size = props.$size ?? 'medium';
+  const isVisible = size !== xxs;
+  const iconSize = size === xs ? `${props.theme.space.base * 2}px` : undefined;
   const borderWidth = getStatusBorderOffset(props);
 
   let padding = '0';
 
-  if (props.$size === s) {
+  if (size === s) {
     padding = math(`${props.theme.space.base + 1}px - (${borderWidth} * 2)`);
-  } else if (includes([m, l], props.$size)) {
+  } else if (includes([m, l], size)) {
     padding = math(`${props.theme.space.base + 3}px - (${borderWidth} * 2)`);
   }
 
@@ -94,10 +97,9 @@ const colorStyles = ({
 };
 
 export const StyledStatusIndicator = styled(StyledStatusIndicatorBase).attrs<IStatusIndicatorProps>(
-  props => ({
+  () => ({
     'data-garden-id': COMPONENT_ID,
-    'data-garden-version': PACKAGE_VERSION,
-    $size: props.$size ?? 'medium'
+    'data-garden-version': PACKAGE_VERSION
   })
 )<IStatusIndicatorProps>`
   ${sizeStyles}

--- a/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
@@ -29,8 +29,11 @@ const iconFadeIn = keyframes`
 `;
 
 const sizeStyles = (props: IStyledStatusIndicatorProps) => {
-  const offset = getStatusBorderOffset(props);
-  const size = getStatusSize(props, offset);
+  /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+   * explicitly passed undefined props, so `$size` may still be undefined here */
+  const sizeProps = { ...props, $size: props.$size ?? 'medium' };
+  const offset = getStatusBorderOffset(sizeProps);
+  const size = getStatusSize(sizeProps, offset);
 
   /**
    * 1. because we are using the stroke icon instead of fill due to artifacts in visual appearance,

--- a/packages/buttons/src/elements/Button.spec.tsx
+++ b/packages/buttons/src/elements/Button.spec.tsx
@@ -31,6 +31,26 @@ describe('Button', () => {
     expect(container.firstChild).toHaveStyleRule('text-decoration', 'underline');
   });
 
+  describe('`type` attribute', () => {
+    it('renders default type of "button"', () => {
+      const { container } = render(<Button />);
+
+      expect(container.firstChild).toHaveAttribute('type', 'button');
+    });
+
+    it('renders default type of "button" if explicitly undefined', () => {
+      const { container } = render(<Button type={undefined} />);
+
+      expect(container.firstChild).toHaveAttribute('type', 'button');
+    });
+
+    it('renders custom type if provided', () => {
+      const { container } = render(<Button type="submit" />);
+
+      expect(container.firstChild).toHaveAttribute('type', 'submit');
+    });
+  });
+
   describe('`data-garden-id` attribute', () => {
     it('sets a default data-garden-id attribute', () => {
       const { getByRole } = render(<Button />);

--- a/packages/buttons/src/elements/Button.tsx
+++ b/packages/buttons/src/elements/Button.tsx
@@ -25,6 +25,7 @@ const ButtonComponent = forwardRef<HTMLButtonElement, IButtonProps>(
       isPrimary,
       isStretched,
       size = 'medium',
+      type = 'button',
       ...other
     },
     ref
@@ -34,6 +35,7 @@ const ButtonComponent = forwardRef<HTMLButtonElement, IButtonProps>(
     return (
       <StyledButton
         {...other}
+        type={type}
         $focusInset={focusInset || splitButtonFocusInset}
         $isBasic={isBasic}
         $isDanger={isDanger}

--- a/packages/buttons/src/elements/IconButton.spec.tsx
+++ b/packages/buttons/src/elements/IconButton.spec.tsx
@@ -21,6 +21,38 @@ describe('IconButton', () => {
     expect(container.querySelector('svg')).not.toBeNull();
   });
 
+  describe('`type` attribute', () => {
+    it('renders default type of "button"', () => {
+      const { container } = render(
+        <IconButton>
+          <TestIcon />
+        </IconButton>
+      );
+
+      expect(container.firstChild).toHaveAttribute('type', 'button');
+    });
+
+    it('renders default type of "button" if explicitly undefined', () => {
+      const { container } = render(
+        <IconButton type={undefined}>
+          <TestIcon />
+        </IconButton>
+      );
+
+      expect(container.firstChild).toHaveAttribute('type', 'button');
+    });
+
+    it('renders custom type if provided', () => {
+      const { container } = render(
+        <IconButton type="submit">
+          <TestIcon />
+        </IconButton>
+      );
+
+      expect(container.firstChild).toHaveAttribute('type', 'submit');
+    });
+  });
+
   describe('Invalid', () => {
     const consoleError = console.error;
 

--- a/packages/buttons/src/elements/IconButton.tsx
+++ b/packages/buttons/src/elements/IconButton.tsx
@@ -26,6 +26,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IIconButtonProps>(
       isPrimary,
       isRotated,
       size = 'medium',
+      type = 'button',
       ...other
     },
     ref
@@ -35,6 +36,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IIconButtonProps>(
     return (
       <StyledIconButton
         {...other}
+        type={type}
         $isBasic={isBasic}
         $isDanger={isDanger}
         $isNeutral={isNeutral}

--- a/packages/buttons/src/styled/StyledButton.spec.tsx
+++ b/packages/buttons/src/styled/StyledButton.spec.tsx
@@ -74,10 +74,20 @@ describe('StyledButton', () => {
     expect(container.firstChild).toHaveStyleRule('width', '100%');
   });
 
-  it('renders default type of "button"', () => {
+  /*
+   * the `type="button"` default is applied by the Button/IconButton elements;
+   * direct styled consumption without `type` renders no attribute
+   */
+  it('renders no type attribute by default', () => {
     const { container } = render(<StyledButton />);
 
-    expect(container.firstChild).toHaveAttribute('type', 'button');
+    expect(container.firstChild).not.toHaveAttribute('type');
+  });
+
+  it('renders no type attribute if explicitly undefined', () => {
+    const { container } = render(<StyledButton type={undefined} />);
+
+    expect(container.firstChild).not.toHaveAttribute('type');
   });
 
   it('renders custom type if provided', () => {

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -438,10 +438,14 @@ const sizeStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
  * 2. FF <input type="submit"> fix
  * 3. Shifting :focus-visible from LVHFA order to preserve `text-decoration` on hover
  */
+/*
+ * the `type="button"` default lives in the `Button`/`IconButton` elements: an
+ * attrs fallback would be discarded by styled-components >= 6.3.12 when a
+ * caller explicitly passes `type={undefined}`
+ */
 export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
   'data-garden-id': (props as any)['data-garden-id'] || COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  type: props.type || 'button'
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledButtonProps>`
   display: ${props => (props.$isLink ? 'inline' : 'inline-flex')};
   align-items: ${props => !props.$isLink && 'center'};

--- a/packages/grid/src/elements/Col.spec.tsx
+++ b/packages/grid/src/elements/Col.spec.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
 import { render } from 'garden-test-utils';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { Col } from './Col';
 import { Row } from './Row';
 import { Grid } from './Grid';
@@ -16,6 +18,29 @@ describe('Col', () => {
     const { container } = render(<Col />);
 
     expect(container.firstChild!.nodeName).toBe('DIV');
+  });
+
+  it('renders a numeric breakpoint size without a containing Grid', () => {
+    const { getByTestId } = render(<Col data-test-id="test" sm={12} />);
+
+    expect(getByTestId('test')).toHaveStyleRule('max-width', '100%', {
+      media: `(min-width:  ${DEFAULT_THEME.breakpoints.sm})`
+    });
+  });
+
+  it('renders a numeric size without a containing Grid', () => {
+    const { getByTestId } = render(<Col data-test-id="test" size={6} />);
+
+    expect(getByTestId('test')).toHaveStyleRule('max-width', '50%');
+  });
+
+  it('renders when wrapped with styled() without a containing Grid', () => {
+    const StyledCol = styled(Col)``;
+    const { getByTestId } = render(<StyledCol data-test-id="test" md={4} />);
+
+    expect(getByTestId('test')).toHaveStyleRule('max-width', `${(4 / 12) * 100}%`, {
+      media: `(min-width:  ${DEFAULT_THEME.breakpoints.md})`
+    });
   });
 
   it('passes ref to underlying DOM element', () => {

--- a/packages/grid/src/elements/Grid.spec.tsx
+++ b/packages/grid/src/elements/Grid.spec.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+import { math } from 'polished';
 import { render } from 'garden-test-utils';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { Grid } from './Grid';
 
 describe('Grid', () => {
@@ -14,6 +16,14 @@ describe('Grid', () => {
     const { container } = render(<Grid />);
 
     expect(container.firstChild!.nodeName).toBe('DIV');
+  });
+
+  it('renders medium gutters by default', () => {
+    const { container } = render(<Grid />);
+    const padding = math(`${DEFAULT_THEME.space.md} / 2`);
+
+    expect(container.firstChild).toHaveStyleRule('padding-right', padding);
+    expect(container.firstChild).toHaveStyleRule('padding-left', padding);
   });
 
   it('passes ref to underlying DOM element', () => {

--- a/packages/grid/src/elements/Row.spec.tsx
+++ b/packages/grid/src/elements/Row.spec.tsx
@@ -24,6 +24,12 @@ describe('Row', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
+  it('wraps by default', () => {
+    const { container } = render(<Row />);
+
+    expect(container.firstChild).toHaveStyleRule('flex-wrap', 'wrap');
+  });
+
   it('renders gutters provided by the containing Grid', () => {
     const { getByTestId } = render(
       <Grid gutters={false}>

--- a/packages/grid/src/styled/StyledCol.ts
+++ b/packages/grid/src/styled/StyledCol.ts
@@ -70,7 +70,10 @@ const flexStyles = (
   order: GridNumber | undefined,
   props: IStyledColProps
 ) => {
-  const margin = offset && `${math(`${offset} / ${props.$columns} * 100`)}%`;
+  /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+   * explicitly passed undefined props, so `$columns` may still be undefined here */
+  const columns = props.$columns ?? 12;
+  const margin = offset && `${math(`${offset} / ${columns} * 100`)}%`;
   let flexBasis;
   let flexGrow;
   let maxWidth;
@@ -86,7 +89,7 @@ const flexStyles = (
     maxWidth = '100%';
     width = 'auto';
   } else if (size !== undefined) {
-    flexBasis = `${math(`${size} / ${props.$columns} * 100`)}%`;
+    flexBasis = `${math(`${size} / ${columns} * 100`)}%`;
     flexGrow = 0;
     maxWidth = flexBasis;
   }
@@ -106,7 +109,7 @@ const flexStyles = (
   if (order === 'first') {
     flexOrder = -1;
   } else if (order === 'last') {
-    flexOrder = math(`${props.$columns} + 1`);
+    flexOrder = math(`${columns} + 1`);
   } else {
     flexOrder = order;
   }
@@ -150,10 +153,9 @@ const sizeStyles = ({ theme, $gutters }: IStyledColProps) => {
   `;
 };
 
-export const StyledCol = styled.div.attrs<IStyledColProps>(props => ({
+export const StyledCol = styled.div.attrs<IStyledColProps>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $columns: props.$columns ?? 12
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledColProps>`
   box-sizing: border-box;
   width: 100%;

--- a/packages/grid/src/styled/StyledGrid.spec.tsx
+++ b/packages/grid/src/styled/StyledGrid.spec.tsx
@@ -53,5 +53,13 @@ describe('StyledGrid', () => {
       expect(container.firstChild).toHaveStyleRule('padding-right', '0');
       expect(container.firstChild).toHaveStyleRule('padding-left', '0');
     });
+
+    it('renders default gutters when gutters are explicitly undefined', () => {
+      const { container } = render(<StyledGrid $gutters={undefined} />);
+      const padding = math(`${DEFAULT_THEME.space.md} / 2`);
+
+      expect(container.firstChild).toHaveStyleRule('padding-right', padding);
+      expect(container.firstChild).toHaveStyleRule('padding-left', padding);
+    });
   });
 });

--- a/packages/grid/src/styled/StyledGrid.ts
+++ b/packages/grid/src/styled/StyledGrid.ts
@@ -35,7 +35,10 @@ const colorStyles = ({ theme, $debug }: IStyledGridProps) => {
 };
 
 const sizeStyles = ({ theme, $gutters }: IStyledGridProps) => {
-  const padding = $gutters ? math(`${theme.space[$gutters!]} / 2`) : 0;
+  /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+   * explicitly passed undefined props, so `$gutters` may still be undefined here */
+  const gutters = $gutters ?? 'md';
+  const padding = gutters ? math(`${theme.space[gutters]} / 2`) : 0;
 
   return css`
     padding-right: ${padding};
@@ -48,10 +51,9 @@ interface IStyledGridProps extends ThemeProps<DefaultTheme> {
   $gutters?: IGridProps['gutters'];
 }
 
-export const StyledGrid = styled.div.attrs<IStyledGridProps>(props => ({
+export const StyledGrid = styled.div.attrs<IStyledGridProps>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $gutters: props.$gutters ?? 'md'
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledGridProps>`
   direction: ${props => props.theme.rtl && 'rtl'};
   margin-right: auto;

--- a/packages/grid/src/styled/StyledRow.ts
+++ b/packages/grid/src/styled/StyledRow.ts
@@ -99,15 +99,16 @@ const sizeStyles = ({ theme, $gutters }: IStyledRowProps) => {
   `;
 };
 
-export const StyledRow = styled.div.attrs<IStyledRowProps>(props => ({
+export const StyledRow = styled.div.attrs<IStyledRowProps>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $wrapAll: props.$wrapAll ?? 'wrap'
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledRowProps>`
   display: flex;
   box-sizing: border-box;
 
-  ${props => flexStyles(props.$alignItems, props.$justifyContent, props.$wrapAll)}
+  /* the $wrapAll fallback cannot live in attrs: styled-components >= 6.3.12
+     preserves explicitly passed undefined props */
+  ${props => flexStyles(props.$alignItems, props.$justifyContent, props.$wrapAll ?? 'wrap')}
 
   ${sizeStyles};
 

--- a/packages/grid/src/utils/useGridContext.spec.tsx
+++ b/packages/grid/src/utils/useGridContext.spec.tsx
@@ -20,4 +20,15 @@ describe('useGridContext', () => {
 
     expect(container.firstChild).toHaveAttribute('data-gutters', 'md');
   });
+
+  it('contains default column count', () => {
+    const GridContextConsumer = () => {
+      const { columns } = useGridContext();
+
+      return <div data-columns={columns}>test</div>;
+    };
+    const { container } = render(<GridContextConsumer />);
+
+    expect(container.firstChild).toHaveAttribute('data-columns', '12');
+  });
 });

--- a/packages/grid/src/utils/useGridContext.ts
+++ b/packages/grid/src/utils/useGridContext.ts
@@ -14,7 +14,7 @@ interface IGridContext {
   debug?: boolean;
 }
 
-export const GridContext = createContext<IGridContext>({ gutters: 'md' });
+export const GridContext = createContext<IGridContext>({ columns: 12, gutters: 'md' });
 
 /**
  * Retrieve Grid component context

--- a/packages/modals/src/elements/Drawer/Body.spec.tsx
+++ b/packages/modals/src/elements/Drawer/Body.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
 import { render } from 'garden-test-utils';
 import { Drawer } from './Drawer';
 
@@ -19,5 +20,18 @@ describe('Drawer.Body', () => {
     );
 
     expect(getByText('content')).toBe(ref.current);
+  });
+
+  it('renders when wrapped with styled()', () => {
+    const StyledBody = styled(Drawer.Body)`
+      padding-bottom: 10px;
+    `;
+    const { getByText } = render(
+      <Drawer isOpen>
+        <StyledBody>content</StyledBody>
+      </Drawer>
+    );
+
+    expect(getByText('content')).toHaveStyleRule('padding-bottom', '10px');
   });
 });

--- a/packages/tags/src/elements/Tag.spec.tsx
+++ b/packages/tags/src/elements/Tag.spec.tsx
@@ -10,6 +10,12 @@ import { render, renderRtl } from 'garden-test-utils';
 import { Tag } from './Tag';
 
 describe('Tag', () => {
+  it('renders medium size by default', () => {
+    const { container } = render(<Tag />);
+
+    expect(container.firstChild).toHaveStyleRule('height', '20px');
+  });
+
   it('applies correct styling with RTL locale', () => {
     const { container } = renderRtl(<Tag />);
 

--- a/packages/tags/src/styled/StyledTag.spec.tsx
+++ b/packages/tags/src/styled/StyledTag.spec.tsx
@@ -74,6 +74,12 @@ describe('StyledTag', () => {
       expect(container.firstChild).toHaveStyleRule('height', '20px');
     });
 
+    it('renders medium styling when size is explicitly undefined', () => {
+      const { container } = render(<StyledTag $size={undefined} />);
+
+      expect(container.firstChild).toHaveStyleRule('height', '20px');
+    });
+
     it('renders large styling if provided', () => {
       const { container } = render(<StyledTag $size="large" />);
 

--- a/packages/tags/src/styled/StyledTag.ts
+++ b/packages/tags/src/styled/StyledTag.ts
@@ -210,10 +210,9 @@ const sizeStyles = ({ $isPill, $isRound, $size, theme }: IStyledTagProps) => {
   `;
 };
 
-export const StyledTag = styled.div.attrs<IStyledTagProps>(props => ({
+export const StyledTag = styled.div.attrs<IStyledTagProps>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $size: props.$size ?? 'medium'
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledTagProps>`
   display: inline-flex;
   flex-wrap: nowrap;

--- a/packages/typography/src/elements/CodeBlock.spec.tsx
+++ b/packages/typography/src/elements/CodeBlock.spec.tsx
@@ -125,6 +125,14 @@ describe('CodeBlock', () => {
   });
 
   describe('size', () => {
+    it('renders medium size by default', async () => {
+      const { container } = render(<CodeBlock />);
+
+      await waitFor(() => {
+        expect(container.getElementsByTagName('code')[0]).toHaveStyleRule('font-size', '13px');
+      });
+    });
+
     it('renders small size', async () => {
       const { container } = render(<CodeBlock size="small" />);
 

--- a/packages/typography/src/styled/StyledCode.ts
+++ b/packages/typography/src/styled/StyledCode.ts
@@ -58,13 +58,11 @@ interface IStyledCodeProps extends Omit<IStyledFontProps, 'size'> {
   $size?: ICodeProps['size'];
 }
 
-export const StyledCode = styled(StyledFont as 'code').attrs<IStyledCodeProps>(props => ({
+export const StyledCode = styled(StyledFont as 'code').attrs<IStyledCodeProps>(() => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   as: 'code',
-  $isMonospace: true,
-  $hue: props.$hue ?? 'grey',
-  $size: props.$size ?? 'inherit'
+  $isMonospace: true
 }))<IStyledCodeProps>`
   border-radius: ${props => props.theme.borderRadii.sm};
   padding: 1.5px;

--- a/packages/typography/src/styled/StyledFont.spec.tsx
+++ b/packages/typography/src/styled/StyledFont.spec.tsx
@@ -49,6 +49,12 @@ describe('StyledFont', () => {
       expect(container.firstChild).not.toHaveStyleRule('font-weight');
     });
 
+    it('renders inherited size when size is explicitly undefined', () => {
+      const { container } = render(<StyledFont $isMonospace $size={undefined} />);
+
+      expect(container.firstChild).toHaveStyleRule('font-size', 'calc(1em - 1px)');
+    });
+
     it('renders small size', () => {
       const { container } = render(<StyledFont $size="small" />);
 

--- a/packages/typography/src/styled/StyledFont.tsx
+++ b/packages/typography/src/styled/StyledFont.tsx
@@ -37,7 +37,10 @@ const fontStyles = ({
   $size,
   theme
 }: IStyledFontProps & ThemeProps<DefaultTheme>) => {
-  const monospace = $isMonospace && ['inherit', 'small', 'medium', 'large'].indexOf($size!) !== -1;
+  /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+   * explicitly passed undefined props, so `$size` may still be undefined here */
+  const size = $size ?? 'inherit';
+  const monospace = $isMonospace && ['inherit', 'small', 'medium', 'large'].indexOf(size) !== -1;
   const fontFamily = monospace && theme.fonts.mono;
   const direction = theme.rtl ? 'rtl' : 'ltr';
   const color = $hue ? getHueColor({ theme, value: $hue }) : undefined;
@@ -46,17 +49,17 @@ const fontStyles = ({
   let lineHeight;
 
   if (monospace) {
-    if ($size === 'inherit') {
+    if (size === 'inherit') {
       fontSize = 'calc(1em - 1px)';
       lineHeight = 'normal';
     } else {
-      const themeSize = THEME_SIZES[$size!];
+      const themeSize = THEME_SIZES[size];
 
       fontSize = math(`${theme.fontSizes[themeSize]} - 1px`);
       lineHeight = math(`${theme.lineHeights[themeSize]} - 1px`);
     }
-  } else if ($size !== 'inherit') {
-    const themeSize = THEME_SIZES[$size!];
+  } else if (size !== 'inherit') {
+    const themeSize = THEME_SIZES[size];
 
     fontSize = theme.fontSizes[themeSize];
     lineHeight = theme.lineHeights[themeSize];
@@ -64,7 +67,7 @@ const fontStyles = ({
 
   if ($isBold === true) {
     fontWeight = theme.fontWeights.semibold;
-  } else if ($isBold === false || $size !== 'inherit') {
+  } else if ($isBold === false || size !== 'inherit') {
     fontWeight = theme.fontWeights.regular;
   }
 
@@ -86,10 +89,9 @@ export interface IStyledFontProps {
   $hue?: string;
 }
 
-export const StyledFont = styled.div.attrs<IStyledFontProps>(props => ({
+export const StyledFont = styled.div.attrs<IStyledFontProps>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $size: props.$size ?? 'inherit'
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledFontProps>`
   ${props => !props.hidden && fontStyles(props)};
 

--- a/packages/typography/src/styled/StyledListItem.spec.tsx
+++ b/packages/typography/src/styled/StyledListItem.spec.tsx
@@ -29,6 +29,12 @@ describe('StyledListItem', () => {
       expect(container.firstChild).toHaveStyleRule('padding-top', '4px');
     });
 
+    it('renders medium spacing when space is explicitly undefined', () => {
+      const { container } = render(<StyledListItem $space={undefined} />);
+
+      expect(container.firstChild).toHaveStyleRule('padding-top', '4px');
+    });
+
     it('renders large spacing', () => {
       const { container } = render(<StyledListItem $space="large" />);
 

--- a/packages/typography/src/styled/StyledListItem.ts
+++ b/packages/typography/src/styled/StyledListItem.ts
@@ -52,11 +52,10 @@ const listItemStyles = (props: IStyledListItemProps & ThemeProps<DefaultTheme>) 
 const ORDERED_ID = 'typography.ordered_list_item';
 
 export const StyledOrderedListItem = styled(StyledFont as 'li').attrs<IStyledListItemProps>(
-  props => ({
+  () => ({
     'data-garden-id': ORDERED_ID,
     'data-garden-version': PACKAGE_VERSION,
-    as: 'li',
-    $space: props.$space ?? 'medium'
+    as: 'li'
   })
 )<IStyledListItemProps>`
   margin-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
@@ -72,11 +71,10 @@ export const StyledOrderedListItem = styled(StyledFont as 'li').attrs<IStyledLis
 const UNORDERED_ID = 'typography.unordered_list_item';
 
 export const StyledUnorderedListItem = styled(StyledFont as 'li').attrs<IStyledListItemProps>(
-  props => ({
+  () => ({
     'data-garden-id': UNORDERED_ID,
     'data-garden-version': PACKAGE_VERSION,
-    as: 'li',
-    $space: props.$space ?? 'medium'
+    as: 'li'
   })
 )<IStyledListItemProps>`
   ${listItemStyles};

--- a/packages/typography/src/styled/StyledListItem.ts
+++ b/packages/typography/src/styled/StyledListItem.ts
@@ -51,13 +51,11 @@ const listItemStyles = (props: IStyledListItemProps & ThemeProps<DefaultTheme>) 
 
 const ORDERED_ID = 'typography.ordered_list_item';
 
-export const StyledOrderedListItem = styled(StyledFont as 'li').attrs<IStyledListItemProps>(
-  () => ({
-    'data-garden-id': ORDERED_ID,
-    'data-garden-version': PACKAGE_VERSION,
-    as: 'li'
-  })
-)<IStyledListItemProps>`
+export const StyledOrderedListItem = styled(StyledFont as 'li').attrs<IStyledListItemProps>(() => ({
+  'data-garden-id': ORDERED_ID,
+  'data-garden-version': PACKAGE_VERSION,
+  as: 'li'
+}))<IStyledListItemProps>`
   margin-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
     math(`${props.theme.space.base} * -1px`)};
   padding-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>


### PR DESCRIPTION
## Description

The styled-components [6.3.12 upgrade](https://github.com/styled-components/styled-components/pull/5683) exposed a compatibility issue: values
supplied through `.attrs()` no longer replace caller-provided `undefined`. This
update removes same-prop fallbacks from `.attrs()`, applies safe defaults where
they are consumed, and verifies the documented component behavior with
regression tests.

## Details

- Protect defaults across accordions, avatars, buttons, grids, tags, and
  typography, including `type="button"`, medium sizing, default gutters, list
  spacing, and inherited code styles.
- Add a 12-column Grid context default and point-of-use guards so `Col`
  calculations do not pass undefined values to Polished.
- Cover both direct styled-component usage and public element defaults with
  explicit undefined regression tests.

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :black_circle: renders as expected in dark mode
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
