### PR TITLE
fix(dropdowns): prevent combobox flicker at high zoom

### DIFF
--- a/packages/dropdowns/src/elements/combobox/Combobox.spec.tsx
+++ b/packages/dropdowns/src/elements/combobox/Combobox.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { HTMLAttributes, InputHTMLAttributes, forwardRef } from 'react';
-import { render, renderRtl } from 'garden-test-utils';
+import { fireEvent, render, renderRtl, waitFor } from 'garden-test-utils';
 import userEvent from '@testing-library/user-event';
 import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 import { IComboboxProps, ISelectedOption } from '../../types';
@@ -638,7 +638,51 @@ describe('Combobox', () => {
 
       await user.keyboard('{Tab}');
 
-      expect(input).toHaveAttribute('hidden');
+      // Input hiding is deferred to the next task so transient blurs are ignored
+      await waitFor(() => expect(input).toHaveAttribute('hidden'));
+    });
+
+    it('does not hide input on transient blur when focus returns to the trigger', async () => {
+      const { getByTestId } = render(<TestCombobox />);
+      const combobox = getByTestId('combobox');
+      const input = getByTestId('input');
+
+      await user.click(combobox.firstChild as HTMLElement);
+
+      expect(input).not.toHaveAttribute('hidden');
+
+      // Simulate a transient blur (null `relatedTarget`) as fired when Floating
+      // UI repositions the listbox at high browser zoom, with focus returning
+      // within the same task
+      fireEvent.focusOut(input, { relatedTarget: null });
+      fireEvent.focusIn(input);
+
+      // Wait past the deferred blur response
+      await new Promise(resolve => {
+        setTimeout(resolve, 10);
+      });
+
+      expect(input).not.toHaveAttribute('hidden');
+    });
+
+    it('does not hide input on spurious blur when focus never left the combobox', async () => {
+      const { getByTestId } = render(<TestCombobox />);
+      const combobox = getByTestId('combobox');
+      const input = getByTestId('input');
+
+      await user.click(combobox.firstChild as HTMLElement);
+
+      expect(input).not.toHaveAttribute('hidden');
+
+      // `fireEvent.focusOut` dispatches without moving `document.activeElement`,
+      // simulating a spurious blur where focus never actually left the input
+      fireEvent.focusOut(input, { relatedTarget: null });
+
+      await new Promise(resolve => {
+        setTimeout(resolve, 10);
+      });
+
+      expect(input).not.toHaveAttribute('hidden');
     });
   });
 

--- a/packages/dropdowns/src/elements/combobox/Combobox.tsx
+++ b/packages/dropdowns/src/elements/combobox/Combobox.tsx
@@ -109,6 +109,7 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
     const triggerRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
     const listboxRef = useRef<HTMLUListElement>(null);
+    const blurTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
     /* istanbul ignore next */
     const theme = useContext(ThemeContext) || DEFAULT_THEME;
     const environment = useWindow(theme);
