### PR TITLE
chore: port v9.15.x patches into the v10 migration snapshot

### DIFF
--- a/.packages/accordions/src/styled/accordion/StyledPanel.spec.tsx
+++ b/.packages/accordions/src/styled/accordion/StyledPanel.spec.tsx
@@ -57,4 +57,13 @@ describe('StyledPanel', () => {
 
     expect(container.firstChild).not.toHaveStyleRule('transition');
   });
+
+  it('renders transition styling when isAnimated is explicitly undefined', () => {
+    const { container } = render(<StyledPanel $isAnimated={undefined} />);
+
+    expect(container.firstChild).toHaveStyleRule(
+      'transition',
+      'padding 0.25s ease-in-out,grid-template-rows 0.25s ease-in-out'
+    );
+  });
 });

--- a/.packages/accordions/src/styled/accordion/StyledPanel.ts
+++ b/.packages/accordions/src/styled/accordion/StyledPanel.ts
@@ -53,14 +53,16 @@ const sizeStyles = (props: IStyledPanel & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-export const StyledPanel = styled.section.attrs<IStyledPanel>(props => ({
+export const StyledPanel = styled.section.attrs<IStyledPanel>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $isAnimated: props.$isAnimated ?? true
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledPanel>`
   display: grid;
   transition: ${props =>
-    props.$isAnimated && 'padding 0.25s ease-in-out, grid-template-rows 0.25s ease-in-out'};
+    /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+     * explicitly passed undefined props, so `$isAnimated` may still be undefined here */
+    (props.$isAnimated ?? true) &&
+    'padding 0.25s ease-in-out, grid-template-rows 0.25s ease-in-out'};
   overflow: hidden;
 
   ${sizeStyles}

--- a/.packages/accordions/src/styled/stepper/StyledInnerContent.ts
+++ b/.packages/accordions/src/styled/stepper/StyledInnerContent.ts
@@ -18,6 +18,8 @@ export const StyledInnerContent = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledInnerContentProps>`
+  margin: -${props => props.theme.space.xxs};
+  padding: ${props => props.theme.space.xxs};
   overflow: hidden;
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   color: ${({ theme }) => getColor({ theme, variable: 'foreground.default' })};

--- a/.packages/accordions/src/styled/stepper/StyledInnerContent.ts
+++ b/.packages/accordions/src/styled/stepper/StyledInnerContent.ts
@@ -25,5 +25,10 @@ export const StyledInnerContent = styled.div.attrs({
   color: ${({ theme }) => getColor({ theme, variable: 'foreground.default' })};
   font-size: ${props => props.theme.fontSizes.md};
 
+  &[aria-hidden='true'] {
+    margin: 0;
+    padding: 0;
+  }
+
   ${componentStyles};
 `;

--- a/.packages/avatars/src/elements/Avatar.spec.tsx
+++ b/.packages/avatars/src/elements/Avatar.spec.tsx
@@ -27,6 +27,26 @@ describe('Avatar', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
+  it('renders medium size by default', () => {
+    const { container } = render(
+      <Avatar>
+        <img alt="" />
+      </Avatar>
+    );
+
+    expect(container.firstChild).toHaveStyleRule('width', '40px!important');
+  });
+
+  it('renders a medium status indicator by default', () => {
+    const { container } = render(
+      <Avatar status="available">
+        <img alt="" />
+      </Avatar>
+    );
+
+    expect(container.querySelector('figcaption')).toHaveStyleRule('height', '12px');
+  });
+
   it('renders badge if provided', () => {
     const badge = '2';
     const { getByText } = render(

--- a/.packages/avatars/src/elements/StatusIndicator.spec.tsx
+++ b/.packages/avatars/src/elements/StatusIndicator.spec.tsx
@@ -7,6 +7,7 @@
 
 import { render, renderRtl, cleanup } from 'garden-test-utils';
 import React from 'react';
+import { PALETTE } from '@zendeskgarden/react-theming';
 
 import { STATUS } from '../types';
 import { StatusIndicator } from './StatusIndicator';
@@ -33,6 +34,12 @@ describe('StatusIndicator', () => {
     const { getByText } = render(<StatusIndicator type="available">{text}</StatusIndicator>);
 
     expect(getByText(text).nodeName).toBe('FIGCAPTION');
+  });
+
+  it('renders offline type by default', () => {
+    const { getByRole } = render(<StatusIndicator />);
+
+    expect(getByRole('img')).toHaveStyleRule('border-color', PALETTE.grey[500]);
   });
 
   it('renders in compact mode', () => {

--- a/.packages/avatars/src/elements/StatusIndicator.spec.tsx
+++ b/.packages/avatars/src/elements/StatusIndicator.spec.tsx
@@ -5,9 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import { PALETTE } from '@zendeskgarden/react-theming';
 import { render, renderRtl, cleanup } from 'garden-test-utils';
 import React from 'react';
-import { PALETTE } from '@zendeskgarden/react-theming';
 
 import { STATUS } from '../types';
 import { StatusIndicator } from './StatusIndicator';

--- a/.packages/avatars/src/styled/StyledAvatar.spec.tsx
+++ b/.packages/avatars/src/styled/StyledAvatar.spec.tsx
@@ -122,6 +122,19 @@ describe('StyledAvatar', () => {
       expect(container.firstChild).toHaveStyleRule('width', '40px!important');
     });
 
+    it('renders medium when size is explicitly undefined', () => {
+      const { container } = render(
+        <StyledAvatar $size={undefined}>
+          <StyledStatusIndicator />
+        </StyledAvatar>
+      );
+
+      expect(container.firstChild).toHaveStyleRule('width', '40px!important');
+      expect(container.firstChild).toHaveStyleRule('bottom', '-2px', {
+        modifier: `&>${StyledStatusIndicator}`
+      });
+    });
+
     it('renders large', () => {
       const { container } = render(<StyledAvatar $size="large" />);
 

--- a/.packages/avatars/src/styled/StyledAvatar.ts
+++ b/.packages/avatars/src/styled/StyledAvatar.ts
@@ -19,9 +19,12 @@ const COMPONENT_ID = 'avatars.avatar';
 const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
   const [xxs, xs, s, m, l] = SIZE;
 
+  /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+   * explicitly passed undefined props, so `$size` may still be undefined here */
+  const size = props.$size ?? 'medium';
   let position = `${props.theme.space.base * -1}px`;
 
-  switch (props.$size) {
+  switch (size) {
     case xxs:
     case xs:
       position = math(`${position}  + 3`);
@@ -160,10 +163,9 @@ export interface IStyledAvatarProps {
 /**
  * Accepts all `<figure>` props
  */
-export const StyledAvatar = styled.figure.attrs<IStyledAvatarProps>(props => ({
+export const StyledAvatar = styled.figure.attrs<IStyledAvatarProps>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $size: props.$size ?? 'medium'
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledAvatarProps>`
   display: inline-flex;
   position: relative;

--- a/.packages/avatars/src/styled/StyledStandaloneStatusIndicator.spec.tsx
+++ b/.packages/avatars/src/styled/StyledStandaloneStatusIndicator.spec.tsx
@@ -5,9 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
-import { render } from 'garden-test-utils';
 import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { render } from 'garden-test-utils';
+import React from 'react';
 
 import { StyledStandaloneStatusIndicator } from './StyledStandaloneStatusIndicator';
 

--- a/.packages/avatars/src/styled/StyledStandaloneStatusIndicator.spec.tsx
+++ b/.packages/avatars/src/styled/StyledStandaloneStatusIndicator.spec.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+import { StyledStandaloneStatusIndicator } from './StyledStandaloneStatusIndicator';
+
+describe('StyledStandaloneStatusIndicator', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledStandaloneStatusIndicator />);
+
+    expect(container.firstChild!.nodeName).toBe('DIV');
+  });
+
+  it('renders medium size by default', () => {
+    const { container } = render(<StyledStandaloneStatusIndicator />);
+
+    expect(container.firstChild).toHaveStyleRule('height', '12px');
+  });
+
+  it('renders medium margin-top when size is explicitly undefined', () => {
+    const { container } = render(<StyledStandaloneStatusIndicator $size={undefined} />);
+    const expectedMargin = `calc((${DEFAULT_THEME.lineHeights.md} - 16px) / 2)`;
+
+    expect(container.firstChild).toHaveStyleRule('margin-top', expectedMargin);
+  });
+
+  it('renders small size', () => {
+    const { container } = render(<StyledStandaloneStatusIndicator $size="small" />);
+
+    expect(container.firstChild).toHaveStyleRule('height', '8px');
+  });
+});

--- a/.packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/.packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -15,15 +15,19 @@ const COMPONENT_ID = 'avatars.status-indicator.indicator';
 
 export const StyledStandaloneStatusIndicator = styled(
   StyledStatusIndicatorBase
-).attrs<IStyledStatusIndicatorProps>(props => ({
+).attrs<IStyledStatusIndicatorProps>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $type: props.$type ?? 'offline'
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledStatusIndicatorProps>`
   position: relative;
   box-sizing: content-box;
-  margin-top: ${props =>
-    `calc((${props.theme.lineHeights.md} - ${getStatusSize(props, '0')}) / 2)`};
+  margin-top: ${props => {
+    /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+     * explicitly passed undefined props, so `$size` may still be undefined here */
+    const sizeProps = { ...props, $size: props.$size ?? 'medium' };
+
+    return `calc((${props.theme.lineHeights.md} - ${getStatusSize(sizeProps, '0')}) / 2)`;
+  }};
 
   ${componentStyles};
 `;

--- a/.packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
+++ b/.packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
@@ -82,6 +82,16 @@ describe('StyledStatusIndicator', () => {
       );
     });
 
+    it('renders medium when size is explicitly undefined', () => {
+      const { container } = render(<StyledStatusIndicator $size={undefined} />);
+
+      expect(container.firstChild).toHaveStyleRule('height', '12px');
+      expect(container.firstChild).toHaveStyleRule(
+        'border',
+        `2px ${DEFAULT_THEME.borderStyles.solid}`
+      );
+    });
+
     it('renders large', () => {
       const { container } = render(<StyledStatusIndicator $size="large" />);
 

--- a/.packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/.packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -25,15 +25,18 @@ const COMPONENT_ID = 'avatars.status_indicator';
 const [xxs, xs, s, m, l] = SIZE;
 
 const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
-  const isVisible = props.$size !== xxs;
-  const iconSize = props.$size === xs ? `${props.theme.space.base * 2}px` : undefined;
+  /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+   * explicitly passed undefined props, so `$size` may still be undefined here */
+  const size = props.$size ?? 'medium';
+  const isVisible = size !== xxs;
+  const iconSize = size === xs ? `${props.theme.space.base * 2}px` : undefined;
   const borderWidth = getStatusBorderOffset(props);
 
   let padding = '0';
 
-  if (props.$size === s) {
+  if (size === s) {
     padding = math(`${props.theme.space.base + 1}px - (${borderWidth} * 2)`);
-  } else if (includes([m, l], props.$size)) {
+  } else if (includes([m, l], size)) {
     padding = math(`${props.theme.space.base + 3}px - (${borderWidth} * 2)`);
   }
 
@@ -94,10 +97,9 @@ const colorStyles = ({
 };
 
 export const StyledStatusIndicator = styled(StyledStatusIndicatorBase).attrs<IStatusIndicatorProps>(
-  props => ({
+  () => ({
     'data-garden-id': COMPONENT_ID,
-    'data-garden-version': PACKAGE_VERSION,
-    $size: props.$size ?? 'medium'
+    'data-garden-version': PACKAGE_VERSION
   })
 )<IStatusIndicatorProps>`
   ${sizeStyles}

--- a/.packages/avatars/src/styled/StyledStatusIndicatorBase.ts
+++ b/.packages/avatars/src/styled/StyledStatusIndicatorBase.ts
@@ -29,8 +29,11 @@ const iconFadeIn = keyframes`
 `;
 
 const sizeStyles = (props: IStyledStatusIndicatorProps) => {
-  const offset = getStatusBorderOffset(props);
-  const size = getStatusSize(props, offset);
+  /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+   * explicitly passed undefined props, so `$size` may still be undefined here */
+  const sizeProps = { ...props, $size: props.$size ?? 'medium' };
+  const offset = getStatusBorderOffset(sizeProps);
+  const size = getStatusSize(sizeProps, offset);
 
   /**
    * 1. because we are using the stroke icon instead of fill due to artifacts in visual appearance,

--- a/.packages/buttons/src/elements/Button.spec.tsx
+++ b/.packages/buttons/src/elements/Button.spec.tsx
@@ -32,6 +32,26 @@ describe('Button', () => {
     expect(container.firstChild).toHaveStyleRule('text-decoration', 'underline');
   });
 
+  describe('`type` attribute', () => {
+    it('renders default type of "button"', () => {
+      const { container } = render(<Button />);
+
+      expect(container.firstChild).toHaveAttribute('type', 'button');
+    });
+
+    it('renders default type of "button" if explicitly undefined', () => {
+      const { container } = render(<Button type={undefined} />);
+
+      expect(container.firstChild).toHaveAttribute('type', 'button');
+    });
+
+    it('renders custom type if provided', () => {
+      const { container } = render(<Button type="submit" />);
+
+      expect(container.firstChild).toHaveAttribute('type', 'submit');
+    });
+  });
+
   describe('`data-garden-id` attribute', () => {
     it('sets a default data-garden-id attribute', () => {
       const { getByRole } = render(<Button />);

--- a/.packages/buttons/src/elements/Button.tsx
+++ b/.packages/buttons/src/elements/Button.tsx
@@ -26,6 +26,7 @@ const ButtonComponent = forwardRef<HTMLButtonElement, IButtonProps>(
       isPrimary,
       isStretched,
       size = 'medium',
+      type = 'button',
       ...other
     },
     ref
@@ -35,6 +36,7 @@ const ButtonComponent = forwardRef<HTMLButtonElement, IButtonProps>(
     return (
       <StyledButton
         {...other}
+        type={type}
         $focusInset={focusInset || splitButtonFocusInset}
         $isBasic={isBasic}
         $isDanger={isDanger}

--- a/.packages/buttons/src/elements/IconButton.spec.tsx
+++ b/.packages/buttons/src/elements/IconButton.spec.tsx
@@ -22,6 +22,38 @@ describe('IconButton', () => {
     expect(container.querySelector('svg')).not.toBeNull();
   });
 
+  describe('`type` attribute', () => {
+    it('renders default type of "button"', () => {
+      const { container } = render(
+        <IconButton>
+          <TestIcon />
+        </IconButton>
+      );
+
+      expect(container.firstChild).toHaveAttribute('type', 'button');
+    });
+
+    it('renders default type of "button" if explicitly undefined', () => {
+      const { container } = render(
+        <IconButton type={undefined}>
+          <TestIcon />
+        </IconButton>
+      );
+
+      expect(container.firstChild).toHaveAttribute('type', 'button');
+    });
+
+    it('renders custom type if provided', () => {
+      const { container } = render(
+        <IconButton type="submit">
+          <TestIcon />
+        </IconButton>
+      );
+
+      expect(container.firstChild).toHaveAttribute('type', 'submit');
+    });
+  });
+
   describe('Invalid', () => {
     const consoleError = console.error;
 

--- a/.packages/buttons/src/elements/IconButton.tsx
+++ b/.packages/buttons/src/elements/IconButton.tsx
@@ -27,6 +27,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IIconButtonProps>(
       isPrimary,
       isRotated,
       size = 'medium',
+      type = 'button',
       ...other
     },
     ref
@@ -36,6 +37,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IIconButtonProps>(
     return (
       <StyledIconButton
         {...other}
+        type={type}
         $isBasic={isBasic}
         $isDanger={isDanger}
         $isNeutral={isNeutral}

--- a/.packages/buttons/src/styled/StyledButton.spec.tsx
+++ b/.packages/buttons/src/styled/StyledButton.spec.tsx
@@ -75,10 +75,20 @@ describe('StyledButton', () => {
     expect(container.firstChild).toHaveStyleRule('width', '100%');
   });
 
-  it('renders default type of "button"', () => {
+  /*
+   * the `type="button"` default is applied by the Button/IconButton elements;
+   * direct styled consumption without `type` renders no attribute
+   */
+  it('renders no type attribute by default', () => {
     const { container } = render(<StyledButton />);
 
-    expect(container.firstChild).toHaveAttribute('type', 'button');
+    expect(container.firstChild).not.toHaveAttribute('type');
+  });
+
+  it('renders no type attribute if explicitly undefined', () => {
+    const { container } = render(<StyledButton type={undefined} />);
+
+    expect(container.firstChild).not.toHaveAttribute('type');
   });
 
   it('renders custom type if provided', () => {

--- a/.packages/buttons/src/styled/StyledButton.ts
+++ b/.packages/buttons/src/styled/StyledButton.ts
@@ -439,10 +439,14 @@ const sizeStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
  * 2. FF <input type="submit"> fix
  * 3. Shifting :focus-visible from LVHFA order to preserve `text-decoration` on hover
  */
+/*
+ * the `type="button"` default lives in the `Button`/`IconButton` elements: an
+ * attrs fallback would be discarded by styled-components >= 6.3.12 when a
+ * caller explicitly passes `type={undefined}`
+ */
 export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
   'data-garden-id': (props as any)['data-garden-id'] || COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  type: props.type || 'button'
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledButtonProps>`
   display: ${props => (props.$isLink ? 'inline' : 'inline-flex')};
   align-items: ${props => !props.$isLink && 'center'};

--- a/.packages/dropdowns/package.json
+++ b/.packages/dropdowns/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
-    "@zendeskgarden/container-combobox": "^2.0.7",
+    "@zendeskgarden/container-combobox": "^2.0.9",
     "@zendeskgarden/container-menu": "^2.0.1",
     "@zendeskgarden/container-utilities": "^2.0.4",
     "@zendeskgarden/react-buttons": "^9.15.0",

--- a/.packages/dropdowns/src/elements/combobox/Combobox.spec.tsx
+++ b/.packages/dropdowns/src/elements/combobox/Combobox.spec.tsx
@@ -719,4 +719,68 @@ describe('Combobox', () => {
       expect(selectionValue).toMatchObject(['value-2']);
     });
   });
+
+  describe('scrollIntoView', () => {
+    it('does not scroll the input into view on mount', () => {
+      const scrollIntoView = jest.fn();
+
+      window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      render(
+        <TestCombobox>
+          <Option isSelected value="value" />
+        </TestCombobox>
+      );
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+
+    it('does not scroll the input into view on mount with initial selection', () => {
+      const scrollIntoView = jest.fn();
+
+      window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      render(
+        <TestCombobox selectionValue="value">
+          <Option value="value" />
+        </TestCombobox>
+      );
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+
+    it('scrolls the input into view when selection changes after mount', async () => {
+      const scrollIntoView = jest.fn();
+
+      window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      const { getByTestId } = render(
+        <TestCombobox defaultExpanded>
+          <Option data-test-id="option" value="value" />
+        </TestCombobox>
+      );
+
+      // Reset mock to ignore any scrollIntoView calls from Option active state on initial render
+      scrollIntoView.mockClear();
+
+      await user.click(getByTestId('option'));
+
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
+    });
+
+    it('does not scroll the last tag into view on mount for non-editable multiselectable', () => {
+      const scrollIntoView = jest.fn();
+
+      window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      render(
+        <TestCombobox isEditable={false} isMultiselectable selectionValue={['value-1', 'value-2']}>
+          <Option value="value-1" />
+          <Option value="value-2" />
+        </TestCombobox>
+      );
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/.packages/dropdowns/src/elements/combobox/Combobox.tsx
+++ b/.packages/dropdowns/src/elements/combobox/Combobox.tsx
@@ -250,9 +250,20 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
       return () => messageProps && setMessageProps(undefined);
     }, [getMessageProps, messageProps, setMessageProps]);
 
+    // Derive a stable primitive from selection so the effect only fires when values actually change,
+    // not when the selection object/array reference changes on re-render.
+    const selectionFingerprint = Array.isArray(selection)
+      ? selection.map(o => o.value).join('\0')
+      : (selection?.value ?? null);
+
+    const prevSelectionRef = useRef(selectionFingerprint);
+
     useEffect(() => {
-      inputRef.current?.scrollIntoView?.();
-    }, [selection]);
+      if (prevSelectionRef.current !== selectionFingerprint) {
+        prevSelectionRef.current = selectionFingerprint;
+        inputRef.current?.scrollIntoView?.();
+      }
+    }, [selectionFingerprint]);
 
     return (
       <ComboboxContext.Provider value={contextValue}>

--- a/.packages/dropdowns/src/elements/combobox/Listbox.spec.tsx
+++ b/.packages/dropdowns/src/elements/combobox/Listbox.spec.tsx
@@ -1,0 +1,132 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useRef } from 'react';
+import { act, render } from 'garden-test-utils';
+import { Listbox } from './Listbox';
+
+interface ITestListboxProps {
+  isExpanded?: boolean;
+}
+
+const TestListbox = ({ isExpanded }: ITestListboxProps) => {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <>
+      <button ref={triggerRef} type="button">
+        trigger
+      </button>
+      <Listbox isExpanded={isExpanded} triggerRef={triggerRef}>
+        <option data-test-id="option" aria-selected={false}>
+          option
+        </option>
+      </Listbox>
+    </>
+  );
+};
+
+describe('Listbox', () => {
+  describe('isMountedRef', () => {
+    it('renders children when expanded', () => {
+      const { queryByTestId, rerender } = render(<TestListbox isExpanded={false} />);
+
+      expect(queryByTestId('option')).toBeNull();
+
+      rerender(<TestListbox isExpanded />);
+
+      expect(queryByTestId('option')).not.toBeNull();
+    });
+
+    it('renders children when expanded inside React.StrictMode', () => {
+      // Regression: in StrictMode, components are mounted, unmounted, and
+      // remounted on first mount. The mount-tracking effect must reset
+      // `isMountedRef.current` to `true` on (re)mount, otherwise every
+      // guarded `setState` (including `setIsVisible(true)`) is suppressed
+      // and children never become visible.
+      const { queryByTestId, rerender } = render(
+        <React.StrictMode>
+          <TestListbox isExpanded={false} />
+        </React.StrictMode>
+      );
+
+      expect(queryByTestId('option')).toBeNull();
+
+      rerender(
+        <React.StrictMode>
+          <TestListbox isExpanded />
+        </React.StrictMode>
+      );
+
+      expect(queryByTestId('option')).not.toBeNull();
+    });
+
+    it('hides children after collapse animation completes', () => {
+      jest.useFakeTimers();
+
+      try {
+        const { queryByTestId, rerender } = render(<TestListbox isExpanded />);
+
+        expect(queryByTestId('option')).not.toBeNull();
+
+        rerender(<TestListbox isExpanded={false} />);
+
+        expect(queryByTestId('option')).not.toBeNull();
+
+        act(() => {
+          jest.advanceTimersByTime(200);
+        });
+
+        expect(queryByTestId('option')).toBeNull();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('hides children after collapse animation completes inside React.StrictMode', () => {
+      jest.useFakeTimers();
+
+      try {
+        const { queryByTestId, rerender } = render(
+          <React.StrictMode>
+            <TestListbox isExpanded />
+          </React.StrictMode>
+        );
+
+        expect(queryByTestId('option')).not.toBeNull();
+
+        rerender(
+          <React.StrictMode>
+            <TestListbox isExpanded={false} />
+          </React.StrictMode>
+        );
+
+        act(() => {
+          jest.advanceTimersByTime(200);
+        });
+
+        expect(queryByTestId('option')).toBeNull();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('does not warn about state updates after unmount', () => {
+      const error = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      try {
+        const { unmount } = render(<TestListbox isExpanded />);
+
+        unmount();
+
+        expect(error).not.toHaveBeenCalled();
+      } finally {
+        error.mockRestore();
+      }
+    });
+  });
+});

--- a/.packages/dropdowns/src/elements/combobox/Listbox.spec.tsx
+++ b/.packages/dropdowns/src/elements/combobox/Listbox.spec.tsx
@@ -5,8 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useRef } from 'react';
 import { act, render } from 'garden-test-utils';
+import React, { useRef } from 'react';
+
 import { Listbox } from './Listbox';
 
 interface ITestListboxProps {

--- a/.packages/dropdowns/src/elements/combobox/Listbox.tsx
+++ b/.packages/dropdowns/src/elements/combobox/Listbox.tsx
@@ -77,9 +77,12 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
     /* Prevent listbox close on scrollbar click */
     const handleMouseDown: MouseEventHandler = event => event.preventDefault();
 
-    useEffect(() => () => {
-      isMountedRef.current = false;
-    }, []);
+    useEffect(
+      () => () => {
+        isMountedRef.current = false;
+      },
+      []
+    );
 
     useEffect(() => {
       // Only allow listbox positioning updates on expanded combobox.

--- a/.packages/dropdowns/src/elements/combobox/Listbox.tsx
+++ b/.packages/dropdowns/src/elements/combobox/Listbox.tsx
@@ -77,12 +77,13 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
     /* Prevent listbox close on scrollbar click */
     const handleMouseDown: MouseEventHandler = event => event.preventDefault();
 
-    useEffect(
-      () => () => {
+    useEffect(() => {
+      isMountedRef.current = true;
+
+      return () => {
         isMountedRef.current = false;
-      },
-      []
-    );
+      };
+    }, []);
 
     useEffect(() => {
       // Only allow listbox positioning updates on expanded combobox.

--- a/.packages/dropdowns/src/elements/combobox/Listbox.tsx
+++ b/.packages/dropdowns/src/elements/combobox/Listbox.tsx
@@ -40,6 +40,7 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
     ref
   ) => {
     const floatingRef = useRef<HTMLDivElement>(null);
+    const isMountedRef = useRef(true);
     const [isVisible, setIsVisible] = useState(false);
     const [height, setHeight] = useState<number>();
     const [width, setWidth] = useState<number>();
@@ -59,7 +60,7 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
         size({
           apply: ({ rects, availableHeight }) => {
             /* istanbul ignore if */
-            if (rects.reference.width > 0) {
+            if (rects.reference.width > 0 && isMountedRef.current) {
               setWidth(rects.reference.width);
 
               if (
@@ -75,6 +76,10 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
     });
     /* Prevent listbox close on scrollbar click */
     const handleMouseDown: MouseEventHandler = event => event.preventDefault();
+
+    useEffect(() => () => {
+      isMountedRef.current = false;
+    }, []);
 
     useEffect(() => {
       // Only allow listbox positioning updates on expanded combobox.
@@ -94,11 +99,13 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
 
       /* istanbul ignore else */
       if (isExpanded) {
-        setIsVisible(true);
+        if (isMountedRef.current) setIsVisible(true);
       } else {
         timeout = setTimeout(() => {
-          setIsVisible(false);
-          setHeight(undefined);
+          if (isMountedRef.current) {
+            setIsVisible(false);
+            setHeight(undefined);
+          }
         }, 200 /* match menu opacity transition */);
       }
 
@@ -110,7 +117,7 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
         /* istanbul ignore if */
         if (height) {
           // Reset height on options change.
-          setHeight(undefined);
+          if (isMountedRef.current) setHeight(undefined);
           update();
         }
       },

--- a/.packages/dropdowns/src/elements/combobox/TagGroup.tsx
+++ b/.packages/dropdowns/src/elements/combobox/TagGroup.tsx
@@ -21,13 +21,22 @@ export const TagGroup = ({
   selection
 }: PropsWithChildren<ITagGroupProps>) => {
   const lastTagRef = useRef<HTMLDivElement>(null);
+  const isMountedRef = useRef(false);
+
+  // Derive a stable primitive from selection so the effect only fires when values actually change,
+  // not when the selection array reference changes on re-render.
+  const selectionFingerprint = selection.map(o => o.value).join('\0');
 
   useEffect(() => {
-    if (!isEditable) {
-      // Scroll the last tag into view.
-      lastTagRef.current?.scrollIntoView?.();
+    if (isMountedRef.current) {
+      if (!isEditable) {
+        // Scroll the last tag into view.
+        lastTagRef.current?.scrollIntoView?.();
+      }
+    } else {
+      isMountedRef.current = true;
     }
-  }, [isEditable, selection]);
+  }, [isEditable, selectionFingerprint]);
 
   return (
     <>

--- a/.packages/dropdowns/src/elements/menu/MenuList.spec.tsx
+++ b/.packages/dropdowns/src/elements/menu/MenuList.spec.tsx
@@ -5,8 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useRef } from 'react';
 import { act, render } from 'garden-test-utils';
+import React, { useRef } from 'react';
+
 import { MenuList } from './MenuList';
 
 interface ITestMenuListProps {

--- a/.packages/dropdowns/src/elements/menu/MenuList.spec.tsx
+++ b/.packages/dropdowns/src/elements/menu/MenuList.spec.tsx
@@ -1,0 +1,132 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useRef } from 'react';
+import { act, render } from 'garden-test-utils';
+import { MenuList } from './MenuList';
+
+interface ITestMenuListProps {
+  isExpanded?: boolean;
+}
+
+const TestMenuList = ({ isExpanded }: ITestMenuListProps) => {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <>
+      <button ref={triggerRef} type="button">
+        trigger
+      </button>
+      <MenuList isExpanded={isExpanded} triggerRef={triggerRef}>
+        <li data-test-id="item" role="menuitem">
+          item
+        </li>
+      </MenuList>
+    </>
+  );
+};
+
+describe('MenuList', () => {
+  describe('isMountedRef', () => {
+    it('renders children when expanded', () => {
+      const { queryByTestId, rerender } = render(<TestMenuList isExpanded={false} />);
+
+      expect(queryByTestId('item')).toBeNull();
+
+      rerender(<TestMenuList isExpanded />);
+
+      expect(queryByTestId('item')).not.toBeNull();
+    });
+
+    it('renders children when expanded inside React.StrictMode', () => {
+      // Regression: in StrictMode, components are mounted, unmounted, and
+      // remounted on first mount. The mount-tracking effect must reset
+      // `isMountedRef.current` to `true` on (re)mount, otherwise every
+      // guarded `setState` (including `setIsVisible(true)`) is suppressed
+      // and children never become visible.
+      const { queryByTestId, rerender } = render(
+        <React.StrictMode>
+          <TestMenuList isExpanded={false} />
+        </React.StrictMode>
+      );
+
+      expect(queryByTestId('item')).toBeNull();
+
+      rerender(
+        <React.StrictMode>
+          <TestMenuList isExpanded />
+        </React.StrictMode>
+      );
+
+      expect(queryByTestId('item')).not.toBeNull();
+    });
+
+    it('hides children after collapse animation completes', () => {
+      jest.useFakeTimers();
+
+      try {
+        const { queryByTestId, rerender } = render(<TestMenuList isExpanded />);
+
+        expect(queryByTestId('item')).not.toBeNull();
+
+        rerender(<TestMenuList isExpanded={false} />);
+
+        expect(queryByTestId('item')).not.toBeNull();
+
+        act(() => {
+          jest.advanceTimersByTime(200);
+        });
+
+        expect(queryByTestId('item')).toBeNull();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('hides children after collapse animation completes inside React.StrictMode', () => {
+      jest.useFakeTimers();
+
+      try {
+        const { queryByTestId, rerender } = render(
+          <React.StrictMode>
+            <TestMenuList isExpanded />
+          </React.StrictMode>
+        );
+
+        expect(queryByTestId('item')).not.toBeNull();
+
+        rerender(
+          <React.StrictMode>
+            <TestMenuList isExpanded={false} />
+          </React.StrictMode>
+        );
+
+        act(() => {
+          jest.advanceTimersByTime(200);
+        });
+
+        expect(queryByTestId('item')).toBeNull();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('does not warn about state updates after unmount', () => {
+      const error = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      try {
+        const { unmount } = render(<TestMenuList isExpanded />);
+
+        unmount();
+
+        expect(error).not.toHaveBeenCalled();
+      } finally {
+        error.mockRestore();
+      }
+    });
+  });
+});

--- a/.packages/dropdowns/src/elements/menu/MenuList.tsx
+++ b/.packages/dropdowns/src/elements/menu/MenuList.tsx
@@ -95,12 +95,13 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
       ]
     });
 
-    useEffect(
-      () => () => {
+    useEffect(() => {
+      isMountedRef.current = true;
+
+      return () => {
         isMountedRef.current = false;
-      },
-      []
-    );
+      };
+    }, []);
 
     useEffect(() => {
       // Only allow positioning updates on expanded menu.

--- a/.packages/dropdowns/src/elements/menu/MenuList.tsx
+++ b/.packages/dropdowns/src/elements/menu/MenuList.tsx
@@ -52,6 +52,7 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
     ref
   ) => {
     const floatingRef = useRef<HTMLDivElement>(null);
+    const isMountedRef = useRef(true);
     const [isVisible, setIsVisible] = useState(isExpanded);
     const [height, setHeight] = useState<number>();
     /* istanbul ignore next */
@@ -85,7 +86,7 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
           apply: ({ rects, availableHeight }) => {
             /* istanbul ignore if */
             if (!(minHeight === null || minHeight === 'fit-content')) {
-              if (rects.floating.height > availableHeight) {
+              if (rects.floating.height > availableHeight && isMountedRef.current) {
                 setHeight(availableHeight);
               }
             }
@@ -93,6 +94,10 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
         })
       ]
     });
+
+    useEffect(() => () => {
+      isMountedRef.current = false;
+    }, []);
 
     useEffect(() => {
       // Only allow positioning updates on expanded menu.
@@ -112,11 +117,13 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
 
       /* istanbul ignore else */
       if (isExpanded) {
-        setIsVisible(true);
+        if (isMountedRef.current) setIsVisible(true);
       } else {
         timeout = setTimeout(() => {
-          setIsVisible(false);
-          setHeight(undefined);
+          if (isMountedRef.current) {
+            setIsVisible(false);
+            setHeight(undefined);
+          }
         }, 200 /* match menu opacity transition */);
       }
 
@@ -128,7 +135,7 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
         /* istanbul ignore if */
         if (height) {
           // Reset height on options change.
-          setHeight(undefined);
+          if (isMountedRef.current) setHeight(undefined);
           update();
         }
       },

--- a/.packages/dropdowns/src/elements/menu/MenuList.tsx
+++ b/.packages/dropdowns/src/elements/menu/MenuList.tsx
@@ -95,9 +95,12 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
       ]
     });
 
-    useEffect(() => () => {
-      isMountedRef.current = false;
-    }, []);
+    useEffect(
+      () => () => {
+        isMountedRef.current = false;
+      },
+      []
+    );
 
     useEffect(() => {
       // Only allow positioning updates on expanded menu.

--- a/.packages/grid/src/elements/Col.spec.tsx
+++ b/.packages/grid/src/elements/Col.spec.tsx
@@ -5,10 +5,10 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { render } from 'garden-test-utils';
 import React from 'react';
 import styled from 'styled-components';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import { Col } from './Col';
 import { Grid } from './Grid';

--- a/.packages/grid/src/elements/Col.spec.tsx
+++ b/.packages/grid/src/elements/Col.spec.tsx
@@ -7,6 +7,8 @@
 
 import { render } from 'garden-test-utils';
 import React from 'react';
+import styled from 'styled-components';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import { Col } from './Col';
 import { Grid } from './Grid';
@@ -17,6 +19,29 @@ describe('Col', () => {
     const { container } = render(<Col />);
 
     expect(container.firstChild!.nodeName).toBe('DIV');
+  });
+
+  it('renders a numeric breakpoint size without a containing Grid', () => {
+    const { getByTestId } = render(<Col data-test-id="test" sm={12} />);
+
+    expect(getByTestId('test')).toHaveStyleRule('max-width', '100%', {
+      media: `(min-width:  ${DEFAULT_THEME.breakpoints.sm})`
+    });
+  });
+
+  it('renders a numeric size without a containing Grid', () => {
+    const { getByTestId } = render(<Col data-test-id="test" size={6} />);
+
+    expect(getByTestId('test')).toHaveStyleRule('max-width', '50%');
+  });
+
+  it('renders when wrapped with styled() without a containing Grid', () => {
+    const StyledCol = styled(Col)``;
+    const { getByTestId } = render(<StyledCol data-test-id="test" md={4} />);
+
+    expect(getByTestId('test')).toHaveStyleRule('max-width', `${(4 / 12) * 100}%`, {
+      media: `(min-width:  ${DEFAULT_THEME.breakpoints.md})`
+    });
   });
 
   it('passes ref to underlying DOM element', () => {

--- a/.packages/grid/src/elements/Grid.spec.tsx
+++ b/.packages/grid/src/elements/Grid.spec.tsx
@@ -6,7 +6,9 @@
  */
 
 import { render } from 'garden-test-utils';
+import { math } from 'polished';
 import React from 'react';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import { Grid } from './Grid';
 
@@ -15,6 +17,14 @@ describe('Grid', () => {
     const { container } = render(<Grid />);
 
     expect(container.firstChild!.nodeName).toBe('DIV');
+  });
+
+  it('renders medium gutters by default', () => {
+    const { container } = render(<Grid />);
+    const padding = math(`${DEFAULT_THEME.space.md} / 2`);
+
+    expect(container.firstChild).toHaveStyleRule('padding-right', padding);
+    expect(container.firstChild).toHaveStyleRule('padding-left', padding);
   });
 
   it('passes ref to underlying DOM element', () => {

--- a/.packages/grid/src/elements/Grid.spec.tsx
+++ b/.packages/grid/src/elements/Grid.spec.tsx
@@ -5,10 +5,10 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { render } from 'garden-test-utils';
 import { math } from 'polished';
 import React from 'react';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import { Grid } from './Grid';
 

--- a/.packages/grid/src/elements/Row.spec.tsx
+++ b/.packages/grid/src/elements/Row.spec.tsx
@@ -25,6 +25,12 @@ describe('Row', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
+  it('wraps by default', () => {
+    const { container } = render(<Row />);
+
+    expect(container.firstChild).toHaveStyleRule('flex-wrap', 'wrap');
+  });
+
   it('renders gutters provided by the containing Grid', () => {
     const { getByTestId } = render(
       <Grid gutters={false}>

--- a/.packages/grid/src/styled/StyledCol.ts
+++ b/.packages/grid/src/styled/StyledCol.ts
@@ -71,7 +71,10 @@ const flexStyles = (
   order: GridNumber | undefined,
   props: IStyledColProps
 ) => {
-  const margin = offset && `${math(`${offset} / ${props.$columns} * 100`)}%`;
+  /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+   * explicitly passed undefined props, so `$columns` may still be undefined here */
+  const columns = props.$columns ?? 12;
+  const margin = offset && `${math(`${offset} / ${columns} * 100`)}%`;
   let flexBasis;
   let flexGrow;
   let maxWidth;
@@ -87,7 +90,7 @@ const flexStyles = (
     maxWidth = '100%';
     width = 'auto';
   } else if (size !== undefined) {
-    flexBasis = `${math(`${size} / ${props.$columns} * 100`)}%`;
+    flexBasis = `${math(`${size} / ${columns} * 100`)}%`;
     flexGrow = 0;
     maxWidth = flexBasis;
   }
@@ -107,7 +110,7 @@ const flexStyles = (
   if (order === 'first') {
     flexOrder = -1;
   } else if (order === 'last') {
-    flexOrder = math(`${props.$columns} + 1`);
+    flexOrder = math(`${columns} + 1`);
   } else {
     flexOrder = order;
   }
@@ -151,10 +154,9 @@ const sizeStyles = ({ theme, $gutters }: IStyledColProps) => {
   `;
 };
 
-export const StyledCol = styled.div.attrs<IStyledColProps>(props => ({
+export const StyledCol = styled.div.attrs<IStyledColProps>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $columns: props.$columns ?? 12
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledColProps>`
   box-sizing: border-box;
   width: 100%;

--- a/.packages/grid/src/styled/StyledGrid.spec.tsx
+++ b/.packages/grid/src/styled/StyledGrid.spec.tsx
@@ -54,5 +54,13 @@ describe('StyledGrid', () => {
       expect(container.firstChild).toHaveStyleRule('padding-right', '0');
       expect(container.firstChild).toHaveStyleRule('padding-left', '0');
     });
+
+    it('renders default gutters when gutters are explicitly undefined', () => {
+      const { container } = render(<StyledGrid $gutters={undefined} />);
+      const padding = math(`${DEFAULT_THEME.space.md} / 2`);
+
+      expect(container.firstChild).toHaveStyleRule('padding-right', padding);
+      expect(container.firstChild).toHaveStyleRule('padding-left', padding);
+    });
   });
 });

--- a/.packages/grid/src/styled/StyledGrid.ts
+++ b/.packages/grid/src/styled/StyledGrid.ts
@@ -36,7 +36,10 @@ const colorStyles = ({ theme, $debug }: IStyledGridProps) => {
 };
 
 const sizeStyles = ({ theme, $gutters }: IStyledGridProps) => {
-  const padding = $gutters ? math(`${theme.space[$gutters!]} / 2`) : 0;
+  /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+   * explicitly passed undefined props, so `$gutters` may still be undefined here */
+  const gutters = $gutters ?? 'md';
+  const padding = gutters ? math(`${theme.space[gutters]} / 2`) : 0;
 
   return css`
     padding-right: ${padding};
@@ -49,10 +52,9 @@ interface IStyledGridProps extends ThemeProps<DefaultTheme> {
   $gutters?: IGridProps['gutters'];
 }
 
-export const StyledGrid = styled.div.attrs<IStyledGridProps>(props => ({
+export const StyledGrid = styled.div.attrs<IStyledGridProps>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $gutters: props.$gutters ?? 'md'
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledGridProps>`
   direction: ${props => props.theme.rtl && 'rtl'};
   margin-right: auto;

--- a/.packages/grid/src/styled/StyledRow.ts
+++ b/.packages/grid/src/styled/StyledRow.ts
@@ -100,15 +100,16 @@ const sizeStyles = ({ theme, $gutters }: IStyledRowProps) => {
   `;
 };
 
-export const StyledRow = styled.div.attrs<IStyledRowProps>(props => ({
+export const StyledRow = styled.div.attrs<IStyledRowProps>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $wrapAll: props.$wrapAll ?? 'wrap'
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledRowProps>`
   display: flex;
   box-sizing: border-box;
 
-  ${props => flexStyles(props.$alignItems, props.$justifyContent, props.$wrapAll)}
+  /* the $wrapAll fallback cannot live in attrs: styled-components >= 6.3.12
+     preserves explicitly passed undefined props */
+  ${props => flexStyles(props.$alignItems, props.$justifyContent, props.$wrapAll ?? 'wrap')}
 
   ${sizeStyles};
 

--- a/.packages/grid/src/utils/useGridContext.spec.tsx
+++ b/.packages/grid/src/utils/useGridContext.spec.tsx
@@ -21,4 +21,15 @@ describe('useGridContext', () => {
 
     expect(container.firstChild).toHaveAttribute('data-gutters', 'md');
   });
+
+  it('contains default column count', () => {
+    const GridContextConsumer = () => {
+      const { columns } = useGridContext();
+
+      return <div data-columns={columns}>test</div>;
+    };
+    const { container } = render(<GridContextConsumer />);
+
+    expect(container.firstChild).toHaveAttribute('data-columns', '12');
+  });
 });

--- a/.packages/grid/src/utils/useGridContext.ts
+++ b/.packages/grid/src/utils/useGridContext.ts
@@ -15,7 +15,7 @@ interface IGridContext {
   debug?: boolean;
 }
 
-export const GridContext = createContext<IGridContext>({ gutters: 'md' });
+export const GridContext = createContext<IGridContext>({ columns: 12, gutters: 'md' });
 
 /**
  * Retrieve Grid component context

--- a/.packages/modals/package.json
+++ b/.packages/modals/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
-    "@zendeskgarden/container-modal": "^1.0.24",
+    "@zendeskgarden/container-modal": "^2.0.0",
     "@zendeskgarden/container-utilities": "^2.0.4",
     "@zendeskgarden/react-buttons": "^9.15.0",
     "dom-helpers": "^5.1.0",

--- a/.packages/modals/src/elements/Drawer/Body.spec.tsx
+++ b/.packages/modals/src/elements/Drawer/Body.spec.tsx
@@ -5,9 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
 import { render } from 'garden-test-utils';
 import React from 'react';
+import styled from 'styled-components';
 
 import { Drawer } from './Drawer';
 

--- a/.packages/modals/src/elements/Drawer/Body.spec.tsx
+++ b/.packages/modals/src/elements/Drawer/Body.spec.tsx
@@ -5,6 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import styled from 'styled-components';
 import { render } from 'garden-test-utils';
 import React from 'react';
 
@@ -20,5 +21,18 @@ describe('Drawer.Body', () => {
     );
 
     expect(getByText('content')).toBe(ref.current);
+  });
+
+  it('renders when wrapped with styled()', () => {
+    const StyledBody = styled(Drawer.Body)`
+      padding-bottom: 10px;
+    `;
+    const { getByText } = render(
+      <Drawer isOpen>
+        <StyledBody>content</StyledBody>
+      </Drawer>
+    );
+
+    expect(getByText('content')).toHaveStyleRule('padding-bottom', '10px');
   });
 });

--- a/.packages/modals/src/elements/Drawer/Drawer.spec.tsx
+++ b/.packages/modals/src/elements/Drawer/Drawer.spec.tsx
@@ -178,6 +178,18 @@ describe('Drawer', () => {
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
   });
 
+  it('does not close the drawer modal when focus moves outside', async () => {
+    const { getByText, getByRole } = render(<Example />);
+
+    await user.click(getByText('Open Drawer'));
+
+    expect(getByRole('dialog')).toBeInTheDocument();
+
+    await user.click(document.body);
+
+    expect(getByRole('dialog')).toBeInTheDocument();
+  });
+
   describe('focus management', () => {
     it('correctly focuses on the Drawer when open', async () => {
       const { getByText, getByRole } = render(<Example />);

--- a/.packages/modals/src/elements/Modal.spec.tsx
+++ b/.packages/modals/src/elements/Modal.spec.tsx
@@ -156,6 +156,13 @@ describe('Modal', () => {
       await user.type(getByTestId('modal'), '{escape}');
       expect(onCloseSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('is not triggered when focus moves outside the modal', async () => {
+      render(<BasicExample onClose={onCloseSpy} />);
+
+      await user.click(document.body);
+      expect(onCloseSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('appendToNode', () => {

--- a/.packages/modals/src/elements/TooltipDialog/TooltipDialog.spec.tsx
+++ b/.packages/modals/src/elements/TooltipDialog/TooltipDialog.spec.tsx
@@ -232,6 +232,35 @@ describe('TooltipDialog', () => {
 
       expect(onCloseSpy).toHaveBeenCalled();
     });
+
+    describe('blur behavior (closeOnBlur: true)', () => {
+      it('is triggered when focus moves outside the dialog', async () => {
+        const { getByText } = render(<Example onClose={onCloseSpy} />);
+
+        await act(async () => {
+          await user.click(getByText('open'));
+        });
+
+        await waitFor(async () => {
+          await user.click(document.body);
+        });
+
+        expect(onCloseSpy).toHaveBeenCalled();
+      });
+
+      it('is not triggered when focus moves to an element inside the dialog', async () => {
+        const { getByRole, getByText } = render(<Example onClose={onCloseSpy} />);
+
+        await act(async () => {
+          await user.click(getByText('open'));
+        });
+
+        // Click the dialog itself (tabIndex=-1) — focus stays inside, no close
+        await user.click(getByRole('dialog'));
+
+        expect(onCloseSpy).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('keepMounted', () => {

--- a/.packages/modals/src/elements/TooltipDialog/TooltipDialog.spec.tsx
+++ b/.packages/modals/src/elements/TooltipDialog/TooltipDialog.spec.tsx
@@ -65,7 +65,7 @@ describe('TooltipDialog', () => {
         await user.click(getByText('open'));
       });
 
-      expect(getByRole('dialog').parentElement).toHaveStyle({ transform: 'translate(-12px, 0px)' });
+      expect(getByRole('dialog').parentElement).toHaveStyle({ transform: 'translate(0px, 0px)' });
     });
 
     it('renders RTL placement correctly', async () => {
@@ -75,8 +75,18 @@ describe('TooltipDialog', () => {
         await user.click(getByText('open'));
       });
 
-      expect(getByRole('dialog').parentElement).toHaveStyle({ transform: 'translate(12px, 0px)' });
+      expect(getByRole('dialog').parentElement).toHaveStyle({ transform: 'translate(0px, 0px)' });
     });
+  });
+
+  it('limits dialog width to viewport width', async () => {
+    const { getByRole, getByText } = render(<Example />);
+
+    await act(async () => {
+      await user.click(getByText('open'));
+    });
+
+    expect(getByRole('dialog')).toHaveStyle({ maxWidth: '100vw' });
   });
 
   it('applies backdropProps to Backdrop element', async () => {

--- a/.packages/modals/src/elements/TooltipDialog/TooltipDialog.tsx
+++ b/.packages/modals/src/elements/TooltipDialog/TooltipDialog.tsx
@@ -75,6 +75,7 @@ const TooltipDialogComponent = React.forwardRef<HTMLDivElement, ITooltipDialogPr
     };
     const { getTitleProps, getCloseProps, getContentProps, getBackdropProps, getModalProps } =
       useModal({
+        closeOnBlur: true,
         idPrefix: id,
         onClose: handleClose,
         modalRef,

--- a/.packages/modals/src/elements/TooltipDialog/TooltipDialog.tsx
+++ b/.packages/modals/src/elements/TooltipDialog/TooltipDialog.tsx
@@ -11,6 +11,7 @@ import {
   flip,
   offset,
   platform,
+  shift,
   useFloating
 } from '@floating-ui/react-dom';
 import { useModal } from '@zendeskgarden/container-modal';
@@ -90,10 +91,12 @@ const TooltipDialogComponent = React.forwardRef<HTMLDivElement, ITooltipDialogPr
       _placement === 'auto' ? PLACEMENT_DEFAULT : _placement!,
       _fallbackPlacements
     );
+    const isAutoPlacement = _placement === 'auto';
 
     const {
       refs,
       placement,
+      middlewareData,
       update,
       floatingStyles: { transform }
     } = useFloating({
@@ -105,9 +108,15 @@ const TooltipDialogComponent = React.forwardRef<HTMLDivElement, ITooltipDialogPr
       placement: floatingPlacement,
       middleware: [
         offset(_offset === undefined ? theme.space.base * 3 : _offset),
-        _placement === 'auto' ? autoPlacement() : flip({ fallbackPlacements })
+        isAutoPlacement ? autoPlacement() : flip({ fallbackPlacements }),
+        shift({ mainAxis: true, crossAxis: true })
       ]
     });
+    const placementSide = placement.split('-')[0];
+    const arrowShift =
+      placementSide === 'top' || placementSide === 'bottom'
+        ? -(middlewareData.shift?.x || 0)
+        : -(middlewareData.shift?.y || 0);
 
     useEffect(() => {
       // Only allow positioning updates on visible tooltip modal.
@@ -199,6 +208,7 @@ const TooltipDialogComponent = React.forwardRef<HTMLDivElement, ITooltipDialogPr
                   <StyledTooltipDialog
                     $transitionState={transitionState}
                     $placement={placement}
+                    $arrowShift={arrowShift}
                     $hasArrow={hasArrow}
                     $isAnimated={isAnimated}
                     inert={isHidden ? '' : undefined}

--- a/.packages/modals/src/styled/StyledTooltipDialog.ts
+++ b/.packages/modals/src/styled/StyledTooltipDialog.ts
@@ -16,6 +16,7 @@ const COMPONENT_ID = 'modals.tooltip_dialog';
 
 export interface IStyledTooltipDialogProps {
   $hasArrow?: boolean;
+  $arrowShift?: number;
   $isAnimated?: boolean;
   $placement: Placement;
   $transitionState?: TransitionStatus;
@@ -25,6 +26,7 @@ export interface IStyledTooltipDialogProps {
 const sizeStyles = (props: ThemeProps<DefaultTheme>) => `
   padding: ${props.theme.space.base * 5}px;
   width: 400px;
+  max-width: 100vw;
   
   &:has(${StyledTooltipDialogClose}) > :first-child {
     padding-${props.theme.rtl ? 'left' : 'right'}: ${props.theme.space.base * 8}px;
@@ -40,6 +42,7 @@ export const StyledTooltipDialog = styled.div.attrs<IStyledTooltipDialogProps>(p
     const computedArrowStyles = arrowStyles(getArrowPosition(props.theme, props.$placement), {
       size: `${props.theme.space.base * 2}px`,
       inset: '1px',
+      shift: `${props.$arrowShift || 0}px`,
       animationModifier: '.is-animated'
     });
 

--- a/.packages/tags/src/elements/Tag.spec.tsx
+++ b/.packages/tags/src/elements/Tag.spec.tsx
@@ -11,6 +11,12 @@ import React from 'react';
 import { Tag } from './Tag';
 
 describe('Tag', () => {
+  it('renders medium size by default', () => {
+    const { container } = render(<Tag />);
+
+    expect(container.firstChild).toHaveStyleRule('height', '20px');
+  });
+
   it('applies correct styling with RTL locale', () => {
     const { container } = renderRtl(<Tag />);
 

--- a/.packages/tags/src/styled/StyledTag.spec.tsx
+++ b/.packages/tags/src/styled/StyledTag.spec.tsx
@@ -75,6 +75,12 @@ describe('StyledTag', () => {
       expect(container.firstChild).toHaveStyleRule('height', '20px');
     });
 
+    it('renders medium styling when size is explicitly undefined', () => {
+      const { container } = render(<StyledTag $size={undefined} />);
+
+      expect(container.firstChild).toHaveStyleRule('height', '20px');
+    });
+
     it('renders large styling if provided', () => {
       const { container } = render(<StyledTag $size="large" />);
 

--- a/.packages/tags/src/styled/StyledTag.ts
+++ b/.packages/tags/src/styled/StyledTag.ts
@@ -211,10 +211,9 @@ const sizeStyles = ({ $isPill, $isRound, $size, theme }: IStyledTagProps) => {
   `;
 };
 
-export const StyledTag = styled.div.attrs<IStyledTagProps>(props => ({
+export const StyledTag = styled.div.attrs<IStyledTagProps>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $size: props.$size ?? 'medium'
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledTagProps>`
   display: inline-flex;
   flex-wrap: nowrap;

--- a/.packages/theming/src/utils/arrowStyles.spec.tsx
+++ b/.packages/theming/src/utils/arrowStyles.spec.tsx
@@ -17,6 +17,7 @@ interface IStyledDivProps extends ThemeProps<DefaultTheme> {
   $arrowPosition: ArrowPosition;
   $arrowSize?: string;
   $arrowInset?: string;
+  $arrowShift?: string;
   $arrowAnimationModifier?: string;
 }
 
@@ -25,6 +26,7 @@ const StyledDiv = styled.div<IStyledDivProps>`
     arrowStyles(props.$arrowPosition, {
       size: props.$arrowSize,
       inset: props.$arrowInset,
+      shift: props.$arrowShift,
       animationModifier: props.$arrowAnimationModifier
     })}
 `;
@@ -95,6 +97,23 @@ describe('arrowStyles', () => {
         const value = getArrowInset(inset);
 
         expect(container.firstChild).toHaveStyleRule('top', value, { modifier: '::before' });
+      });
+    });
+  });
+
+  describe('shift', () => {
+    it('applies offset to centered arrow positions', () => {
+      const SHIFT = '4px';
+      const POSITION: ArrowPosition[] = ['top', 'right', 'bottom', 'left'];
+
+      POSITION.forEach(position => {
+        const { container } = render(<StyledDiv $arrowPosition={position} $arrowShift={SHIFT} />);
+
+        const property = position === 'top' || position === 'bottom' ? 'left' : 'top';
+
+        expect(container.firstChild).toHaveStyleRule(property, `calc(50% + ${SHIFT})`, {
+          modifier: '::before'
+        });
       });
     });
   });

--- a/.packages/theming/src/utils/arrowStyles.ts
+++ b/.packages/theming/src/utils/arrowStyles.ts
@@ -47,6 +47,7 @@ const positionStyles = (position: ArrowPosition, size: number, inset: number, sh
   const marginPx = `${margin}px`;
   const placementPx = `${placement}px`;
   const offsetPx = `${size + shift}px`;
+  const centeredOffset = shift === 0 ? '50%' : `calc(50% + ${shift}px)`;
 
   let positionCss;
   let transform;
@@ -56,13 +57,13 @@ const positionStyles = (position: ArrowPosition, size: number, inset: number, sh
     positionCss = css`
       top: ${placementPx};
       right: ${position === 'top-right' && offsetPx};
-      left: ${position === 'top' ? '50%' : position === 'top-left' && offsetPx};
+      left: ${position === 'top' ? centeredOffset : position === 'top-left' && offsetPx};
       margin-left: ${position === 'top' && marginPx};
     `;
   } else if (position.startsWith('right')) {
     transform = 'rotate(-45deg)';
     positionCss = css`
-      top: ${position === 'right' ? '50%' : position === 'right-top' && offsetPx};
+      top: ${position === 'right' ? centeredOffset : position === 'right-top' && offsetPx};
       right: ${placementPx};
       bottom: ${position === 'right-bottom' && offsetPx};
       margin-top: ${position === 'right' && marginPx};
@@ -72,13 +73,13 @@ const positionStyles = (position: ArrowPosition, size: number, inset: number, sh
     positionCss = css`
       right: ${position === 'bottom-right' && offsetPx};
       bottom: ${placementPx};
-      left: ${position === 'bottom' ? '50%' : position === 'bottom-left' && offsetPx};
+      left: ${position === 'bottom' ? centeredOffset : position === 'bottom-left' && offsetPx};
       margin-left: ${position === 'bottom' && marginPx};
     `;
   } else if (position.startsWith('left')) {
     transform = 'rotate(135deg)';
     positionCss = css`
-      top: ${position === 'left' ? '50%' : position === 'left-top' && offsetPx};
+      top: ${position === 'left' ? centeredOffset : position === 'left-top' && offsetPx};
       bottom: ${offsetPx};
       left: ${placementPx};
       margin-top: ${position === 'left' && marginPx};

--- a/.packages/typography/src/elements/CodeBlock.spec.tsx
+++ b/.packages/typography/src/elements/CodeBlock.spec.tsx
@@ -126,6 +126,14 @@ describe('CodeBlock', () => {
   });
 
   describe('size', () => {
+    it('renders medium size by default', async () => {
+      const { container } = render(<CodeBlock />);
+
+      await waitFor(() => {
+        expect(container.getElementsByTagName('code')[0]).toHaveStyleRule('font-size', '13px');
+      });
+    });
+
     it('renders small size', async () => {
       const { container } = render(<CodeBlock size="small" />);
 

--- a/.packages/typography/src/styled/StyledCode.ts
+++ b/.packages/typography/src/styled/StyledCode.ts
@@ -59,13 +59,11 @@ interface IStyledCodeProps extends Omit<IStyledFontProps, 'size'> {
   $size?: ICodeProps['size'];
 }
 
-export const StyledCode = styled(StyledFont as 'code').attrs<IStyledCodeProps>(props => ({
+export const StyledCode = styled(StyledFont as 'code').attrs<IStyledCodeProps>(() => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   as: 'code',
-  $isMonospace: true,
-  $hue: props.$hue ?? 'grey',
-  $size: props.$size ?? 'inherit'
+  $isMonospace: true
 }))<IStyledCodeProps>`
   border-radius: ${props => props.theme.borderRadii.sm};
   padding: 1.5px;

--- a/.packages/typography/src/styled/StyledFont.spec.tsx
+++ b/.packages/typography/src/styled/StyledFont.spec.tsx
@@ -50,6 +50,12 @@ describe('StyledFont', () => {
       expect(container.firstChild).not.toHaveStyleRule('font-weight');
     });
 
+    it('renders inherited size when size is explicitly undefined', () => {
+      const { container } = render(<StyledFont $isMonospace $size={undefined} />);
+
+      expect(container.firstChild).toHaveStyleRule('font-size', 'calc(1em - 1px)');
+    });
+
     it('renders small size', () => {
       const { container } = render(<StyledFont $size="small" />);
 

--- a/.packages/typography/src/styled/StyledFont.tsx
+++ b/.packages/typography/src/styled/StyledFont.tsx
@@ -38,7 +38,10 @@ const fontStyles = ({
   $size,
   theme
 }: IStyledFontProps & ThemeProps<DefaultTheme>) => {
-  const monospace = $isMonospace && ['inherit', 'small', 'medium', 'large'].indexOf($size!) !== -1;
+  /* attrs cannot provide this fallback: styled-components >= 6.3.12 preserves
+   * explicitly passed undefined props, so `$size` may still be undefined here */
+  const size = $size ?? 'inherit';
+  const monospace = $isMonospace && ['inherit', 'small', 'medium', 'large'].indexOf(size) !== -1;
   const fontFamily = monospace && theme.fonts.mono;
   const direction = theme.rtl ? 'rtl' : 'ltr';
   const color = $hue ? getHueColor({ theme, value: $hue }) : undefined;
@@ -47,17 +50,17 @@ const fontStyles = ({
   let lineHeight;
 
   if (monospace) {
-    if ($size === 'inherit') {
+    if (size === 'inherit') {
       fontSize = 'calc(1em - 1px)';
       lineHeight = 'normal';
     } else {
-      const themeSize = THEME_SIZES[$size!];
+      const themeSize = THEME_SIZES[size];
 
       fontSize = math(`${theme.fontSizes[themeSize]} - 1px`);
       lineHeight = math(`${theme.lineHeights[themeSize]} - 1px`);
     }
-  } else if ($size !== 'inherit') {
-    const themeSize = THEME_SIZES[$size!];
+  } else if (size !== 'inherit') {
+    const themeSize = THEME_SIZES[size];
 
     fontSize = theme.fontSizes[themeSize];
     lineHeight = theme.lineHeights[themeSize];
@@ -65,7 +68,7 @@ const fontStyles = ({
 
   if ($isBold === true) {
     fontWeight = theme.fontWeights.semibold;
-  } else if ($isBold === false || $size !== 'inherit') {
+  } else if ($isBold === false || size !== 'inherit') {
     fontWeight = theme.fontWeights.regular;
   }
 
@@ -87,10 +90,9 @@ export interface IStyledFontProps {
   $hue?: string;
 }
 
-export const StyledFont = styled.div.attrs<IStyledFontProps>(props => ({
+export const StyledFont = styled.div.attrs<IStyledFontProps>(() => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  $size: props.$size ?? 'inherit'
+  'data-garden-version': PACKAGE_VERSION
 }))<IStyledFontProps>`
   ${props => !props.hidden && fontStyles(props)};
 

--- a/.packages/typography/src/styled/StyledListItem.spec.tsx
+++ b/.packages/typography/src/styled/StyledListItem.spec.tsx
@@ -30,6 +30,12 @@ describe('StyledListItem', () => {
       expect(container.firstChild).toHaveStyleRule('padding-top', '4px');
     });
 
+    it('renders medium spacing when space is explicitly undefined', () => {
+      const { container } = render(<StyledListItem $space={undefined} />);
+
+      expect(container.firstChild).toHaveStyleRule('padding-top', '4px');
+    });
+
     it('renders large spacing', () => {
       const { container } = render(<StyledListItem $space="large" />);
 

--- a/.packages/typography/src/styled/StyledListItem.ts
+++ b/.packages/typography/src/styled/StyledListItem.ts
@@ -52,14 +52,11 @@ const listItemStyles = (props: IStyledListItemProps & ThemeProps<DefaultTheme>) 
 
 const ORDERED_ID = 'typography.ordered_list_item';
 
-export const StyledOrderedListItem = styled(StyledFont as 'li').attrs<IStyledListItemProps>(
-  props => ({
-    'data-garden-id': ORDERED_ID,
-    'data-garden-version': PACKAGE_VERSION,
-    as: 'li',
-    $space: props.$space ?? 'medium'
-  })
-)<IStyledListItemProps>`
+export const StyledOrderedListItem = styled(StyledFont as 'li').attrs<IStyledListItemProps>(() => ({
+  'data-garden-id': ORDERED_ID,
+  'data-garden-version': PACKAGE_VERSION,
+  as: 'li'
+}))<IStyledListItemProps>`
   margin-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
     math(`${props.theme.space.base} * -1px`)};
   padding-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
@@ -73,11 +70,10 @@ export const StyledOrderedListItem = styled(StyledFont as 'li').attrs<IStyledLis
 const UNORDERED_ID = 'typography.unordered_list_item';
 
 export const StyledUnorderedListItem = styled(StyledFont as 'li').attrs<IStyledListItemProps>(
-  props => ({
+  () => ({
     'data-garden-id': UNORDERED_ID,
     'data-garden-version': PACKAGE_VERSION,
-    as: 'li',
-    $space: props.$space ?? 'medium'
+    as: 'li'
   })
 )<IStyledListItemProps>`
   ${listItemStyles};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,57 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 <!-- DO NOT MODIFY BELOW THIS COMMENT -->
 <!-- insert-new-changelog-here -->
 
+## v9.15.8 (2026-08-20)
+
+#### :bug: Bug Fix
+* `accordions`, `avatars`, `buttons`, `grid`, `tags`, `typography`
+  * [#2143](https://github.com/zendeskgarden/react-components/pull/2143) fix: keep components behavior stable for users on styled-components >= 6.3.12 ([@ze-flo](https://github.com/ze-flo))
+
+## v9.15.7 (2026-07-23)
+
+#### :bug: Bug Fix
+* `dropdowns`
+  * [#2140](https://github.com/zendeskgarden/react-components/pull/2140) fix(dropdowns): stop auto-activating first option while editing autocomplete Combobox ([@jgorfine-zendesk](https://github.com/jgorfine-zendesk))
+
+## v9.15.6 (2026-06-26)
+
+#### :bug: Bug Fix
+* `accordions`
+  * [#2137](https://github.com/zendeskgarden/react-components/pull/2137) fix(accordions): prevent step content overflow when collapsed ([@ze-flo](https://github.com/ze-flo))
+
+## v9.15.5 (2026-05-28)
+
+#### :bug: Bug Fix
+* `modals`, `theming`
+  * [#2130](https://github.com/zendeskgarden/react-components/pull/2130) fix(modals): keep tooltip dialog within viewport bounds ([@bmson](https://github.com/bmson))
+
+## v9.15.4 (2026-04-27)
+
+#### :bug: Bug Fix
+* `modals`
+  * [#2127](https://github.com/zendeskgarden/react-components/pull/2127) fix(modals): upgrade `container-modal` to v2 to fix blur-close behavior ([@ze-flo](https://github.com/ze-flo))
+* `dropdowns`
+  * [#2126](https://github.com/zendeskgarden/react-components/pull/2126) fix(dropdowns): restore isMountedRef on remount to fix StrictMode regression ([@ze-flo](https://github.com/ze-flo))
+
+## v9.15.3 (2026-04-23)
+
+#### :bug: Bug Fix
+* [#2125](https://github.com/zendeskgarden/react-components/pull/2125) fix(publishing): ensure `latest` tag is applied to most recent release ([@ze-flo](https://github.com/ze-flo))
+
+## v9.15.2 (2026-04-23)
+
+#### :bug: Bug Fix
+* `accordions`, `dropdowns`
+  * [#2123](https://github.com/zendeskgarden/react-components/pull/2123) fix(accordions): prevent focus ring clipping in stepper content ([@ze-flo](https://github.com/ze-flo))
+* `dropdowns`
+  * [#2124](https://github.com/zendeskgarden/react-components/pull/2124) fix(dropdowns): guard Listbox and MenuList state setters against post-unmount updates ([@jamesbrauman](https://github.com/jamesbrauman))
+
+## v9.15.1 (2026-04-02)
+
+#### :bug: Bug Fix
+* `dropdowns`
+  * [#2115](https://github.com/zendeskgarden/react-components/pull/2115) fix(dropdowns): avoid unwanted page scroll when Combobox mounts or re-renders ([@ze-flo](https://github.com/ze-flo))
+
 ## v10.0.0-next.2 (2026-03-20)
 
 #### :seedling: Internal


### PR DESCRIPTION
## Summary

Forward-ports the substantive v9.15.1–v9.15.8 fixes from the `v9` branch into `.packages/` — the frozen v9.15.0 snapshot that serves as the migration source for v10 single-package development — and prepends the corresponding entries to `CHANGELOG.md`.

Cherry-picked fixes:
- [#2115](https://github.com/zendeskgarden/react-components/pull/2115) fix(dropdowns): avoid unwanted page scroll when Combobox mounts or re-renders
- [#2123](https://github.com/zendeskgarden/react-components/pull/2123) fix(accordions): prevent focus ring clipping in stepper content
- [#2124](https://github.com/zendeskgarden/react-components/pull/2124) fix(dropdowns): guard Listbox and MenuList state setters against post-unmount updates
- [#2126](https://github.com/zendeskgarden/react-components/pull/2126) fix(dropdowns): restore isMountedRef on remount to fix StrictMode regression
- [#2127](https://github.com/zendeskgarden/react-components/pull/2127) fix(modals): upgrade `container-modal` to v2 to fix blur-close behavior
- [#2130](https://github.com/zendeskgarden/react-components/pull/2130) fix(modals): keep tooltip dialog within viewport bounds
- [#2137](https://github.com/zendeskgarden/react-components/pull/2137) fix(accordions): prevent step content overflow when collapsed
- [#2140](https://github.com/zendeskgarden/react-components/pull/2140) fix(dropdowns): stop auto-activating first option while editing autocomplete Combobox
- [#2143](https://github.com/zendeskgarden/react-components/pull/2143) fix: keep components behavior stable for users on styled-components >= 6.3.12

Intentionally excluded:
- `chore(release): publish` version bumps (v9-specific; main uses pnpm + v10.0.0-next versioning)
- [#2116](https://github.com/zendeskgarden/react-components/pull/2116) chore(ci): v9-branch CI configuration
- [#2125](https://github.com/zendeskgarden/react-components/pull/2125) came through empty — main's `lerna.json` already reflects it

Notes:
- No `src/` changes: the v10 accordion has no stepper yet (so [#2123](https://github.com/zendeskgarden/react-components/pull/2123)/[#2137](https://github.com/zendeskgarden/react-components/pull/2137) can't apply), and `src/` has zero `.attrs` usage (so [#2143](https://github.com/zendeskgarden/react-components/pull/2143) has nothing to fix there). Fixes will ride into `src/` as each component migrates.
- Conflict resolutions: kept main's `package.json` field ordering (applied only the `container-combobox` ^2.0.9 bump), accepted `package-lock.json` deletions, and merged import blocks in 4 spec files.

## Test plan
- [ ] CI passes (`.packages/` is not covered by the v10 build/test/lint configs; changes are snapshot-only)
- [ ] Spot-check cherry-picked diffs against their v9 sources
- [ ] Verify CHANGELOG.md renders correctly above the v10.0.0-next entries