### PR TITLE
refactor(forms): size unified InputGroup icon buttons with CSS and rename prop to isUnified

### DIFF
--- a/packages/buttons/src/elements/IconButton.tsx
+++ b/packages/buttons/src/elements/IconButton.tsx
@@ -7,7 +7,7 @@
 
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import { IIconButtonProps, ICON_BUTTON_SIZE } from '../types';
+import { IIconButtonProps, SIZE } from '../types';
 import { StyledIconButton, StyledIcon } from '../styled';
 import { useSplitButtonContext } from '../utils/useSplitButtonContext';
 
@@ -62,5 +62,5 @@ IconButton.propTypes = {
   isPill: PropTypes.bool,
   isPrimary: PropTypes.bool,
   isRotated: PropTypes.bool,
-  size: PropTypes.oneOf(ICON_BUTTON_SIZE)
+  size: PropTypes.oneOf(SIZE)
 };

--- a/packages/buttons/src/index.ts
+++ b/packages/buttons/src/index.ts
@@ -13,9 +13,6 @@ export { SplitButton } from './elements/SplitButton';
 export { ToggleButton } from './elements/ToggleButton';
 export { ToggleIconButton } from './elements/ToggleIconButton';
 
-export { StyledButton } from './styled/StyledButton';
-export { StyledIconButton } from './styled/StyledIconButton';
-
 export type {
   IButtonProps,
   IButtonIconProps as IButtonEndIconProps,

--- a/packages/buttons/src/styled/StyledButton.spec.tsx
+++ b/packages/buttons/src/styled/StyledButton.spec.tsx
@@ -97,12 +97,6 @@ describe('StyledButton', () => {
   });
 
   describe('Sizes', () => {
-    it('renders smallest styling if provided', () => {
-      const { container } = render(<StyledButton $size="smallest" />);
-
-      expect(container.firstChild).toHaveStyleRule('line-height', '22px');
-    });
-
     it('renders small styling if provided', () => {
       const { container } = render(<StyledButton $size="small" />);
 

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -15,7 +15,7 @@ import {
   getFocusBoxShadow,
   componentStyles
 } from '@zendeskgarden/react-theming';
-import { ICON_BUTTON_SIZE } from '../types';
+import { IButtonProps } from '../types';
 import { StyledSplitButton } from './StyledSplitButton';
 import { StyledIcon } from './StyledIcon';
 
@@ -24,8 +24,7 @@ export const COMPONENT_ID = 'buttons.button';
 export interface IStyledButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   $isUnderlined?: boolean;
   $isDanger?: boolean;
-  /* widened to include IconButton's "smallest" option, since IconButton shares this styled component */
-  $size?: (typeof ICON_BUTTON_SIZE)[number];
+  $size?: IButtonProps['size'];
   $isStretched?: boolean;
   $isNeutral?: boolean;
   $isPrimary?: boolean;
@@ -44,9 +43,7 @@ const getBorderRadius = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) =
 };
 
 export const getHeight = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
-  if (props.$size === 'smallest') {
-    return `${props.theme.space.base * 6}px`;
-  } else if (props.$size === 'small') {
+  if (props.$size === 'small') {
     return `${props.theme.space.base * 8}px`;
   } else if (props.$size === 'large') {
     return `${props.theme.space.base * 12}px`;

--- a/packages/buttons/src/styled/StyledIconButton.spec.tsx
+++ b/packages/buttons/src/styled/StyledIconButton.spec.tsx
@@ -55,17 +55,6 @@ describe('StyledIconButton', () => {
   });
 
   describe('Sizes', () => {
-    it('renders smallest styling if provided, without shrinking the icon glyph', () => {
-      const { container } = render(<StyledIconButton $size="smallest" />);
-
-      expect(container.firstChild).toHaveStyleRule('width', '24px');
-      expect(container.firstChild).toHaveStyleRule('width', '16px', {
-        modifier: css`
-          ${StyledIcon}
-        ` as unknown as string
-      });
-    });
-
     it('renders small styling if provided', () => {
       const { container } = render(<StyledIconButton $size="small" />);
 

--- a/packages/buttons/src/types/index.ts
+++ b/packages/buttons/src/types/index.ts
@@ -9,9 +9,6 @@ import { AnchorHTMLAttributes, ButtonHTMLAttributes, SVGAttributes } from 'react
 
 export const SIZE = ['small', 'medium', 'large'] as const;
 
-/** "smallest" is only meaningful for an icon-only button, whose icon glyph never shrinks below `iconSizes.md` */
-export const ICON_BUTTON_SIZE = ['smallest', ...SIZE] as const;
-
 export interface IButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** Applies danger styling */
   isDanger?: boolean;
@@ -41,11 +38,9 @@ export interface IToggleButtonProps extends IButtonProps {
   isPressed?: boolean | 'mixed';
 }
 
-export interface IIconButtonProps extends Omit<IButtonProps, 'isStretched' | 'isLink' | 'size'> {
+export interface IIconButtonProps extends Omit<IButtonProps, 'isStretched' | 'isLink'> {
   /** Rotates icon 180 degrees */
   isRotated?: boolean;
-  /** Specifies the button size */
-  size?: (typeof ICON_BUTTON_SIZE)[number];
 }
 
 export interface IToggleIconButtonProps

--- a/packages/forms/demo/inputGroup.stories.tsx
+++ b/packages/forms/demo/inputGroup.stories.tsx
@@ -7,8 +7,15 @@
 
 import React from 'react';
 import type { StoryObj } from '@storybook/react-vite';
+import { useArgs } from 'storybook/preview-api';
 import { InputGroup, Input, VALIDATION } from '@zendeskgarden/react-forms';
 import { InputGroupStory } from './stories/InputGroupStory';
+import {
+  InputGroupUnifiedStory,
+  UNIFIED_ICON_ITEMS,
+  UNIFIED_TEXT_ITEMS
+} from './stories/InputGroupUnifiedStory';
+import { InputGroupClearableStory } from './stories/InputGroupClearableStory';
 import { INPUT_GROUP_ITEMS as ITEMS } from './stories/data';
 import { commonArgs, commonArgTypes, fieldSubcomponents } from './stories/common';
 
@@ -69,4 +76,146 @@ export const Example: StoryObj<typeof InputGroupStory> = {
       url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=103%3A20265'
     }
   }
+};
+
+/* ------------------------------------------------------------------------ */
+/* Unified variants — self-contained; nothing above this section is         */
+/* modified. To remove: delete this section, the InputGroupUnifiedStory and */
+/* InputGroupClearableStory imports above, and their demo/stories files.    */
+/* ------------------------------------------------------------------------ */
+
+const unifiedArgTypes = {
+  items: { name: 'children' },
+  ...commonArgTypes,
+  disabled: {
+    control: 'boolean' as const,
+    table: { category: 'Story' }
+  },
+  isNeutral: { table: { category: 'Button' } },
+  isPrimary: {
+    control: 'boolean' as const,
+    table: { category: 'Button' }
+  },
+  isDanger: {
+    control: 'boolean' as const,
+    table: { category: 'Button' }
+  },
+  isToggle: {
+    control: 'boolean' as const,
+    name: 'ToggleButton',
+    table: { category: 'Button' }
+  },
+  readOnly: {
+    control: 'boolean' as const,
+    table: { category: 'Input' }
+  },
+  inputValidation: {
+    control: 'radio' as const,
+    name: 'validation',
+    options: VALIDATION,
+    table: { category: 'Input' }
+  }
+};
+
+type UnifiedStory = StoryObj<typeof InputGroupUnifiedStory>;
+
+export const Unified: UnifiedStory = {
+  render: args => <InputGroupUnifiedStory {...args} />,
+  args: {
+    ...commonArgs,
+    items: UNIFIED_TEXT_ITEMS,
+    isNeutral: true,
+    isUnified: true
+  },
+  argTypes: unifiedArgTypes
+};
+
+export const UnifiedWithIconButtons: UnifiedStory = {
+  render: args => <InputGroupUnifiedStory {...args} />,
+  name: 'Unified with icon buttons',
+  args: {
+    ...commonArgs,
+    items: UNIFIED_ICON_ITEMS,
+    isNeutral: true,
+    isUnified: true
+  },
+  argTypes: unifiedArgTypes
+};
+
+export const UnifiedCompact: UnifiedStory = {
+  render: args => <InputGroupUnifiedStory {...args} />,
+  name: 'Unified compact',
+  args: {
+    ...commonArgs,
+    items: UNIFIED_ICON_ITEMS,
+    isNeutral: true,
+    isUnified: true,
+    isCompact: true
+  },
+  argTypes: unifiedArgTypes
+};
+
+export const UnifiedStates: UnifiedStory = {
+  render: args => <InputGroupUnifiedStory {...args} />,
+  name: 'Unified states',
+  args: {
+    ...commonArgs,
+    items: UNIFIED_ICON_ITEMS,
+    isNeutral: true,
+    isUnified: true,
+    validation: 'error',
+    inputValidation: 'error'
+  },
+  argTypes: unifiedArgTypes
+};
+
+/* untyped so isUnified/focusInset (InputGroup props leaking in via the shared meta's `component`, but unused by this layout-only outer group) can be disabled without an excess-property error */
+const clearableArgTypes = {
+  ...commonArgTypes,
+  isUnified: { table: { disable: true } },
+  focusInset: { table: { disable: true } },
+  value: {
+    control: 'text' as const,
+    table: { category: 'ClearableInput' }
+  },
+  disabled: {
+    control: 'boolean' as const,
+    table: { category: 'ClearableInput' }
+  },
+  readOnly: {
+    control: 'boolean' as const,
+    table: { category: 'ClearableInput' }
+  },
+  isCompact: {
+    control: 'boolean' as const,
+    table: { category: 'ClearableInput' }
+  },
+  placeholder: {
+    control: 'text' as const,
+    table: { category: 'ClearableInput' }
+  },
+  clearButtonLabel: {
+    control: 'text' as const,
+    table: { category: 'ClearableInput' }
+  }
+};
+
+export const ClearableWithCalendar: StoryObj<typeof InputGroupClearableStory> = {
+  render: args => {
+    const updateArgs = useArgs()[1];
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) =>
+      updateArgs({ value: event.target.value });
+
+    return <InputGroupClearableStory {...args} onChange={handleChange} />;
+  },
+  name: 'Clearable with calendar',
+  args: {
+    ...commonArgs,
+    label: 'Date',
+    value: '3/5/2024',
+    placeholder: 'Select a date',
+    clearButtonLabel: 'Clear date'
+  },
+  argTypes: clearableArgTypes
 };

--- a/packages/forms/demo/stories/InputGroupClearableStory.tsx
+++ b/packages/forms/demo/stories/InputGroupClearableStory.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { StoryFn } from '@storybook/react-vite';
+import {
+  ClearableInput,
+  IClearableInputProps,
+  IInputGroupProps,
+  InputGroup
+} from '@zendeskgarden/react-forms';
+import { IconButton } from '@zendeskgarden/react-buttons';
+import CalendarIcon from '@zendeskgarden/svg-icons/src/16/calendar-stroke.svg';
+import { FieldStory, IFieldArgs } from './FieldStory';
+
+interface IArgs
+  extends
+    Pick<IInputGroupProps, 'isCompact'>,
+    IFieldArgs,
+    Pick<
+      IClearableInputProps,
+      'disabled' | 'readOnly' | 'clearButtonLabel' | 'placeholder' | 'value' | 'onChange'
+    > {}
+
+export const InputGroupClearableStory: StoryFn<IArgs> = ({
+  label,
+  isLabelRegular,
+  isLabelHidden,
+  hasHint,
+  hint,
+  hasMessage,
+  message,
+  validation,
+  validationLabel,
+  isCompact,
+  disabled,
+  readOnly,
+  clearButtonLabel,
+  placeholder,
+  value = '',
+  onChange
+}) => (
+  <FieldStory
+    label={label}
+    isLabelRegular={isLabelRegular}
+    isLabelHidden={isLabelHidden}
+    hasHint={hasHint}
+    hint={hint}
+    hasMessage={hasMessage}
+    message={message}
+    validation={validation}
+    validationLabel={validationLabel}
+  >
+    {/* the outer group supplies layout only; ClearableInput renders the unified inner group itself */}
+    <InputGroup isCompact={isCompact}>
+      <ClearableInput
+        value={value}
+        isCompact={isCompact}
+        disabled={disabled}
+        readOnly={readOnly}
+        placeholder={placeholder}
+        validation={validation}
+        onChange={onChange}
+        clearButtonLabel={clearButtonLabel}
+        wrapperProps={{ focusInset: true }}
+      />
+      <IconButton
+        aria-label={`Choose date: ${label}`}
+        isBasic={false}
+        isPill={false}
+        isNeutral
+        focusInset
+        disabled={disabled}
+        size={isCompact ? 'small' : undefined}
+      >
+        <CalendarIcon aria-hidden="true" />
+      </IconButton>
+    </InputGroup>
+  </FieldStory>
+);

--- a/packages/forms/demo/stories/InputGroupStory.tsx
+++ b/packages/forms/demo/stories/InputGroupStory.tsx
@@ -18,14 +18,14 @@ interface IGroupButtonProps extends PropsWithChildren {
   isPrimary?: boolean;
   isDanger?: boolean;
   isToggle?: boolean;
-  isSeamless?: boolean;
+  isUnified?: boolean;
   size?: IButtonProps['size'];
 }
 
-const GroupButton = ({ isToggle, isSeamless, ...props }: IGroupButtonProps) => {
+const GroupButton = ({ isToggle, isUnified, ...props }: IGroupButtonProps) => {
   const [isPressed, setIsPressed] = useState(false);
-  /* the non-seamless variant's overlapping borders need an inset ring to avoid clipping */
-  const focusInset = !isSeamless;
+  /* the non-unified variant's overlapping borders need an inset ring to avoid clipping */
+  const focusInset = !isUnified;
 
   return isToggle ? (
     <ToggleButton
@@ -90,7 +90,7 @@ export const InputGroupStory: StoryFn<IArgs> = ({
             isPrimary={isPrimary}
             isDanger={isDanger}
             isToggle={isToggle}
-            isSeamless={args.isSeamless}
+            isUnified={args.isUnified}
             size={args.isCompact ? 'small' : undefined}
           >
             {item.text}

--- a/packages/forms/demo/stories/InputGroupUnifiedStory.tsx
+++ b/packages/forms/demo/stories/InputGroupUnifiedStory.tsx
@@ -1,0 +1,180 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { PropsWithChildren, useState } from 'react';
+import { StoryFn } from '@storybook/react-vite';
+import { IInputGroupProps, IInputProps, Input, InputGroup } from '@zendeskgarden/react-forms';
+import {
+  Button,
+  IButtonProps,
+  IconButton,
+  ToggleButton,
+  ToggleIconButton
+} from '@zendeskgarden/react-buttons';
+import CalendarIcon from '@zendeskgarden/svg-icons/src/16/calendar-stroke.svg';
+import ClearIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
+import SearchIcon from '@zendeskgarden/svg-icons/src/16/search-stroke.svg';
+import { FieldStory, IFieldArgs } from './FieldStory';
+
+const ICONS = {
+  calendar: CalendarIcon,
+  clear: ClearIcon,
+  search: SearchIcon
+};
+
+interface IUnifiedGroupItem {
+  text: string;
+  isButton: boolean;
+  icon?: keyof typeof ICONS;
+}
+
+export const UNIFIED_TEXT_ITEMS: IUnifiedGroupItem[] = [
+  {
+    text: 'Content',
+    isButton: false
+  },
+  {
+    text: 'Copy',
+    isButton: true
+  }
+];
+
+export const UNIFIED_ICON_ITEMS: IUnifiedGroupItem[] = [
+  {
+    text: 'Search',
+    isButton: true,
+    icon: 'search'
+  },
+  {
+    text: 'Content',
+    isButton: false
+  },
+  {
+    text: 'Clear',
+    isButton: true,
+    icon: 'clear'
+  }
+];
+
+interface IGroupButtonProps extends PropsWithChildren {
+  disabled?: boolean;
+  isNeutral: boolean;
+  isPrimary?: boolean;
+  isDanger?: boolean;
+  isToggle?: boolean;
+  isUnified?: boolean;
+  icon?: keyof typeof ICONS;
+  size?: IButtonProps['size'];
+  'aria-label'?: string;
+}
+
+const GroupButton = ({ isToggle, isUnified, icon, children, ...props }: IGroupButtonProps) => {
+  const [isPressed, setIsPressed] = useState(false);
+  /* the non-unified variant's overlapping borders need an inset ring to avoid clipping */
+  const focusInset = !isUnified;
+  const Icon = icon ? ICONS[icon] : undefined;
+  const toggleProps = {
+    isPressed,
+    onClick: () => setIsPressed(!isPressed)
+  };
+
+  /* icon buttons stay basic; the unified container draws the border, and its CSS sizes the button */
+  if (Icon) {
+    return isToggle ? (
+      <ToggleIconButton focusInset={focusInset} {...props} {...toggleProps}>
+        <Icon aria-hidden="true" />
+      </ToggleIconButton>
+    ) : (
+      <IconButton focusInset={focusInset} {...props}>
+        <Icon aria-hidden="true" />
+      </IconButton>
+    );
+  }
+
+  return isToggle ? (
+    <ToggleButton focusInset={focusInset} {...props} {...toggleProps}>
+      {children}
+    </ToggleButton>
+  ) : (
+    <Button focusInset={focusInset} {...props}>
+      {children}
+    </Button>
+  );
+};
+
+interface IArgs extends IInputGroupProps, IFieldArgs {
+  items: IUnifiedGroupItem[];
+  disabled?: boolean;
+  isNeutral: boolean;
+  isPrimary?: boolean;
+  isDanger?: boolean;
+  isToggle?: boolean;
+  readOnly?: boolean;
+  inputValidation?: IInputProps['validation'];
+}
+
+export const InputGroupUnifiedStory: StoryFn<IArgs> = ({
+  label,
+  isLabelRegular,
+  isLabelHidden,
+  hasHint,
+  hint,
+  hasMessage,
+  message,
+  validationLabel,
+  items,
+  disabled,
+  isNeutral,
+  isPrimary,
+  isDanger,
+  isToggle,
+  readOnly,
+  inputValidation,
+  ...args
+}) => (
+  <FieldStory
+    label={label}
+    isLabelRegular={isLabelRegular}
+    isLabelHidden={isLabelHidden}
+    hasHint={hasHint}
+    hint={hint}
+    hasMessage={hasMessage}
+    message={message}
+    validation={args.validation}
+    validationLabel={validationLabel}
+  >
+    <InputGroup {...args}>
+      {items.map((item, index) =>
+        item.isButton ? (
+          <GroupButton
+            key={index}
+            disabled={disabled}
+            isNeutral={isNeutral}
+            isPrimary={isPrimary}
+            isDanger={isDanger}
+            isToggle={isToggle}
+            isUnified={args.isUnified}
+            icon={item.icon}
+            aria-label={item.icon ? item.text : undefined}
+            size={args.isCompact ? 'small' : undefined}
+          >
+            {item.text}
+          </GroupButton>
+        ) : (
+          <Input
+            key={index}
+            placeholder={item.text}
+            readOnly={readOnly}
+            disabled={disabled}
+            isCompact={args.isCompact}
+            validation={inputValidation}
+          />
+        )
+      )}
+    </InputGroup>
+  </FieldStory>
+);

--- a/packages/forms/demo/~patterns/patterns.mdx
+++ b/packages/forms/demo/~patterns/patterns.mdx
@@ -18,7 +18,7 @@ The `FileUpload` component is shown here working together with the
 ## Date field
 
 Two `InputGroup`s nested inside a bare outer `InputGroup`: an inner
-`isSeamless` group for the text input and its clear button (bordered and
+`isUnified` group for the text input and its clear button (bordered and
 focused as one field, `focusInset` since it sits close to a sibling), plus a
 plain bordered `IconButton` that would open the calendar. The outer group
 supplies only layout (spacing between the two segments) and groups them under

--- a/packages/forms/src/elements/ClearableInput.spec.tsx
+++ b/packages/forms/src/elements/ClearableInput.spec.tsx
@@ -21,7 +21,7 @@ const ControlledClearableInput = ({
 };
 
 describe('ClearableInput', () => {
-  it('renders an Input inside a seamless InputGroup', () => {
+  it('renders an Input inside a unified InputGroup', () => {
     const { getByRole } = render(<ClearableInput onChange={jest.fn()} />);
 
     expect(getByRole('group')).toBeInTheDocument();

--- a/packages/forms/src/elements/ClearableInput.tsx
+++ b/packages/forms/src/elements/ClearableInput.tsx
@@ -69,7 +69,7 @@ export const ClearableInput = React.forwardRef<HTMLInputElement, IClearableInput
 
     return (
       <InputGroup
-        isSeamless
+        isUnified
         focusInset={false}
         isCompact={isCompact}
         {...wrapperProps}

--- a/packages/forms/src/elements/Input.spec.tsx
+++ b/packages/forms/src/elements/Input.spec.tsx
@@ -15,9 +15,9 @@ import { InputGroup } from './input-group/InputGroup';
 describe('Input', () => {
   const user = userEvent.setup();
 
-  it('is bare by default inside a seamless InputGroup', () => {
+  it('is bare by default inside a unified InputGroup', () => {
     const { getByTestId } = render(
-      <InputGroup isSeamless>
+      <InputGroup isUnified>
         <Input data-test-id="input" />
       </InputGroup>
     );
@@ -25,9 +25,9 @@ describe('Input', () => {
     expect(getByTestId('input')).toHaveStyleRule('border', 'none');
   });
 
-  it('respects an explicit isBare override inside a seamless InputGroup', () => {
+  it('respects an explicit isBare override inside a unified InputGroup', () => {
     const { getByTestId } = render(
-      <InputGroup isSeamless>
+      <InputGroup isUnified>
         <Input data-test-id="input" isBare={false} />
       </InputGroup>
     );

--- a/packages/forms/src/elements/Input.tsx
+++ b/packages/forms/src/elements/Input.tsx
@@ -37,7 +37,7 @@ export const Input = React.forwardRef<HTMLInputElement, IInputProps>(
         ref={ref}
         onSelect={onSelectHandler}
         {...combinedProps}
-        $isBare={isBare === undefined && inputGroupContext?.isSeamless ? true : isBare}
+        $isBare={isBare === undefined && inputGroupContext?.isUnified ? true : isBare}
         $isCompact={inputGroupContext ? inputGroupContext.isCompact : isCompact}
         $focusInset={inputGroupContext && focusInset === undefined ? true : focusInset}
         $validation={validation}

--- a/packages/forms/src/elements/input-group/InputGroup.spec.tsx
+++ b/packages/forms/src/elements/input-group/InputGroup.spec.tsx
@@ -119,9 +119,9 @@ describe('InputGroup', () => {
     });
   });
 
-  it('does not force focusInset on an IconButton child when isSeamless, leaving it to the consumer', () => {
+  it('does not force focusInset on an IconButton child when isUnified, leaving it to the consumer', () => {
     const { getByRole } = render(
-      <InputGroup isSeamless>
+      <InputGroup isUnified>
         <IconButton aria-label="Icon button">
           <span />
         </IconButton>
@@ -137,7 +137,7 @@ describe('InputGroup', () => {
     });
   });
 
-  it('does not force focusInset on an IconButton child when not isSeamless', () => {
+  it('does not force focusInset on an IconButton child when not isUnified', () => {
     const { getByRole } = render(
       <InputGroup>
         <IconButton aria-label="Icon button">
@@ -155,9 +155,9 @@ describe('InputGroup', () => {
     });
   });
 
-  it('respects an explicit focusInset override on an IconButton child when isSeamless', () => {
+  it('respects an explicit focusInset override on an IconButton child when isUnified', () => {
     const { getByRole } = render(
-      <InputGroup isSeamless>
+      <InputGroup isUnified>
         <IconButton focusInset aria-label="Icon button">
           <span />
         </IconButton>
@@ -173,9 +173,9 @@ describe('InputGroup', () => {
     });
   });
 
-  it('applies an inset focus ring to a seamless container itself when focusInset is set', () => {
+  it('applies an inset focus ring to a unified container itself when focusInset is set', () => {
     const { getByTestId, getByRole } = render(
-      <InputGroup data-test-id="input-group" isSeamless focusInset>
+      <InputGroup data-test-id="input-group" isUnified focusInset>
         <Input aria-label="Input" />
       </InputGroup>
     );
@@ -189,9 +189,9 @@ describe('InputGroup', () => {
     );
   });
 
-  it('does not apply an inset focus ring to a seamless container by default', () => {
+  it('does not apply an inset focus ring to a unified container by default', () => {
     const { getByTestId, getByRole } = render(
-      <InputGroup data-test-id="input-group" isSeamless>
+      <InputGroup data-test-id="input-group" isUnified>
         <Input aria-label="Input" />
       </InputGroup>
     );
@@ -205,52 +205,16 @@ describe('InputGroup', () => {
     );
   });
 
-  it('forces size="small" on an IconButton child when isSeamless and not compact', () => {
+  it('does not override an IconButton child size prop, since unified sizing is applied via CSS', () => {
     const { getByRole } = render(
-      <InputGroup isSeamless>
-        <IconButton aria-label="Icon button">
-          <span />
-        </IconButton>
-      </InputGroup>
-    );
-
-    expect(getByRole('button', { name: 'Icon button' })).toHaveStyleRule('height', '32px');
-  });
-
-  it('forces size="smallest" on an IconButton child when isSeamless and isCompact', () => {
-    const { getByRole } = render(
-      <InputGroup isSeamless isCompact>
-        <IconButton aria-label="Icon button">
-          <span />
-        </IconButton>
-      </InputGroup>
-    );
-
-    expect(getByRole('button', { name: 'Icon button' })).toHaveStyleRule('height', '24px');
-  });
-
-  it('rejects an explicit size override on an IconButton child when isSeamless and not compact, since any other size breaks the isSeamless styles', () => {
-    const { getByRole } = render(
-      <InputGroup isSeamless>
+      <InputGroup isUnified isCompact>
         <IconButton size="large" aria-label="Icon button">
           <span />
         </IconButton>
       </InputGroup>
     );
 
-    expect(getByRole('button', { name: 'Icon button' })).toHaveStyleRule('height', '32px');
-  });
-
-  it('rejects an explicit size override on an IconButton child when isSeamless and isCompact, since any other size breaks the isSeamless styles', () => {
-    const { getByRole } = render(
-      <InputGroup isSeamless isCompact>
-        <IconButton size="large" aria-label="Icon button">
-          <span />
-        </IconButton>
-      </InputGroup>
-    );
-
-    expect(getByRole('button', { name: 'Icon button' })).toHaveStyleRule('height', '24px');
+    expect(getByRole('button', { name: 'Icon button' })).toHaveStyleRule('height', '48px');
   });
 
   describe('InputGroup child items', () => {

--- a/packages/forms/src/elements/input-group/InputGroup.tsx
+++ b/packages/forms/src/elements/input-group/InputGroup.tsx
@@ -5,9 +5,8 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children, cloneElement, isValidElement, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { IconButton } from '@zendeskgarden/react-buttons';
 import { IInputGroupProps } from '../../types';
 import useFieldContext from '../../utils/useFieldContext';
 import { InputGroupContext } from '../../utils/useInputGroupContext';
@@ -17,32 +16,13 @@ import { StyledInputGroup } from '../../styled';
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const InputGroup = React.forwardRef<HTMLDivElement, IInputGroupProps>(
-  ({ isCompact, isSeamless, focusInset, children, ...other }, ref) => {
+  ({ isCompact, isUnified, focusInset, children, ...other }, ref) => {
     const fieldContext = useFieldContext();
-    const contextValue = useMemo(() => ({ isCompact, isSeamless }), [isCompact, isSeamless]);
+    const contextValue = useMemo(() => ({ isCompact, isUnified }), [isCompact, isUnified]);
     const labelId =
       fieldContext?.hasLabel && !other['aria-label']
         ? fieldContext.getLabelProps({}).id
         : undefined;
-
-    let seamlessIconButtonSize: 'small' | 'smallest' | undefined;
-
-    if (isSeamless) {
-      seamlessIconButtonSize = isCompact ? 'smallest' : 'small';
-    }
-
-    const mappedChildren = Children.map(children, child => {
-      if (!isValidElement(child) || child.type !== IconButton) {
-        return child;
-      }
-
-      const props = child.props as { size?: string };
-
-      /* isSeamless assumes a "small"/"smallest" IconButton for its padding math, so that isn't left to the consumer */
-      return cloneElement(child, {
-        size: seamlessIconButtonSize || props.size
-      });
-    });
 
     return (
       <InputGroupContext.Provider value={contextValue}>
@@ -51,12 +31,12 @@ export const InputGroup = React.forwardRef<HTMLDivElement, IInputGroupProps>(
           aria-labelledby={labelId}
           ref={ref}
           $isCompact={isCompact}
-          $isSeamless={isSeamless}
+          $isUnified={isUnified}
           $focusInset={focusInset}
           {...other}
           role="group"
         >
-          {mappedChildren}
+          {children}
         </StyledInputGroup>
       </InputGroupContext.Provider>
     );
@@ -67,6 +47,6 @@ InputGroup.displayName = 'InputGroup';
 
 InputGroup.propTypes = {
   isCompact: PropTypes.bool,
-  isSeamless: PropTypes.bool,
+  isUnified: PropTypes.bool,
   focusInset: PropTypes.bool
 };

--- a/packages/forms/src/styled/input-group/StyledInputGroup.spec.tsx
+++ b/packages/forms/src/styled/input-group/StyledInputGroup.spec.tsx
@@ -9,33 +9,35 @@ import React from 'react';
 import { render } from 'garden-test-utils';
 import { em } from 'polished';
 import { DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
-import { StyledButton, StyledIconButton } from '@zendeskgarden/react-buttons';
 import { StyledInputGroup } from './StyledInputGroup';
 import { StyledTextInput } from '../text/StyledTextInput';
 
+const BUTTON_SELECTOR = "button[data-garden-id='buttons.button']";
+const ICON_BUTTON_SELECTOR = "button[data-garden-id='buttons.icon_button']";
+
 describe('StyledInputGroup', () => {
-  it('sets a font-size matching StyledTextInput, regardless of $isCompact or $isSeamless', () => {
+  it('sets a font-size matching StyledTextInput, regardless of $isCompact or $isUnified', () => {
     const { container: plain } = render(<StyledInputGroup />);
     const { container: compact } = render(<StyledInputGroup $isCompact />);
-    const { container: seamless } = render(<StyledInputGroup $isSeamless />);
-    const { container: compactSeamless } = render(<StyledInputGroup $isSeamless $isCompact />);
+    const { container: unified } = render(<StyledInputGroup $isUnified />);
+    const { container: compactUnified } = render(<StyledInputGroup $isUnified $isCompact />);
 
     expect(plain.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.md);
     expect(compact.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.md);
-    expect(seamless.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.md);
-    expect(compactSeamless.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.md);
+    expect(unified.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.md);
+    expect(compactUnified.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.md);
   });
 
-  describe('$isSeamless', () => {
+  describe('$isUnified', () => {
     it('renders a container border and radius', () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+      const { container } = render(<StyledInputGroup $isUnified />);
 
       expect(container.firstChild).toHaveStyleRule('border', '1px solid');
       expect(container.firstChild).toHaveStyleRule('border-radius', '4px');
     });
 
-    it('renders default border-color and background-color, matching the non-seamless field colors', () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+    it('renders default border-color and background-color, matching the non-unified field colors', () => {
+      const { container } = render(<StyledInputGroup $isUnified />);
       const borderColor = getColor({
         theme: DEFAULT_THEME,
         variable: 'border.default',
@@ -49,17 +51,32 @@ describe('StyledInputGroup', () => {
     });
 
     it('renders a 40px minimum height by default, and 32px when compact', () => {
-      const { container: regular } = render(<StyledInputGroup $isSeamless />);
-      const { container: compact } = render(<StyledInputGroup $isSeamless $isCompact />);
+      const { container: regular } = render(<StyledInputGroup $isUnified />);
+      const { container: compact } = render(<StyledInputGroup $isUnified $isCompact />);
 
       expect(regular.firstChild).toHaveStyleRule('min-height', '40px');
       expect(compact.firstChild).toHaveStyleRule('min-height', '32px');
     });
 
-    it('does not resize the IconButton via CSS, since InputGroup delegates sizing to its "small"/"smallest" size prop instead', () => {
-      const { container: regular } = render(<StyledInputGroup $isSeamless />);
-      const { container: compact } = render(<StyledInputGroup $isSeamless $isCompact />);
-      const modifier = `& ${StyledIconButton}`;
+    it('sizes icon buttons to fit the container via CSS: 32px, or 24px when compact', () => {
+      const { container: regular } = render(<StyledInputGroup $isUnified />);
+      const { container: compact } = render(<StyledInputGroup $isUnified $isCompact />);
+      const modifier = `& ${ICON_BUTTON_SELECTOR}`;
+
+      expect(regular.firstChild).toHaveStyleRule('width', '32px', { modifier });
+      expect(regular.firstChild).toHaveStyleRule('min-width', '32px', { modifier });
+      expect(regular.firstChild).toHaveStyleRule('height', '32px', { modifier });
+      expect(regular.firstChild).toHaveStyleRule('min-height', '32px', { modifier });
+      expect(compact.firstChild).toHaveStyleRule('width', '24px', { modifier });
+      expect(compact.firstChild).toHaveStyleRule('min-width', '24px', { modifier });
+      expect(compact.firstChild).toHaveStyleRule('height', '24px', { modifier });
+      expect(compact.firstChild).toHaveStyleRule('min-height', '24px', { modifier });
+    });
+
+    it('applies no [aria-pressed] exception, so a ToggleIconButton is sized like any icon button', () => {
+      const { container: regular } = render(<StyledInputGroup $isUnified />);
+      const { container: compact } = render(<StyledInputGroup $isUnified $isCompact />);
+      const modifier = `& ${ICON_BUTTON_SELECTOR}:not([aria-pressed])`;
 
       expect(regular.firstChild).not.toHaveStyleRule('width', expect.any(String), { modifier });
       expect(regular.firstChild).not.toHaveStyleRule('height', expect.any(String), { modifier });
@@ -68,9 +85,9 @@ describe('StyledInputGroup', () => {
     });
 
     it('leaves the IconButton icon glyph at its own default size (iconSizes.md, 16px), regardless of $isCompact', () => {
-      const { container: regular } = render(<StyledInputGroup $isSeamless />);
-      const { container: compact } = render(<StyledInputGroup $isSeamless $isCompact />);
-      const modifier = `& ${StyledIconButton} svg`;
+      const { container: regular } = render(<StyledInputGroup $isUnified />);
+      const { container: compact } = render(<StyledInputGroup $isUnified $isCompact />);
+      const modifier = `& ${ICON_BUTTON_SELECTOR} svg`;
 
       expect(regular.firstChild).not.toHaveStyleRule('width', expect.any(String), { modifier });
       expect(regular.firstChild).not.toHaveStyleRule('height', expect.any(String), { modifier });
@@ -78,24 +95,24 @@ describe('StyledInputGroup', () => {
       expect(compact.firstChild).not.toHaveStyleRule('height', expect.any(String), { modifier });
     });
 
-    it("sets the container's vertical padding to fit a regular IconButton's own small size, and to 3px once a compact IconButton is shrunk to fit", () => {
-      const { container: regular } = render(<StyledInputGroup $isSeamless />);
-      const { container: compact } = render(<StyledInputGroup $isSeamless $isCompact />);
+    it("sets the container's vertical padding to fit the CSS-sized IconButton, regular or compact", () => {
+      const { container: regular } = render(<StyledInputGroup $isUnified />);
+      const { container: compact } = render(<StyledInputGroup $isUnified $isCompact />);
 
       expect(regular.firstChild).toHaveStyleRule('padding-block', '3px');
       expect(compact.firstChild).toHaveStyleRule('padding-block', '3px');
     });
 
     it('does not resize the width of plain text buttons', () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+      const { container } = render(<StyledInputGroup $isUnified />);
 
       expect(container.firstChild).not.toHaveStyleRule('width', '28px', { modifier: '& button' });
     });
 
     it("shrinks a plain text button's height to match the icon button size, so it doesn't grow the container beyond its own min-height", () => {
-      const { container: regular } = render(<StyledInputGroup $isSeamless />);
-      const { container: compact } = render(<StyledInputGroup $isSeamless $isCompact />);
-      const modifier = `& ${StyledButton}:not(${StyledIconButton})`;
+      const { container: regular } = render(<StyledInputGroup $isUnified />);
+      const { container: compact } = render(<StyledInputGroup $isUnified $isCompact />);
+      const modifier = `& ${BUTTON_SELECTOR}`;
 
       expect(regular.firstChild).toHaveStyleRule('height', '28px', { modifier });
       expect(regular.firstChild).toHaveStyleRule('min-height', '28px', { modifier });
@@ -107,14 +124,14 @@ describe('StyledInputGroup', () => {
     });
 
     it('centers children and adds inter-item spacing', () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+      const { container } = render(<StyledInputGroup $isUnified />);
 
       expect(container.firstChild).toHaveStyleRule('align-items', 'center');
       expect(container.firstChild).toHaveStyleRule('gap', '8px');
     });
 
     it('stretches StyledTextInput to the container height, despite the container centering its other children', () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+      const { container } = render(<StyledInputGroup $isUnified />);
 
       expect(container.firstChild).toHaveStyleRule('align-self', 'stretch', {
         modifier: `& ${StyledTextInput}`
@@ -122,13 +139,13 @@ describe('StyledInputGroup', () => {
     });
 
     it("matches the container's inline edge padding to the inter-item gap", () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+      const { container } = render(<StyledInputGroup $isUnified />);
 
       expect(container.firstChild).toHaveStyleRule('padding-inline', '8px');
     });
 
     it('gives a child Input a theme.space.xxs padding-inline-start, regardless of its position among siblings, so its text totals 12px from whatever precedes it', () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+      const { container } = render(<StyledInputGroup $isUnified />);
 
       expect(container.firstChild).toHaveStyleRule(
         'padding-inline-start',
@@ -140,8 +157,8 @@ describe('StyledInputGroup', () => {
     });
 
     it("tucks a trailing/leading icon button's own visual inset into the container's edge padding, so the button's visible edge sits a constant 4px from the container edge regardless of $isCompact", () => {
-      const { container: regular } = render(<StyledInputGroup $isSeamless />);
-      const { container: compact } = render(<StyledInputGroup $isSeamless $isCompact />);
+      const { container: regular } = render(<StyledInputGroup $isUnified />);
+      const { container: compact } = render(<StyledInputGroup $isUnified $isCompact />);
       const paddingHorizontal = em(`${DEFAULT_THEME.space.base * 3}px`, DEFAULT_THEME.fontSizes.md);
       /* always derived from the regular (unshrunk) IconButton's own geometry, since a compact IconButton's icon doesn't shrink alongside it */
       const iconInset = (32 - parseFloat(DEFAULT_THEME.iconSizes.md)) / 2;
@@ -149,40 +166,40 @@ describe('StyledInputGroup', () => {
       const compactPadding = `calc(${paddingHorizontal} - ${iconInset}px)`;
 
       expect(regular.firstChild).toHaveStyleRule('padding-inline-end', regularPadding, {
-        modifier: `&:has(> ${StyledIconButton}:last-child)`
+        modifier: `&:has(> ${ICON_BUTTON_SELECTOR}:last-child)`
       });
       expect(regular.firstChild).toHaveStyleRule('padding-inline-start', regularPadding, {
-        modifier: `&:has(> ${StyledIconButton}:first-child)`
+        modifier: `&:has(> ${ICON_BUTTON_SELECTOR}:first-child)`
       });
       expect(compact.firstChild).toHaveStyleRule('padding-inline-end', compactPadding, {
-        modifier: `&:has(> ${StyledIconButton}:last-child)`
+        modifier: `&:has(> ${ICON_BUTTON_SELECTOR}:last-child)`
       });
       expect(compact.firstChild).toHaveStyleRule('padding-inline-start', compactPadding, {
-        modifier: `&:has(> ${StyledIconButton}:first-child)`
+        modifier: `&:has(> ${ICON_BUTTON_SELECTOR}:first-child)`
       });
     });
 
     it("does not override the container's edge padding for a trailing/leading text button, leaving the button's own padding untouched", () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+      const { container } = render(<StyledInputGroup $isUnified />);
 
       expect(container.firstChild).not.toHaveStyleRule('padding-inline-end', expect.any(String), {
-        modifier: `&:has(> ${StyledButton}:not(${StyledIconButton}):last-child)`
+        modifier: `&:has(> ${BUTTON_SELECTOR}:last-child)`
       });
       expect(container.firstChild).not.toHaveStyleRule('padding-inline-start', expect.any(String), {
-        modifier: `&:has(> ${StyledButton}:not(${StyledIconButton}):first-child)`
+        modifier: `&:has(> ${BUTTON_SELECTOR}:first-child)`
       });
     });
 
     it("does not touch a text button's own padding-inline, only resizing it to fit the container", () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+      const { container } = render(<StyledInputGroup $isUnified />);
 
       expect(container.firstChild).not.toHaveStyleRule('padding-inline', expect.any(String), {
-        modifier: `& ${StyledButton}:not(${StyledIconButton})`
+        modifier: `& ${BUTTON_SELECTOR}`
       });
     });
 
     it('highlights the container border on focus-within, unless a button owns the focus-visible ring', () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+      const { container } = render(<StyledInputGroup $isUnified />);
       const focusBorderColor = getColor({
         theme: DEFAULT_THEME,
         variable: 'border.primaryEmphasis'
@@ -194,7 +211,7 @@ describe('StyledInputGroup', () => {
     });
 
     it('highlights the container border on hover, matching StyledTextInput', () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+      const { container } = render(<StyledInputGroup $isUnified />);
       const hoverBorderColor = getColor({
         theme: DEFAULT_THEME,
         variable: 'border.primaryEmphasis'
@@ -206,7 +223,7 @@ describe('StyledInputGroup', () => {
     });
 
     it('transitions border-color smoothly, matching StyledTextInput', () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+      const { container } = render(<StyledInputGroup $isUnified />);
 
       expect(container.firstChild).toHaveStyleRule(
         'transition',
@@ -215,7 +232,7 @@ describe('StyledInputGroup', () => {
     });
 
     it('transitions box-shadow smoothly, matching the focus indicator timing used by MediaInput', () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+      const { container } = render(<StyledInputGroup $isUnified />);
 
       expect(container.firstChild).toHaveStyleRule(
         'transition',
@@ -233,7 +250,7 @@ describe('StyledInputGroup', () => {
       it.each(['success', 'warning', 'error'] as const)(
         'highlights the container border in the %s color at rest, based on a descendant data-validation attribute',
         validation => {
-          const { container } = render(<StyledInputGroup $isSeamless />);
+          const { container } = render(<StyledInputGroup $isUnified />);
           const borderColor = getColor({
             theme: DEFAULT_THEME,
             variable: VALIDATION_BORDER_VARIABLE[validation]
@@ -248,7 +265,7 @@ describe('StyledInputGroup', () => {
       it.each(['success', 'warning', 'error'] as const)(
         'highlights the container border in the %s color on hover, based on a descendant data-validation attribute',
         validation => {
-          const { container } = render(<StyledInputGroup $isSeamless />);
+          const { container } = render(<StyledInputGroup $isUnified />);
           const borderColor = getColor({
             theme: DEFAULT_THEME,
             variable: VALIDATION_BORDER_VARIABLE[validation]
@@ -263,7 +280,7 @@ describe('StyledInputGroup', () => {
       it.each(['success', 'warning', 'error'] as const)(
         'highlights the container border in the %s color on focus-within, based on a descendant data-validation attribute',
         validation => {
-          const { container } = render(<StyledInputGroup $isSeamless />);
+          const { container } = render(<StyledInputGroup $isUnified />);
           const borderColor = getColor({
             theme: DEFAULT_THEME,
             variable: VALIDATION_BORDER_VARIABLE[validation]
@@ -278,7 +295,7 @@ describe('StyledInputGroup', () => {
 
     describe('disabled', () => {
       it("highlights the container border and background in disabled colors, based on a descendant's :disabled state", () => {
-        const { container } = render(<StyledInputGroup $isSeamless />);
+        const { container } = render(<StyledInputGroup $isUnified />);
         const borderColor = getColor({ theme: DEFAULT_THEME, variable: 'border.disabled' });
         const backgroundColor = getColor({ theme: DEFAULT_THEME, variable: 'background.disabled' });
 
@@ -291,13 +308,13 @@ describe('StyledInputGroup', () => {
       });
 
       it('shows a text cursor by default', () => {
-        const { container } = render(<StyledInputGroup $isSeamless />);
+        const { container } = render(<StyledInputGroup $isUnified />);
 
         expect(container.firstChild).toHaveStyleRule('cursor', 'text');
       });
 
       it("shows a default cursor based on a descendant's :disabled state", () => {
-        const { container } = render(<StyledInputGroup $isSeamless />);
+        const { container } = render(<StyledInputGroup $isUnified />);
 
         expect(container.firstChild).toHaveStyleRule('cursor', 'default', {
           modifier: `&:has(${StyledTextInput}:disabled)`
@@ -307,7 +324,7 @@ describe('StyledInputGroup', () => {
 
     describe('readOnly', () => {
       it("highlights the container background in the disabled background color, based on a descendant's readonly attribute", () => {
-        const { container } = render(<StyledInputGroup $isSeamless />);
+        const { container } = render(<StyledInputGroup $isUnified />);
         const backgroundColor = getColor({ theme: DEFAULT_THEME, variable: 'background.disabled' });
 
         expect(container.firstChild).toHaveStyleRule('background-color', backgroundColor, {
@@ -316,7 +333,7 @@ describe('StyledInputGroup', () => {
       });
 
       it("does not change the container's border-color or cursor, since a read-only input remains focusable and selectable", () => {
-        const { container } = render(<StyledInputGroup $isSeamless />);
+        const { container } = render(<StyledInputGroup $isUnified />);
         const modifier = `&:has(${StyledTextInput}[readonly])`;
 
         expect(container.firstChild).not.toHaveStyleRule('border-color', expect.any(String), {
@@ -329,9 +346,9 @@ describe('StyledInputGroup', () => {
     });
 
     it('does not impose an inset focus ring on icon buttons via CSS, leaving that to the consumer via the focusInset prop', () => {
-      const { container: regular } = render(<StyledInputGroup $isSeamless />);
-      const { container: compact } = render(<StyledInputGroup $isSeamless $isCompact />);
-      const modifier = `& ${StyledIconButton}:focus-visible`;
+      const { container: regular } = render(<StyledInputGroup $isUnified />);
+      const { container: compact } = render(<StyledInputGroup $isUnified $isCompact />);
+      const modifier = `& ${ICON_BUTTON_SELECTOR}:focus-visible`;
 
       expect(regular.firstChild).not.toHaveStyleRule(
         'box-shadow',
@@ -345,16 +362,16 @@ describe('StyledInputGroup', () => {
       );
     });
 
-    it('does not apply the border-overlap hacks used by the non-seamless variant', () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+    it('does not apply the border-overlap hacks used by the non-unified variant', () => {
+      const { container } = render(<StyledInputGroup $isUnified />);
 
       expect(container.firstChild).not.toHaveStyleRule('margin-left', '-1px', {
         modifier: '&>*:not(:first-child)'
       });
     });
 
-    it('does not apply the item z-index layering used by the non-seamless variant', () => {
-      const { container } = render(<StyledInputGroup $isSeamless />);
+    it('does not apply the item z-index layering used by the non-unified variant', () => {
+      const { container } = render(<StyledInputGroup $isUnified />);
 
       expect(container.firstChild).not.toHaveStyleRule('z-index', '-1', { modifier: '&>*' });
       expect(container.firstChild).not.toHaveStyleRule('z-index', '0', {
@@ -362,7 +379,7 @@ describe('StyledInputGroup', () => {
       });
     });
 
-    it('still applies item z-index layering for the non-seamless border-overlap variant', () => {
+    it('still applies item z-index layering for the non-unified border-overlap variant', () => {
       const { container } = render(<StyledInputGroup />);
 
       expect(container.firstChild).toHaveStyleRule('z-index', '-1', { modifier: '&>*' });
@@ -371,7 +388,7 @@ describe('StyledInputGroup', () => {
       });
     });
 
-    it('does not apply seamless gap or edge padding to the non-seamless variant', () => {
+    it('does not apply unified gap or edge padding to the non-unified variant', () => {
       const { container } = render(<StyledInputGroup />);
 
       expect(container.firstChild).not.toHaveStyleRule('gap', '8px');

--- a/packages/forms/src/styled/input-group/StyledInputGroup.ts
+++ b/packages/forms/src/styled/input-group/StyledInputGroup.ts
@@ -8,7 +8,6 @@
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { em, math } from 'polished';
 import { componentStyles, focusStyles, getColor } from '@zendeskgarden/react-theming';
-import { StyledButton, StyledIconButton } from '@zendeskgarden/react-buttons';
 import { Validation } from '../../types';
 import { StyledTextInput } from '../text/StyledTextInput';
 import { StyledLabel } from '../common/StyledLabel';
@@ -17,20 +16,27 @@ import { StyledMessage } from '../common/StyledMessage';
 
 const COMPONENT_ID = 'forms.input_group';
 
-/* shared between sizeStyles' padding math and seamlessStyles' actual override, to keep them in sync */
+/* targets react-buttons' public data-garden-id hooks, since its styled components are private; a consumer-overridden data-garden-id exempts that button from these styles 
+TODO: remove this once packages are unified
+
+*/
+const BUTTON_SELECTOR = "button[data-garden-id='buttons.button']";
+const ICON_BUTTON_SELECTOR = "button[data-garden-id='buttons.icon_button']";
+
+/* shared between sizeStyles' padding math and unifiedStyles' actual override, to keep them in sync */
 const getCompactIconButtonSize = (theme: DefaultTheme) => math(`${theme.space.base}px * 6`);
 
 interface IStyledInputGroupProps {
   $isCompact?: boolean;
-  $isSeamless?: boolean;
+  $isUnified?: boolean;
   $focusInset?: boolean;
 }
 
 const sizeStyles = (props: ThemeProps<DefaultTheme> & IStyledInputGroupProps) => {
-  const { theme, $isCompact, $isSeamless } = props;
+  const { theme, $isCompact, $isUnified } = props;
   const fontSize = theme.fontSizes.md;
 
-  if (!$isSeamless) {
+  if (!$isUnified) {
     return css`
       font-size: ${fontSize};
     `;
@@ -39,7 +45,7 @@ const sizeStyles = (props: ThemeProps<DefaultTheme> & IStyledInputGroupProps) =>
   const containerSize = $isCompact ? theme.space.lg : theme.space.xl;
   /* the target edge-to-icon distance for a leading/trailing IconButton, kept independent of the container's own padding-inline below */
   const buttonEdgeTarget = em(theme.space.sm, fontSize);
-  /* tracks the size seamlessStyles actually renders, which is shrunk when compact */
+  /* tracks the size unifiedStyles actually renders, which is shrunk when compact */
   const iconButtonSize = $isCompact
     ? parseFloat(getCompactIconButtonSize(theme))
     : parseFloat(theme.space.lg);
@@ -58,11 +64,11 @@ const sizeStyles = (props: ThemeProps<DefaultTheme> & IStyledInputGroupProps) =>
     gap: ${theme.space.xs};
 
     /* compensates for the IconButton's own inset so its icon, not its edge, lands at the target edge distance */
-    &:has(> ${StyledIconButton}:first-child) {
+    &:has(> ${ICON_BUTTON_SELECTOR}:first-child) {
       padding-inline-start: ${iconButtonPaddingInline};
     }
 
-    &:has(> ${StyledIconButton}:last-child) {
+    &:has(> ${ICON_BUTTON_SELECTOR}:last-child) {
       padding-inline-end: ${iconButtonPaddingInline};
     }
 
@@ -134,14 +140,15 @@ const disabledStyles = (props: ThemeProps<DefaultTheme> & IStyledInputGroupProps
   `;
 };
 
-const seamlessStyles = (props: ThemeProps<DefaultTheme> & IStyledInputGroupProps) => {
-  if (!props.$isSeamless) {
+const unifiedStyles = (props: ThemeProps<DefaultTheme> & IStyledInputGroupProps) => {
+  if (!props.$isUnified) {
     return undefined;
   }
 
   const { theme, $isCompact, $focusInset } = props;
   const containerSize = $isCompact ? theme.space.lg : theme.space.xl;
   const buttonSize = math(`${theme.space.base}px * ${$isCompact ? 6 : 7}`);
+  const iconButtonSize = $isCompact ? getCompactIconButtonSize(theme) : theme.space.lg;
   const borderColor = getColor({
     theme,
     variable: 'border.default',
@@ -172,14 +179,18 @@ const seamlessStyles = (props: ThemeProps<DefaultTheme> & IStyledInputGroupProps
       align-self: stretch; /* override the container's own centered children */
     }
 
-    /* IconButton sizes itself via its own "small"/"smallest" size prop, forced by InputGroup */
-    & ${StyledIconButton} {
+    /* sizes any icon button (IconButton, ToggleIconButton, ...) to fit the container; its icon glyph stays iconSizes.md regardless, and pressed-state styling is geometry-independent */
+    & ${ICON_BUTTON_SELECTOR} {
       flex: none;
       align-self: center;
+      width: ${iconButtonSize};
+      min-width: ${iconButtonSize};
+      height: ${iconButtonSize};
+      min-height: ${iconButtonSize};
     }
 
     /* shrinks a text button's height to fit the container, without touching its own padding */
-    & ${StyledButton}:not(${StyledIconButton}) {
+    & ${BUTTON_SELECTOR} {
       height: ${buttonSize};
       min-height: ${buttonSize};
       line-height: ${buttonLineHeight};
@@ -235,7 +246,7 @@ const itemStyles = (props: ThemeProps<DefaultTheme> & IStyledInputGroupProps) =>
   const endDirection = props.theme.rtl ? 'left' : 'right';
 
   return css`
-    ${!props.$isSeamless &&
+    ${!props.$isUnified &&
     css`
       & > * {
         z-index: -1;
@@ -263,7 +274,7 @@ const itemStyles = (props: ThemeProps<DefaultTheme> & IStyledInputGroupProps) =>
       border-bottom-width: 0;
     }
 
-    ${!props.$isSeamless &&
+    ${!props.$isUnified &&
     css`
       & > *:not(:first-child) {
         margin-${startDirection}: -${props.theme.borderWidths.sm}; /* [1] */
@@ -300,7 +311,7 @@ export const StyledInputGroup = styled.div.attrs({
   ${props => sizeStyles(props)};
   ${props => positionStyles(props)};
   ${props => itemStyles(props)};
-  ${props => seamlessStyles(props)};
+  ${props => unifiedStyles(props)};
 
   ${componentStyles};
 `;

--- a/packages/forms/src/types/index.ts
+++ b/packages/forms/src/types/index.ts
@@ -45,9 +45,9 @@ export interface IFieldsetProps extends FieldsetHTMLAttributes<HTMLFieldSetEleme
 
 export interface IInputGroupProps
   extends Pick<IFieldsetProps, 'isCompact'>, HTMLAttributes<HTMLDivElement> {
-  /** Applies seamless styling so the group is bordered/focused as a single field */
-  isSeamless?: boolean;
-  /** Insets the container's own `isSeamless` focus ring, e.g. when nested inside another group */
+  /** Applies unified styling so the group is bordered/focused as a single field */
+  isUnified?: boolean;
+  /** Insets the container's own `isUnified` focus ring, e.g. when nested inside another group */
   focusInset?: boolean;
 }
 

--- a/packages/forms/src/utils/useInputGroupContext.ts
+++ b/packages/forms/src/utils/useInputGroupContext.ts
@@ -9,7 +9,7 @@ import { createContext, useContext } from 'react';
 
 interface IInputGroupContext {
   isCompact?: boolean;
-  isSeamless?: boolean;
+  isUnified?: boolean;
 }
 
 export const InputGroupContext = createContext<IInputGroupContext | undefined>(undefined);


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE THIS PR!**
> This pull request is for review and discussion. To incorporate these changes into your branch, cherry-pick commit `c566d98b70ea93283eda7a9a90746b402815336b` directly.

## Description

Updates the unified `InputGroup` variant to handle icon-button sizing entirely through container CSS, leaves child elements unmutated, reverts `packages/buttons` back to its pre-branch state, and renames the `isSeamless` prop to `isUnified`.

## Details
* **Prop rename:** Renamed `isSeamless` to `isUnified` across types, context, components, specs, and story files to match Garden's `is<Adjective>` convention (`isBasic`, `isPill`, `isRecessed`).
* **Pure CSS sizing:** `StyledInputGroup.ts` sizes child icon buttons (32px regular, 24px compact) using public `data-garden-id` selectors.
* **Removed child mutation:** Removed `Children.map` and `cloneElement` from `InputGroup.tsx`. Children render untouched.
* **Uniform toggle sizing:** Sized `ToggleIconButton` identically to standard icon buttons so container padding math stays coherent.
