### PR TITLE
fix(datepickers): stop calling onChange from within DatePicker reducer

### DIFF
--- a/packages/datepickers/demo/~patterns/patterns.mdx
+++ b/packages/datepickers/demo/~patterns/patterns.mdx
@@ -20,3 +20,16 @@ See in this example, that the calendar is currently getting cropped. Enable the
 <Canvas>
   <Story of={Stories.Example} />
 </Canvas>
+
+## Custom date format
+
+`formatDate` and `customParseDate` let you display and parse dates in a
+format other than the default. They work as a matched pair: `formatDate`
+controls how the committed value is displayed in the input, and
+`customParseDate` controls how typed text is read back into a `Date`. Both
+need to agree on the same shape, otherwise typed input stops parsing
+correctly once the field reformats to the committed value.
+
+<Canvas>
+  <Story of={Stories.CustomDateFormat} />
+</Canvas>

--- a/packages/datepickers/demo/~patterns/patterns.stories.tsx
+++ b/packages/datepickers/demo/~patterns/patterns.stories.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import type { StoryObj } from '@storybook/react-vite';
 import { CalendarStory } from './stories/CalendarStory';
+import { CustomDateFormatStory } from './stories/CustomDateFormatStory';
 
 export default {
   title: 'Packages/DatePickers/[patterns]'
@@ -18,4 +19,9 @@ export const Example: StoryObj<typeof CalendarStory> = {
   name: 'Calendar',
   args: { appendToNode: false },
   argTypes: { appendToNode: { control: 'boolean' } }
+};
+
+export const CustomDateFormat: StoryObj<typeof CustomDateFormatStory> = {
+  render: () => <CustomDateFormatStory />,
+  name: 'Custom date format'
 };

--- a/packages/datepickers/demo/~patterns/stories/CustomDateFormatStory.tsx
+++ b/packages/datepickers/demo/~patterns/stories/CustomDateFormatStory.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { StoryFn } from '@storybook/react-vite';
+import { DatePicker } from '@zendeskgarden/react-datepickers';
+import { Field, Input } from '@zendeskgarden/react-forms';
+
+const DATE_PATTERN = /^(?<day>\d{2})\.(?<month>\d{2})\.(?<year>\d{4})$/u;
+
+/**
+ * formatDate and customParseDate are a matched pair: formatDate controls how
+ * the committed value is displayed, and customParseDate controls how typed
+ * text is read back into a Date. They must agree on the same shape, or typed
+ * input stops parsing once the field reformats to the committed value.
+ */
+const formatDate = (date: Date) => {
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+
+  return `${day}.${month}.${date.getFullYear()}`;
+};
+
+const customParseDate = (value: string) => {
+  const match = DATE_PATTERN.exec(value);
+
+  if (!match?.groups) {
+    return new Date(NaN);
+  }
+
+  const { day, month, year } = match.groups;
+
+  return new Date(Number(year), Number(month) - 1, Number(day));
+};
+
+export const CustomDateFormatStory: StoryFn = () => {
+  const [value, setValue] = useState<Date | undefined>(new Date());
+
+  return (
+    <Field>
+      <Field.Label>Select a date</Field.Label>
+      <Field.Hint>Expects DD.MM.YYYY, e.g. 25.12.2026</Field.Hint>
+      <DatePicker
+        value={value}
+        onChange={setValue}
+        formatDate={formatDate}
+        customParseDate={customParseDate}
+      >
+        <Input />
+      </DatePicker>
+    </Field>
+  );
+};

--- a/packages/datepickers/src/elements/DatePicker/DatePicker.spec.tsx
+++ b/packages/datepickers/src/elements/DatePicker/DatePicker.spec.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, renderRtl, fireEvent, act } from 'garden-test-utils';
 import { addDays } from 'date-fns/addDays';
@@ -225,6 +225,36 @@ describe('DatePicker', () => {
       fireEvent.click(days[days.length - 1]);
 
       expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn about updating a component while rendering another when controlled', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
+      const Controlled = () => {
+        const [value, setValue] = useState<Date | undefined>(DEFAULT_DATE);
+
+        return (
+          <DatePicker value={value} onChange={setValue}>
+            <input data-test-id="input" />
+          </DatePicker>
+        );
+      };
+
+      const { getByTestId, getAllByTestId } = render(<Controlled />);
+      const input = getByTestId('input');
+
+      await user.clear(input);
+      await user.type(input, '1/4/2019');
+      await user.click(input);
+      fireEvent.click(getAllByTestId('day')[1]);
+
+      const hasRenderPhaseUpdateWarning = consoleErrorSpy.mock.calls.some(
+        args => typeof args[0] === 'string' && args[0].includes('Cannot update a component')
+      );
+
+      expect(hasRenderPhaseUpdateWarning).toBe(false);
+
+      consoleErrorSpy.mockRestore();
     });
   });
 