@@ -179,6 +180,9 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
     const triggerProps = getTriggerProps({
       onFocus: () => {
         if (!isDisabled) {
+          // Focus (re-)entered the trigger; cancel any pending blur response
+          clearTimeout(blurTimeoutRef.current);
+
           if (isEditable) {
             setIsInputHidden(false);
           }
@@ -190,13 +194,32 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
       },
       onBlur: event => {
         if (event.relatedTarget === null || !triggerRef.current?.contains(event.relatedTarget)) {
-          if (isEditable) {
-            setIsInputHidden(true);
-          }
+          /**
+           * Defer the blur response to the next task. `relatedTarget` is `null`
+           * for transient blurs — e.g. when Floating UI repositions the listbox
+           * at high browser zoom — so re-check where focus actually landed before
+           * hiding the input. Hiding an input that still owns focus fires a
+           * follow-up blur that downstream state (`useCombobox`) treats as a
+           * listbox close.
+           */
+          clearTimeout(blurTimeoutRef.current);
 
-          if (isMultiselectable) {
-            setIsTagGroupExpanded(false);
-          }
+          blurTimeoutRef.current = setTimeout(() => {
+            const activeElement = triggerRef.current?.ownerDocument.activeElement ?? null;
+            const isFocusContained =
+              !!triggerRef.current?.contains(activeElement) ||
+              !!listboxRef.current?.contains(activeElement);
+
+            if (!isFocusContained) {
+              if (isEditable) {
+                setIsInputHidden(true);
+              }
+
+              if (isMultiselectable) {
+                setIsTagGroupExpanded(false);
+              }
+            }
+          }, 0);
         }
       }
     }) as HTMLAttributes<HTMLDivElement>;
@@ -212,6 +235,11 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
     const listboxProps = getListboxProps({
       'aria-label': _listboxAriaLabel!
     }) as HTMLAttributes<HTMLUListElement>;
+
+    useEffect(() => {
+      // Cancel a pending deferred blur response on unmount
+      return () => clearTimeout(blurTimeoutRef.current);
+    }, []);
 
     useEffect(() => {
       // context callback

--- a/packages/dropdowns/src/elements/combobox/Listbox.spec.tsx
+++ b/packages/dropdowns/src/elements/combobox/Listbox.spec.tsx
@@ -7,13 +7,21 @@
 
 import React, { useRef } from 'react';
 import { act, render } from 'garden-test-utils';
+import { useFloating } from '@floating-ui/react-dom';
 import { Listbox } from './Listbox';
+
+jest.mock<typeof import('@floating-ui/react-dom')>('@floating-ui/react-dom', () => ({
+  ...jest.requireActual('@floating-ui/react-dom'),
+  useFloating: jest.fn()
+}));
 
 interface ITestListboxProps {
   isExpanded?: boolean;
+  maxHeight?: string;
+  minHeight?: string;
 }
 
-const TestListbox = ({ isExpanded }: ITestListboxProps) => {
+const TestListbox = ({ isExpanded, maxHeight, minHeight }: ITestListboxProps) => {
   const triggerRef = useRef<HTMLButtonElement>(null);
 
   return (
@@ -21,7 +29,12 @@ const TestListbox = ({ isExpanded }: ITestListboxProps) => {
       <button ref={triggerRef} type="button">
         trigger
       </button>
-      <Listbox isExpanded={isExpanded} triggerRef={triggerRef}>
+      <Listbox
+        isExpanded={isExpanded}
+        maxHeight={maxHeight}
+        minHeight={minHeight}
+        triggerRef={triggerRef}
+      >
         <option data-test-id="option" aria-selected={false}>
           option
         </option>
@@ -31,6 +44,22 @@ const TestListbox = ({ isExpanded }: ITestListboxProps) => {
 };
 
 describe('Listbox', () => {
+  const mockUseFloating = jest.mocked(useFloating);
+  let floatingOptions: Record<string, any>;
+
+  beforeEach(() => {
+    mockUseFloating.mockImplementation((options: any) => {
+      floatingOptions = options;
+
+      return {
+        refs: { reference: { current: null }, floating: { current: null } },
+        placement: 'bottom-start',
+        update: jest.fn(),
+        floatingStyles: { transform: undefined }
+      } as unknown as ReturnType<typeof useFloating>;
+    });
+  });
+
   describe('isMountedRef', () => {
     it('renders children when expanded', () => {
       const { queryByTestId, rerender } = render(<TestListbox isExpanded={false} />);
@@ -127,6 +156,63 @@ describe('Listbox', () => {
       } finally {
         error.mockRestore();
       }
+    });
+  });
+
+  describe('size middleware', () => {
+    const getSizeApply = () => {
+      const middleware = floatingOptions.middleware as { name: string; options?: any }[];
+      const entry = middleware.find(middlewareEntry => middlewareEntry.name === 'size');
+      // Floating UI v2 stores middleware options as a `[options, detectOverflowOptions]` tuple
+      const options = Array.isArray(entry?.options) ? entry.options[0] : entry?.options;
+
+      return options?.apply;
+    };
+
+    it('rounds subpixel measurements and skips no-op updates', () => {
+      const { container } = render(<TestListbox isExpanded />);
+      const apply = getSizeApply();
+      const listbox = container.querySelector('ul') as HTMLElement;
+      const floating = listbox.parentElement as HTMLElement;
+
+      act(() => {
+        apply({ rects: { reference: { width: 100.44 } }, availableHeight: 200.75 });
+      });
+
+      expect(floating.style.width).toBe('100px');
+      expect(listbox.style.maxHeight).toBe('200px');
+
+      // Subpixel oscillation at high browser zoom must not yield new state
+      act(() => {
+        apply({ rects: { reference: { width: 100.37 } }, availableHeight: 200.69 });
+      });
+
+      expect(floating.style.width).toBe('100px');
+      expect(listbox.style.maxHeight).toBe('200px');
+    });
+
+    it('caps the listbox to the `maxHeight` prop', () => {
+      const { container } = render(<TestListbox isExpanded maxHeight="400px" />);
+      const apply = getSizeApply();
+      const listbox = container.querySelector('ul') as HTMLElement;
+
+      act(() => {
+        apply({ rects: { reference: { width: 100 } }, availableHeight: 500 });
+      });
+
+      expect(listbox.style.maxHeight).toBe('min(400px, 500px)');
+    });
+
+    it('skips height constraint when `minHeight` is `fit-content`', () => {
+      const { container } = render(<TestListbox isExpanded minHeight="fit-content" />);
+      const apply = getSizeApply();
+      const listbox = container.querySelector('ul') as HTMLElement;
+
+      act(() => {
+        apply({ rects: { reference: { width: 100 } }, availableHeight: 200 });
+      });
+
+      expect(listbox.style.maxHeight).toBe('');
     });
   });
 });

--- a/packages/dropdowns/src/elements/combobox/Listbox.tsx
+++ b/packages/dropdowns/src/elements/combobox/Listbox.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, {
+  CSSProperties,
   MouseEventHandler,
   forwardRef,
   useContext,
@@ -41,7 +42,7 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
     const floatingRef = useRef<HTMLDivElement>(null);
     const isMountedRef = useRef(true);
     const [isVisible, setIsVisible] = useState(false);
-    const [height, setHeight] = useState<number>();
+    const [availableHeight, setAvailableHeight] = useState<number>();
     const [width, setWidth] = useState<number>();
     /* istanbul ignore next */
     const theme = useContext(ThemeContext) || DEFAULT_THEME;
@@ -57,16 +58,25 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
         offset(theme.space.base),
         flip(),
         size({
-          apply: ({ rects, availableHeight }) => {
+          apply: ({ rects, availableHeight: nextAvailableHeight }) => {
             /* istanbul ignore if */
             if (rects.reference.width > 0 && isMountedRef.current) {
-              setWidth(rects.reference.width);
+              /**
+               * Round to whole pixels and skip no-op updates. At high browser
+               * zoom, subpixel measurements oscillate between Floating UI
+               * updates; writing them straight to state causes a render loop
+               * that presents as listbox flicker.
+               */
+              const nextWidth = Math.round(rects.reference.width);
 
-              if (
-                !(minHeight === null || minHeight === 'fit-content') &&
-                rects.floating.height > availableHeight
-              ) {
-                setHeight(availableHeight);
+              setWidth(previous => (previous === nextWidth ? previous : nextWidth));
+
+              if (!(minHeight === null || minHeight === 'fit-content')) {
+                const nextMaxHeight = Math.max(0, Math.floor(nextAvailableHeight));
+
+                setAvailableHeight(previous =>
+                  previous === nextMaxHeight ? previous : nextMaxHeight
+                );
               }
             }
           }
@@ -107,7 +117,7 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
         timeout = setTimeout(() => {
           if (isMountedRef.current) {
             setIsVisible(false);
-            setHeight(undefined);
+            setAvailableHeight(undefined);
           }
         }, 200 /* match menu opacity transition */);
       }
@@ -115,21 +125,17 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
       return () => clearTimeout(timeout);
     }, [isExpanded]);
 
-    useEffect(
-      () => {
-        /* istanbul ignore if */
-        if (height) {
-          // Reset height on options change.
-          if (isMountedRef.current) setHeight(undefined);
-          update();
-        }
-      },
-      /* eslint-disable-line react-hooks/exhaustive-deps */ [
-        /* height, // prevent height update loop */
-        children,
-        update
-      ]
-    );
+    const listboxStyle: CSSProperties = {};
+
+    if (availableHeight !== undefined) {
+      /**
+       * Constrain with `max-height` rather than a fixed `height` so the listbox
+       * shrinks naturally when options change, without a state reset cycle.
+       */
+      listboxStyle.maxHeight = maxHeight
+        ? `min(${maxHeight}, ${availableHeight}px)`
+        : availableHeight;
+    }
 
     const Node = (
       <StyledFloatingListbox
@@ -149,7 +155,7 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
             !isExpanded
           }
           onMouseDown={composeEventHandlers(onMouseDown, handleMouseDown)}
-          style={{ height }}
+          style={listboxStyle}
           {...props}
           ref={ref}
         >


### PR DESCRIPTION
## Description

Prevent combobox listboxes from flickering or unexpectedly hiding the input when browser zoom produces unstable layout measurements.

## Details

- Round floating element measurements and avoid state updates when values are unchanged
- Use max height constraints so option changes do not repeatedly reset listbox size
- Defer blur handling and confirm that focus has actually left the combobox before hiding its input
- Add coverage for transient blur events and listbox sizing behavior