--- a/packages/datepickers/src/elements/DatePicker/DatePicker.tsx
+++ b/packages/datepickers/src/elements/DatePicker/DatePicker.tsx
@@ -54,10 +54,11 @@ export const DatePicker = forwardRef<HTMLDivElement, IDatePickerProps>((props, c
   } = props;
   const theme = useContext(ThemeContext) || DEFAULT_THEME;
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const memoizedReducer = useCallback(
-    datepickerReducer({ value, formatDate, locale, customParseDate, onChange }),
-    [value, formatDate, locale, onChange, customParseDate]
-  );
+  const memoizedReducer = useCallback(datepickerReducer({ value, formatDate, locale }), [
+    value,
+    formatDate,
+    locale
+  ]);
   const [state, dispatch] = useReducer(memoizedReducer, retrieveInitialState(props));
   const triggerRef = useRef<HTMLInputElement>(null);
   const floatingRef = useRef<HTMLDivElement>(null);
@@ -148,6 +149,7 @@ export const DatePicker = forwardRef<HTMLDivElement, IDatePickerProps>((props, c
             maxValue={maxValue}
             locale={locale}
             weekStartsOn={weekStartsOn}
+            onChange={onChange}
           />
         </StyledMenu>
       )}
@@ -161,6 +163,9 @@ export const DatePicker = forwardRef<HTMLDivElement, IDatePickerProps>((props, c
         dispatch={dispatch}
         state={state}
         refKey={refKey!}
+        value={value}
+        onChange={onChange}
+        customParseDate={customParseDate}
         ref={mergeRefs([triggerRef, Child.ref ? Child.ref : null])}
       />
       <DatePickerContext.Provider value={contextValue}>

--- a/packages/datepickers/src/elements/DatePicker/components/Calendar.tsx
+++ b/packages/datepickers/src/elements/DatePicker/components/Calendar.tsx
@@ -36,10 +36,11 @@ interface ICalendarProps extends HTMLAttributes<HTMLDivElement> {
   isCompact?: boolean;
   locale?: string;
   weekStartsOn?: DateFnsIndex;
+  onChange?: (date: Date) => void;
 }
 
 export const Calendar = forwardRef<HTMLDivElement, ICalendarProps>(
-  ({ value, minValue, maxValue, isCompact, locale, weekStartsOn }, ref) => {
+  ({ value, minValue, maxValue, isCompact, locale, weekStartsOn, onChange }, ref) => {
     const { state, dispatch } = useDatePickerContext();
 
     const preferredWeekStartsOn = weekStartsOn || getStartOfWeek(locale);
@@ -103,6 +104,10 @@ export const Calendar = forwardRef<HTMLDivElement, ICalendarProps>(
             aria-disabled={isDisabled || undefined}
             onClick={() => {
               if (!isDisabled) {
+                if (onChange && !isSameDay(value!, date)) {
+                  onChange(date);
+                }
+
                 dispatch({ type: 'SELECT_DATE', value: date });
               }
             }}

--- a/packages/datepickers/src/elements/DatePicker/components/Calendar.tsx
+++ b/packages/datepickers/src/elements/DatePicker/components/Calendar.tsx
@@ -29,7 +29,7 @@ import useDatePickerContext from '../utils/useDatePickerContext';
 import { DateFnsIndex, getStartOfWeek } from '../../../utils/calendar-utils';
 import { MonthSelector } from './MonthSelector';
 
-interface ICalendarProps extends HTMLAttributes<HTMLDivElement> {
+interface ICalendarProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
   value?: Date;
   minValue?: Date;
   maxValue?: Date;

--- a/packages/datepickers/src/elements/DatePicker/components/Input.tsx
+++ b/packages/datepickers/src/elements/DatePicker/components/Input.tsx
@@ -6,18 +6,23 @@
  */
 
 import { Dispatch, ReactElement, RefAttributes, cloneElement, forwardRef, useRef } from 'react';
+import { isValid } from 'date-fns/isValid';
+import { isSameDay } from 'date-fns/isSameDay';
 import { KEYS, composeEventHandlers } from '@zendeskgarden/container-utilities';
-import { DatePickerAction, IDatePickerState } from '../utils/date-picker-reducer';
+import { DatePickerAction, IDatePickerState, parseInputValue } from '../utils/date-picker-reducer';
 
 interface IInputProps {
   dispatch: Dispatch<DatePickerAction>;
   element: ReactElement & RefAttributes<HTMLInputElement>;
   refKey: string;
   state: IDatePickerState;
+  value?: Date;
+  onChange?: (date: Date) => void;
+  customParseDate?: (inputValue: string) => Date;
 }
 
 export const Input = forwardRef<HTMLInputElement, IInputProps>(
-  ({ element, dispatch, state, refKey }, ref) => {
+  ({ element, dispatch, state, refKey, value, onChange, customParseDate }, ref) => {
     const isInputMouseDownRef = useRef(false);
 
     const handleBlur = () => {
@@ -25,7 +30,14 @@ export const Input = forwardRef<HTMLInputElement, IInputProps>(
     };
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      dispatch({ type: 'MANUALLY_UPDATE_INPUT', value: e.target.value });
+      const inputValue = e.target.value;
+      const currentDate = parseInputValue({ inputValue, customParseDate });
+
+      if (onChange && currentDate && isValid(currentDate) && !isSameDay(value!, currentDate)) {
+        onChange(currentDate);
+      }
+
+      dispatch({ type: 'MANUALLY_UPDATE_INPUT', value: inputValue });
     };
 
     const handleClick = () => {

--- a/packages/datepickers/src/elements/DatePicker/utils/date-picker-reducer.ts
+++ b/packages/datepickers/src/elements/DatePicker/utils/date-picker-reducer.ts
@@ -10,7 +10,6 @@ import { subMonths } from 'date-fns/subMonths';
 import { isValid } from 'date-fns/isValid';
 import { parse } from 'date-fns/parse';
 import { isBefore } from 'date-fns/isBefore';
-import { isSameDay } from 'date-fns/isSameDay';
 import { IDatePickerProps } from '../../../types';
 
 export interface IDatePickerState {
@@ -22,7 +21,7 @@ export interface IDatePickerState {
 /**
  * Parse string input value using current locale and date formats
  */
-function parseInputValue({
+export function parseInputValue({
   inputValue,
   customParseDate
 }: {
@@ -96,15 +95,11 @@ export const datepickerReducer =
   ({
     value,
     formatDate,
-    locale,
-    customParseDate,
-    onChange
+    locale
   }: {
     value?: Date;
     formatDate?: (date: Date) => string;
     locale: any;
-    customParseDate?: (inputValue: string) => Date;
-    onChange?: (date: Date) => void;
   }) =>
   (state: IDatePickerState, action: DatePickerAction): IDatePickerState => {
     switch (action.type) {
@@ -127,11 +122,6 @@ export const datepickerReducer =
       }
       case 'MANUALLY_UPDATE_INPUT': {
         const inputValue = action.value;
-        const currentDate = parseInputValue({ inputValue, customParseDate });
-
-        if (onChange && currentDate && isValid(currentDate) && !isSameDay(value!, currentDate)) {
-          onChange(currentDate);
-        }
 
         return { ...state, isOpen: true, inputValue };
       }
@@ -148,10 +138,6 @@ export const datepickerReducer =
       }
       case 'SELECT_DATE': {
         const inputValue = formatInputValue({ date: action.value, locale, formatDate });
-
-        if (onChange && action.value && isValid(action.value) && !isSameDay(value!, action.value)) {
-          onChange(action.value);
-        }
 
         return { ...state, isOpen: false, inputValue };
       }


### PR DESCRIPTION
## Description

**Resolves #1359**

`DatePicker` triggered a "Cannot update a component while rendering a different component" console warning because `datepickerReducer` called the `onChange` prop as a side effect inside the reducer body (for both `SELECT_DATE` and `MANUALLY_UPDATE_INPUT`). React re-invokes reducers during the render phase to process dispatched actions, so that `onChange` call — and the consumer's `setState` it triggers — fired while `DatePicker` was mid-render.

This surfaced in the CodeSandbox repro and not in this repo's own Storybook, because Storybook's Controls addon manages args via its own store (`useArgs`/`updateArgs`), not a real `setState` in the render tree — so the default `DatePicker` stories never actually exercised a controlled `onChange` consumer the way a real app (or the CodeSandbox prototype) would. The jest repro below reproduces it directly against a controlled `useState`/`onChange` consumer, matching the original report.

`onChange` is now called directly from the real event handlers (`Calendar`'s day `onClick`, `Input`'s `handleChange`) instead of from the reducer, matching the pattern `DatePickerRange`'s `Start`/`End`/`Month` already use. The reducer is now pure, with no side effects.

Also added a permanent "Custom date format" pattern story (`[patterns]` group) demonstrating `formatDate`/`customParseDate` as a matched pair, since neither prop had a live documented example before, and both needed verification after being threaded through as explicit props instead of reducer-internal state.

https://github.com/user-attachments/assets/ccf81849-5067-4980-a454-51aea89dbdca

## Detail

Reproduced locally with a jest spy on `console.error`, mounting a controlled `DatePicker` (`useState`/`onChange={setState}`) matching the original CodeSandbox repro. The stack trace pointed directly at the bug:

```
onChange (date-picker-reducer.ts:153:11)
  at updateReducer (react-dom...)
  at useReducer (DatePicker.tsx:61:39)
  at renderWithHooks ...
```

Also manually verified in a real browser (Storybook) that:
- `onChange` still fires correctly via both `Calendar` (day click) and `Input` (typed date)
- the `value`-based dedupe (no duplicate `onChange` on re-selecting the same date) still works
- `formatDate`/`customParseDate` still round-trip correctly (new pattern story: `Packages/DatePickers/[patterns]` → "Custom date format")

<!-- closes #1359 -->

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:black_circle: renders as expected in dark mode~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [ ] :memo: tested in Chrome, Firefox, Safari, and Edge

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
